### PR TITLE
[WIP] Compatibility with TLS 1.2 and OpenSSL 1.1.0

### DIFF
--- a/source/extensions/transport_sockets/tls/context_config_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_config_impl.cc
@@ -264,8 +264,10 @@ unsigned ContextConfigImpl::tlsVersionFromProto(
     return TLS1_1_VERSION;
   case envoy::api::v2::auth::TlsParameters::TLSv1_2:
     return TLS1_2_VERSION;
+#ifdef TLS1_3_VERSION
   case envoy::api::v2::auth::TlsParameters::TLSv1_3:
     return TLS1_3_VERSION;
+#endif
   default:
     NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
   }
@@ -315,7 +317,11 @@ ClientContextConfigImpl::ClientContextConfigImpl(
 }
 
 const unsigned ServerContextConfigImpl::DEFAULT_MIN_VERSION = TLS1_VERSION;
+#ifdef TLS1_3_VERSION
 const unsigned ServerContextConfigImpl::DEFAULT_MAX_VERSION = TLS1_3_VERSION;
+#else // OpenSSL 1.1.0
+const unsigned ServerContextConfigImpl::DEFAULT_MAX_VERSION = TLS1_2_VERSION;
+#endif
 
 const std::string ServerContextConfigImpl::DEFAULT_CIPHER_SUITES =
     "[ECDHE-ECDSA-AES128-GCM-SHA256|ECDHE-ECDSA-CHACHA20-POLY1305]:"

--- a/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
+++ b/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
@@ -178,7 +178,9 @@ class SslCertficateIntegrationTest
       public SslIntegrationTestBase {
 public:
   SslCertficateIntegrationTest() : SslIntegrationTestBase(std::get<0>(GetParam())) {
+#ifdef TLS1_3_VERSION
     server_tlsv1_3_ = true;
+#endif
   }
 
   Network::ClientConnectionPtr
@@ -231,8 +233,12 @@ public:
 INSTANTIATE_TEST_SUITE_P(
     IpVersionsClientVersions, SslCertficateIntegrationTest,
     testing::Combine(testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+#ifdef TLS1_3_VERSION
                      testing::Values(envoy::api::v2::auth::TlsParameters::TLSv1_2,
                                      envoy::api::v2::auth::TlsParameters::TLSv1_3)),
+#else // OpenSSL 1.1.0
+                     testing::Values(envoy::api::v2::auth::TlsParameters::TLSv1_2)),
+#endif
     SslCertficateIntegrationTest::ipClientVersionTestParamsToString);
 
 // Server with an RSA certificate and a client with RSA/ECDSA cipher suites works.


### PR DESCRIPTION
This change makes extensions working on OpenSSL 1.1.0 which still uses
TLS 1.2 standard instead of TLS 1.3. OpenSSL 1.1.0 is still a supported
version.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>