### PR TITLE
bazel: Fix optional dynamic linking of OpenSSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ To build OpenSSL-enabled Envoy run the following command.
 $ bazel build //:envoy
 ```
 
-If you need OpenSSL dynamically linked to Envoy then re-map `@boringssl` to
-`@openssl_shared` by editing the [WORKSPACE](WORKSPACE) file.
+If you need OpenSSL dynamically linked to Envoy then edit the the
+[WORKSPACE](WORKSPACE) file, comment the line with `openssl_repository` function
+call and uncomment the one with `openssl_shared_repository`.
 
 ## Testing
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,19 +2,14 @@ workspace(name = "envoy_openssl")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-      name = "openssl",
-      urls = ["https://github.com/openssl/openssl/archive/OpenSSL_1_1_1d.tar.gz"],
-      sha256 = "23011a5cc78e53d0dc98dfa608c51e72bcd350aa57df74c5d5574ba4ffb62e74",
-      build_file = "@//:openssl.BUILD",
-      strip_prefix = "openssl-OpenSSL_1_1_1d",
-)
+load("//:openssl.bzl", "openssl_repository", "openssl_shared_repository")
 
-new_local_repository(
-    name = "openssl_shared",
-    path = "/usr/lib/x86_64-linux-gnu",
-    build_file = "openssl_host_shared.BUILD"
-)
+# If you need OpenSSL dynamically linked to Envoy then comment the line
+# with `openssl_repository` function call and uncomment the one with
+# `openssl_shared_repository`.
+
+openssl_repository()
+# openssl_shared_repository()
 
 local_repository(
     name = "envoy_build_config",

--- a/openssl.bzl
+++ b/openssl.bzl
@@ -1,0 +1,17 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def openssl_repository():
+    http_archive(
+        name = "openssl",
+        urls = ["https://github.com/openssl/openssl/archive/OpenSSL_1_1_1d.tar.gz"],
+        sha256 = "23011a5cc78e53d0dc98dfa608c51e72bcd350aa57df74c5d5574ba4ffb62e74",
+        build_file = "@//:openssl.BUILD",
+        strip_prefix = "openssl-OpenSSL_1_1_1d",
+    )
+
+def openssl_shared_repository():
+    native.new_local_repository(
+        name = "openssl",
+        path = "/usr/lib/x86_64-linux-gnu",
+        build_file = "openssl_host_shared.BUILD"
+    )


### PR DESCRIPTION
Before this change, README was suggesting to replace Envoy repo_mapping
from `boringssl` to `openssl_shared`. That solution was working only for
the Envoy repository, but bssl_wrapper was still using `openssl` as a
dependency.

Because of that, even after re-mapping Envoy to shared OpenSSL, Bazel
was still downloading the OpenSSL tarball and using it for bssl_wrapper.

This change fixes that issue by defining functions in openssl.bzl file.
Both of them define `openssl` repository. The first one
(`openssl_repository`) uses the OpenSSL tarball. The second one
(`openssl_shared_repository`) uses shared OpenSSL library.

WORKSPACE by default calls the `openssl_repository` function and has a
commented call to the `openssl_shared_repository` function. If someone
wants to build Envoy with shared OpenSSL, the first function call should
be commented and the second one uncommented.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>