### PR TITLE
Update Envoy

### DIFF
--- a/source/extensions/common/aws/signer.h
+++ b/source/extensions/common/aws/signer.h
@@ -18,14 +18,14 @@ public:
    * @param sign_body include the message body in the signature. The body must be fully buffered.
    * @throws EnvoyException if the request cannot be signed.
    */
-  virtual void sign(Http::Message& message, bool sign_body) PURE;
+  virtual void sign(Http::RequestMessage& message, bool sign_body) PURE;
 
   /**
    * Sign an AWS request.
    * @param headers AWS API request headers.
    * @throws EnvoyException if the request cannot be signed.
    */
-  virtual void sign(Http::HeaderMap& headers) PURE;
+  virtual void sign(Http::RequestHeaderMap& headers) PURE;
 };
 
 using SignerPtr = std::unique_ptr<Signer>;

--- a/source/extensions/common/aws/signer_impl.cc
+++ b/source/extensions/common/aws/signer_impl.cc
@@ -17,17 +17,17 @@ namespace Extensions {
 namespace Common {
 namespace Aws {
 
-void SignerImpl::sign(Http::Message& message, bool sign_body) {
+void SignerImpl::sign(Http::RequestMessage& message, bool sign_body) {
   const auto content_hash = createContentHash(message, sign_body);
   auto& headers = message.headers();
   sign(headers, content_hash);
 }
 
-void SignerImpl::sign(Http::HeaderMap& headers) {
+void SignerImpl::sign(Http::RequestHeaderMap& headers) {
   sign(headers, SignatureConstants::get().HashedEmptyString);
 }
 
-void SignerImpl::sign(Http::HeaderMap& headers, const std::string& content_hash) {
+void SignerImpl::sign(Http::RequestHeaderMap& headers, const std::string& content_hash) {
   const auto& credentials = credentials_provider_->getCredentials();
   if (!credentials.accessKeyId() || !credentials.secretAccessKey()) {
     // Empty or "anonymous" credentials are a valid use-case for non-production environments.
@@ -68,7 +68,7 @@ void SignerImpl::sign(Http::HeaderMap& headers, const std::string& content_hash)
   headers.addCopy(Http::Headers::get().Authorization, authorization_header);
 }
 
-std::string SignerImpl::createContentHash(Http::Message& message, bool sign_body) const {
+std::string SignerImpl::createContentHash(Http::RequestMessage& message, bool sign_body) const {
   if (!sign_body) {
     return SignatureConstants::get().HashedEmptyString;
   }

--- a/source/extensions/common/aws/signer_impl.h
+++ b/source/extensions/common/aws/signer_impl.h
@@ -50,11 +50,11 @@ public:
         time_source_(time_source), long_date_formatter_(SignatureConstants::get().LongDateFormat),
         short_date_formatter_(SignatureConstants::get().ShortDateFormat) {}
 
-  void sign(Http::Message& message, bool sign_body = false) override;
-  void sign(Http::HeaderMap& headers) override;
+  void sign(Http::RequestMessage& message, bool sign_body = false) override;
+  void sign(Http::RequestHeaderMap& headers) override;
 
 private:
-  std::string createContentHash(Http::Message& message, bool sign_body) const;
+  std::string createContentHash(Http::RequestMessage& message, bool sign_body) const;
 
   std::string createCredentialScope(absl::string_view short_date) const;
 
@@ -69,7 +69,7 @@ private:
                                         const std::map<std::string, std::string>& canonical_headers,
                                         absl::string_view signature) const;
 
-  void sign(Http::HeaderMap& headers, const std::string& content_hash);
+  void sign(Http::RequestHeaderMap& headers, const std::string& content_hash);
 
   const std::string service_name_;
   const std::string region_;

--- a/source/extensions/filters/http/aws_request_signing/aws_request_signing_filter.cc
+++ b/source/extensions/filters/http/aws_request_signing/aws_request_signing_filter.cc
@@ -22,7 +22,7 @@ FilterStats Filter::generateStats(const std::string& prefix, Stats::Scope& scope
   return {ALL_AWS_REQUEST_SIGNING_FILTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
 }
 
-Http::FilterHeadersStatus Filter::decodeHeaders(Http::HeaderMap& headers, bool) {
+Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers, bool) {
   try {
     config_->signer().sign(headers);
     config_->stats().signing_added_.inc();

--- a/source/extensions/filters/http/aws_request_signing/aws_request_signing_filter.h
+++ b/source/extensions/filters/http/aws_request_signing/aws_request_signing_filter.h
@@ -74,7 +74,8 @@ public:
 
   static FilterStats generateStats(const std::string& prefix, Stats::Scope& scope);
 
-  Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap& headers, bool end_stream) override;
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers,
+                                          bool end_stream) override;
 
 private:
   std::shared_ptr<FilterConfig> config_;

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -115,7 +115,8 @@ int StreamHandleWrapper::luaRespond(lua_State* state) {
   luaL_checktype(state, 2, LUA_TTABLE);
   size_t body_size;
   const char* raw_body = luaL_optlstring(state, 3, nullptr, &body_size);
-  Http::HeaderMapPtr headers = buildHeadersFromTable(state, 2);
+  auto headers = std::make_unique<Http::ResponseHeaderMapImpl>();
+  buildHeadersFromTable(*headers, state, 2);
 
   uint64_t status;
   if (headers->Status() == nullptr ||
@@ -137,9 +138,8 @@ int StreamHandleWrapper::luaRespond(lua_State* state) {
   return lua_yield(state, 0);
 }
 
-Http::HeaderMapPtr StreamHandleWrapper::buildHeadersFromTable(lua_State* state, int table_index) {
-  Http::HeaderMapPtr headers(new Http::HeaderMapImpl());
-
+void StreamHandleWrapper::buildHeadersFromTable(Http::HeaderMap& headers, lua_State* state,
+                                                int table_index) {
   // Build a header map to make the request. We iterate through the provided table to do this and
   // check that we are getting strings.
   lua_pushnil(state);
@@ -152,19 +152,17 @@ Http::HeaderMapPtr StreamHandleWrapper::buildHeadersFromTable(lua_State* state, 
       lua_pushnil(state);
       while (lua_next(state, -2) != 0) {
         const char* value = luaL_checkstring(state, -1);
-        headers->addCopy(Http::LowerCaseString(key), value);
+        headers.addCopy(Http::LowerCaseString(key), value);
         lua_pop(state, 1);
       }
     } else {
       const char* value = luaL_checkstring(state, -1);
-      headers->addCopy(Http::LowerCaseString(key), value);
+      headers.addCopy(Http::LowerCaseString(key), value);
     }
     // Removes 'value'; keeps 'key' for next iteration. This is the input for lua_next() so that
     // it can push the next key/value pair onto the stack.
     lua_pop(state, 1);
   }
-
-  return headers;
 }
 
 int StreamHandleWrapper::luaHttpCall(lua_State* state) {
@@ -183,7 +181,9 @@ int StreamHandleWrapper::luaHttpCall(lua_State* state) {
     return luaL_error(state, "http call cluster invalid. Must be configured");
   }
 
-  Http::MessagePtr message(new Http::RequestMessageImpl(buildHeadersFromTable(state, 3)));
+  auto headers = std::make_unique<Http::RequestHeaderMapImpl>();
+  buildHeadersFromTable(*headers, state, 3);
+  Http::RequestMessagePtr message(new Http::RequestMessageImpl(std::move(headers)));
 
   // Check that we were provided certain headers.
   if (message->headers().Path() == nullptr || message->headers().Method() == nullptr ||
@@ -213,7 +213,7 @@ int StreamHandleWrapper::luaHttpCall(lua_State* state) {
   }
 }
 
-void StreamHandleWrapper::onSuccess(Http::MessagePtr&& response) {
+void StreamHandleWrapper::onSuccess(Http::ResponseMessagePtr&& response) {
   ASSERT(state_ == State::HttpCall || state_ == State::Running);
   ENVOY_LOG(debug, "async HTTP response complete");
   http_request_ = nullptr;
@@ -264,9 +264,10 @@ void StreamHandleWrapper::onFailure(Http::AsyncClient::FailureReason) {
   ENVOY_LOG(debug, "async HTTP failure");
 
   // Just fake a basic 503 response.
-  Http::MessagePtr response_message(new Http::ResponseMessageImpl(Http::HeaderMapPtr{
-      new Http::HeaderMapImpl{{Http::Headers::get().Status,
-                               std::to_string(enumToInt(Http::Code::ServiceUnavailable))}}}));
+  Http::ResponseMessagePtr response_message(
+      new Http::ResponseMessageImpl(Http::createHeaderMap<Http::ResponseHeaderMapImpl>(
+          {{Http::Headers::get().Status,
+            std::to_string(enumToInt(Http::Code::ServiceUnavailable))}})));
   response_message->body() = std::make_unique<Buffer::OwnedImpl>("upstream failure");
   onSuccess(std::move(response_message));
 }
@@ -607,7 +608,7 @@ void Filter::scriptLog(spdlog::level::level_enum level, const char* message) {
   }
 }
 
-void Filter::DecoderCallbacks::respond(Http::HeaderMapPtr&& headers, Buffer::Instance* body,
+void Filter::DecoderCallbacks::respond(Http::ResponseHeaderMapPtr&& headers, Buffer::Instance* body,
                                        lua_State*) {
   callbacks_->encodeHeaders(std::move(headers), body == nullptr);
   if (body && !parent_.destroyed_) {
@@ -615,7 +616,8 @@ void Filter::DecoderCallbacks::respond(Http::HeaderMapPtr&& headers, Buffer::Ins
   }
 }
 
-void Filter::EncoderCallbacks::respond(Http::HeaderMapPtr&&, Buffer::Instance*, lua_State* state) {
+void Filter::EncoderCallbacks::respond(Http::ResponseHeaderMapPtr&&, Buffer::Instance*,
+                                       lua_State* state) {
   // TODO(mattklein123): Support response in response path if nothing has been continued
   // yet.
   luaL_error(state, "respond not currently supported in the response path");

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -134,12 +134,12 @@ public:
   }
 
   void sendServerInitialMetadata(const TestMetadata& metadata) {
-    Http::HeaderMapPtr reply_headers{new Http::TestHeaderMapImpl{{":status", "200"}}};
+    Http::HeaderMapPtr reply_headers{new Http::TestResponseHeaderMapImpl{{":status", "200"}}};
     for (auto& value : metadata) {
       reply_headers->addReference(value.first, value.second);
     }
     expectInitialMetadata(metadata);
-    fake_stream_->encodeHeaders(Http::HeaderMapImpl(*reply_headers), false);
+    fake_stream_->encodeHeaders(Http::TestHeaderMapImpl(*reply_headers), false);
   }
 
   void sendReply() {

--- a/test/extensions/common/aws/mocks.h
+++ b/test/extensions/common/aws/mocks.h
@@ -23,7 +23,8 @@ public:
   MockSigner();
   ~MockSigner() override;
 
-  MOCK_METHOD(void, sign, (Http::Message&, bool));
+  MOCK_METHOD(void, sign, (Http::RequestMessage&, bool));
+  MOCK_METHOD(void, sign, (Http::RequestHeaderMap&));
 };
 
 class MockMetadataFetcher {

--- a/test/extensions/common/aws/signer_impl_test.cc
+++ b/test/extensions/common/aws/signer_impl_test.cc
@@ -43,7 +43,7 @@ public:
 
   NiceMock<MockCredentialsProvider>* credentials_provider_;
   Event::SimulatedTimeSystem time_system_;
-  Http::MessagePtr message_;
+  Http::RequestMessagePtr message_;
   SignerImpl signer_;
   Credentials credentials_;
   Credentials token_credentials_;

--- a/test/extensions/filters/http/aws_request_signing/BUILD
+++ b/test/extensions/filters/http/aws_request_signing/BUILD
@@ -18,6 +18,7 @@ envoy_extension_cc_test(
     extension_name = "envoy.filters.http.aws_request_signing",
     deps = [
         "//source/extensions/filters/http/aws_request_signing:aws_request_signing_filter_lib",
+        "//test/extensions/common/aws:aws_mocks",
         "@envoy//test/mocks/http:http_mocks",
     ],
 )

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -37,7 +37,7 @@ class TestFilter : public Filter {
 public:
   using Filter::Filter;
 
-  MOCK_METHOD2(scriptLog, void(spdlog::level::level_enum level, const char* message));
+  MOCK_METHOD(void, scriptLog, (spdlog::level::level_enum level, const char* message));
 };
 
 class LuaHttpFilterTest : public testing::Test {
@@ -199,7 +199,7 @@ TEST_F(LuaHttpFilterTest, ScriptHeadersOnlyRequestHeadersOnly) {
   InSequence s;
   setup(HEADER_ONLY_SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("/")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 }
@@ -209,7 +209,7 @@ TEST_F(LuaHttpFilterTest, ScriptHeadersOnlyRequestBody) {
   InSequence s;
   setup(HEADER_ONLY_SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("/")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
 
@@ -222,14 +222,14 @@ TEST_F(LuaHttpFilterTest, ScriptHeadersOnlyRequestBodyTrailers) {
   InSequence s;
   setup(HEADER_ONLY_SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("/")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
 
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
 
-  Http::TestHeaderMapImpl request_trailers{{"foo", "bar"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"foo", "bar"}};
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
 }
 
@@ -238,7 +238,7 @@ TEST_F(LuaHttpFilterTest, ScriptBodyChunksRequestHeadersOnly) {
   InSequence s;
   setup(BODY_CHUNK_SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("/")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("done")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
@@ -249,7 +249,7 @@ TEST_F(LuaHttpFilterTest, ScriptBodyChunksRequestBody) {
   InSequence s;
   setup(BODY_CHUNK_SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("/")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
   Http::MetadataMap metadata_map{{"metadata", "metadata"}};
@@ -266,7 +266,7 @@ TEST_F(LuaHttpFilterTest, ScriptBodyChunksRequestBodyTrailers) {
   InSequence s;
   setup(BODY_CHUNK_SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("/")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
 
@@ -274,7 +274,7 @@ TEST_F(LuaHttpFilterTest, ScriptBodyChunksRequestBodyTrailers) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("5")));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
 
-  Http::TestHeaderMapImpl request_trailers{{"foo", "bar"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"foo", "bar"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("done")));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
 }
@@ -284,7 +284,7 @@ TEST_F(LuaHttpFilterTest, ScriptTrailersRequestHeadersOnly) {
   InSequence s;
   setup(TRAILERS_SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("/")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("no trailers")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
@@ -295,7 +295,7 @@ TEST_F(LuaHttpFilterTest, ScriptTrailersRequestBody) {
   InSequence s;
   setup(TRAILERS_SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("/")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
 
@@ -310,7 +310,7 @@ TEST_F(LuaHttpFilterTest, ScriptTrailersRequestBodyTrailers) {
   InSequence s;
   setup(TRAILERS_SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("/")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
 
@@ -318,7 +318,7 @@ TEST_F(LuaHttpFilterTest, ScriptTrailersRequestBodyTrailers) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("5")));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
 
-  Http::TestHeaderMapImpl request_trailers{{"foo", "bar"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"foo", "bar"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("bar")));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
 }
@@ -328,7 +328,7 @@ TEST_F(LuaHttpFilterTest, ScriptTrailersNoBodyRequestHeadersOnly) {
   InSequence s;
   setup(TRAILERS_NO_BODY_SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("/")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("no trailers")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
@@ -339,7 +339,7 @@ TEST_F(LuaHttpFilterTest, ScriptTrailersNoBodyRequestBody) {
   InSequence s;
   setup(TRAILERS_NO_BODY_SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("/")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
 
@@ -353,14 +353,14 @@ TEST_F(LuaHttpFilterTest, ScriptTrailersNoBodyRequestBodyTrailers) {
   InSequence s;
   setup(TRAILERS_NO_BODY_SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("/")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
 
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
 
-  Http::TestHeaderMapImpl request_trailers{{"foo", "bar"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"foo", "bar"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("bar")));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
 }
@@ -370,7 +370,7 @@ TEST_F(LuaHttpFilterTest, ScriptBodyRequestHeadersOnly) {
   InSequence s;
   setup(BODY_SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("/")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("no body")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
@@ -381,7 +381,7 @@ TEST_F(LuaHttpFilterTest, ScriptBodyRequestBody) {
   InSequence s;
   setup(BODY_SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("/")));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers, false));
@@ -396,7 +396,7 @@ TEST_F(LuaHttpFilterTest, ScriptBodyRequestBodyTwoFrames) {
   InSequence s;
   setup(BODY_SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("/")));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers, false));
@@ -416,7 +416,7 @@ TEST_F(LuaHttpFilterTest, ScriptBodyRequestBodyTwoFramesTrailers) {
   InSequence s;
   setup(BODY_SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("/")));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers, false));
@@ -429,7 +429,7 @@ TEST_F(LuaHttpFilterTest, ScriptBodyRequestBodyTwoFramesTrailers) {
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(data2, false));
   decoder_callbacks_.addDecodedData(data2, false);
 
-  Http::TestHeaderMapImpl request_trailers{{"foo", "bar"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"foo", "bar"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("10")));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
 }
@@ -439,7 +439,7 @@ TEST_F(LuaHttpFilterTest, ScriptBodyTrailersRequestHeadersOnly) {
   InSequence s;
   setup(BODY_TRAILERS_SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("/")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("no body")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("no trailers")));
@@ -451,7 +451,7 @@ TEST_F(LuaHttpFilterTest, ScriptBodyTrailersRequestBody) {
   InSequence s;
   setup(BODY_TRAILERS_SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("/")));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers, false));
@@ -467,7 +467,7 @@ TEST_F(LuaHttpFilterTest, ScriptBodyTrailersRequestBodyTrailers) {
   InSequence s;
   setup(BODY_TRAILERS_SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("/")));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers, false));
@@ -476,7 +476,7 @@ TEST_F(LuaHttpFilterTest, ScriptBodyTrailersRequestBodyTrailers) {
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(data, false));
   decoder_callbacks_.addDecodedData(data, false);
 
-  Http::TestHeaderMapImpl request_trailers{{"foo", "bar"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"foo", "bar"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("5")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("bar")));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
@@ -499,7 +499,7 @@ TEST_F(LuaHttpFilterTest, BodyChunkOutsideOfLoop) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
 
   Buffer::OwnedImpl data1("hello");
@@ -523,13 +523,13 @@ TEST_F(LuaHttpFilterTest, ScriptRandomRequestBodyTrailers) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
 
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
 
-  Http::TestHeaderMapImpl request_trailers{{"foo", "bar"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"foo", "bar"}};
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
 }
 
@@ -545,7 +545,7 @@ TEST_F(LuaHttpFilterTest, ScriptErrorHeadersRequestBodyTrailers) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_,
               scriptLog(spdlog::level::err,
                         StrEq("[string \"...\"]:4: attempt to index local 'foo' (a nil value)")));
@@ -554,7 +554,7 @@ TEST_F(LuaHttpFilterTest, ScriptErrorHeadersRequestBodyTrailers) {
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
 
-  Http::TestHeaderMapImpl request_trailers{{"foo", "bar"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"foo", "bar"}};
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
 }
 
@@ -573,7 +573,7 @@ TEST_F(LuaHttpFilterTest, ThreadEnvironments) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 
   TestFilter filter2(config_);
@@ -593,7 +593,7 @@ TEST_F(LuaHttpFilterTest, UnexpectedYield) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_,
               scriptLog(spdlog::level::err, StrEq("script performed an unexpected yield")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
@@ -613,7 +613,7 @@ TEST_F(LuaHttpFilterTest, ErrorDuringCallback) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_,
               scriptLog(spdlog::level::err,
                         StrEq("[string \"...\"]:5: attempt to index local 'foo' (a nil value)")));
@@ -633,7 +633,7 @@ TEST_F(LuaHttpFilterTest, HeadersIteratorAcrossYield) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers, false));
 
@@ -673,7 +673,7 @@ TEST_F(LuaHttpFilterTest, RequestAndResponse) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("/")));
   EXPECT_CALL(decoder_callbacks_, clearRouteCache());
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
@@ -682,11 +682,11 @@ TEST_F(LuaHttpFilterTest, RequestAndResponse) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("5")));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
 
-  Http::TestHeaderMapImpl request_trailers{{"foo", "bar"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"foo", "bar"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("bar")));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
 
-  Http::TestHeaderMapImpl continue_headers{{":status", "100"}};
+  Http::TestResponseHeaderMapImpl continue_headers{{":status", "100"}};
   // No lua hooks for 100-continue
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("100"))).Times(0);
   EXPECT_EQ(Http::FilterHeadersStatus::Continue,
@@ -695,7 +695,7 @@ TEST_F(LuaHttpFilterTest, RequestAndResponse) {
   Http::MetadataMap metadata_map{{"metadata", "metadata"}};
   EXPECT_EQ(Http::FilterMetadataStatus::Continue, filter_->encodeMetadata(metadata_map));
 
-  Http::TestHeaderMapImpl response_headers{{":status", "200"}};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("200")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, false));
 
@@ -703,7 +703,7 @@ TEST_F(LuaHttpFilterTest, RequestAndResponse) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("10")));
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->encodeData(data2, false));
 
-  Http::TestHeaderMapImpl response_trailers{{"hello", "world"}};
+  Http::TestResponseTrailerMapImpl response_trailers{{"hello", "world"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("world")));
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers));
 }
@@ -723,10 +723,10 @@ TEST_F(LuaHttpFilterTest, ResponseBlockingBody) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 
-  Http::TestHeaderMapImpl response_headers{{":status", "200"}};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("200")));
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->encodeHeaders(response_headers, false));
@@ -761,14 +761,14 @@ TEST_F(LuaHttpFilterTest, HttpCall) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   Http::MockAsyncClientRequest request(&cluster_manager_.async_client_);
   Http::AsyncClient::Callbacks* callbacks;
   EXPECT_CALL(cluster_manager_, get(Eq("cluster")));
   EXPECT_CALL(cluster_manager_, httpAsyncClientForCluster("cluster"));
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
       .WillOnce(
-          Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& cb,
+          Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             EXPECT_EQ((Http::TestHeaderMapImpl{{":path", "/"},
                                                {":method", "POST"},
@@ -787,11 +787,11 @@ TEST_F(LuaHttpFilterTest, HttpCall) {
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(data, false));
 
-  Http::TestHeaderMapImpl request_trailers{{"foo", "bar"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"foo", "bar"}};
   EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->decodeTrailers(request_trailers));
 
-  Http::MessagePtr response_message(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
+  Http::ResponseMessagePtr response_message(new Http::ResponseMessageImpl(
+      Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
   response_message->body() = std::make_unique<Buffer::OwnedImpl>("response");
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 200")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("response")));
@@ -838,14 +838,14 @@ TEST_F(LuaHttpFilterTest, DoubleHttpCall) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   Http::MockAsyncClientRequest request(&cluster_manager_.async_client_);
   Http::AsyncClient::Callbacks* callbacks;
   EXPECT_CALL(cluster_manager_, get(Eq("cluster")));
   EXPECT_CALL(cluster_manager_, httpAsyncClientForCluster("cluster"));
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
       .WillOnce(
-          Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& cb,
+          Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             EXPECT_EQ((Http::TestHeaderMapImpl{{":path", "/"},
                                                {":method", "POST"},
@@ -859,8 +859,8 @@ TEST_F(LuaHttpFilterTest, DoubleHttpCall) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers, false));
 
-  Http::MessagePtr response_message(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
+  Http::ResponseMessagePtr response_message(new Http::ResponseMessageImpl(
+      Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
   response_message->body() = std::make_unique<Buffer::OwnedImpl>("response");
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 200")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("response")));
@@ -868,7 +868,7 @@ TEST_F(LuaHttpFilterTest, DoubleHttpCall) {
   EXPECT_CALL(cluster_manager_, httpAsyncClientForCluster("cluster2"));
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
       .WillOnce(
-          Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& cb,
+          Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             EXPECT_EQ((Http::TestHeaderMapImpl{
                           {":path", "/bar"}, {":method", "GET"}, {":authority", "foo"}}),
@@ -879,7 +879,7 @@ TEST_F(LuaHttpFilterTest, DoubleHttpCall) {
   callbacks->onSuccess(std::move(response_message));
 
   response_message = std::make_unique<Http::ResponseMessageImpl>(
-      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "403"}}});
+      Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "403"}}});
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 403")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("no body")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
@@ -888,7 +888,7 @@ TEST_F(LuaHttpFilterTest, DoubleHttpCall) {
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
 
-  Http::TestHeaderMapImpl request_trailers{{"foo", "bar"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"foo", "bar"}};
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
 }
 
@@ -917,14 +917,14 @@ TEST_F(LuaHttpFilterTest, HttpCallNoBody) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   Http::MockAsyncClientRequest request(&cluster_manager_.async_client_);
   Http::AsyncClient::Callbacks* callbacks;
   EXPECT_CALL(cluster_manager_, get(Eq("cluster")));
   EXPECT_CALL(cluster_manager_, httpAsyncClientForCluster("cluster"));
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
       .WillOnce(
-          Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& cb,
+          Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             EXPECT_EQ((Http::TestHeaderMapImpl{
                           {":path", "/"}, {":method", "GET"}, {":authority", "foo"}}),
@@ -939,11 +939,11 @@ TEST_F(LuaHttpFilterTest, HttpCallNoBody) {
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(data, false));
 
-  Http::TestHeaderMapImpl request_trailers{{"foo", "bar"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"foo", "bar"}};
   EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->decodeTrailers(request_trailers));
 
-  Http::MessagePtr response_message(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
+  Http::ResponseMessagePtr response_message(new Http::ResponseMessageImpl(
+      Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 200")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("no body")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
@@ -975,14 +975,14 @@ TEST_F(LuaHttpFilterTest, HttpCallImmediateResponse) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   Http::MockAsyncClientRequest request(&cluster_manager_.async_client_);
   Http::AsyncClient::Callbacks* callbacks;
   EXPECT_CALL(cluster_manager_, get(Eq("cluster")));
   EXPECT_CALL(cluster_manager_, httpAsyncClientForCluster("cluster"));
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
       .WillOnce(
-          Invoke([&](Http::MessagePtr& message, Http::AsyncClient::Callbacks& cb,
+          Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             EXPECT_EQ((Http::TestHeaderMapImpl{
                           {":path", "/"}, {":method", "GET"}, {":authority", "foo"}}),
@@ -994,8 +994,8 @@ TEST_F(LuaHttpFilterTest, HttpCallImmediateResponse) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers, false));
 
-  Http::MessagePtr response_message(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
+  Http::ResponseMessagePtr response_message(new Http::ResponseMessageImpl(
+      Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
   Http::TestHeaderMapImpl expected_headers{{":status", "403"},
                                            {"set-cookie", "flavor=chocolate; Path=/"},
                                            {"set-cookie", "variant=chewy; Path=/"}};
@@ -1025,14 +1025,14 @@ TEST_F(LuaHttpFilterTest, HttpCallErrorAfterResumeSuccess) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   Http::MockAsyncClientRequest request(&cluster_manager_.async_client_);
   Http::AsyncClient::Callbacks* callbacks;
   EXPECT_CALL(cluster_manager_, get(Eq("cluster")));
   EXPECT_CALL(cluster_manager_, httpAsyncClientForCluster("cluster"));
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
       .WillOnce(
-          Invoke([&](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
+          Invoke([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             callbacks = &cb;
             return &request;
@@ -1041,8 +1041,8 @@ TEST_F(LuaHttpFilterTest, HttpCallErrorAfterResumeSuccess) {
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers, true));
 
-  Http::MessagePtr response_message(new Http::ResponseMessageImpl(
-      Http::HeaderMapPtr{new Http::TestHeaderMapImpl{{":status", "200"}}}));
+  Http::ResponseMessagePtr response_message(new Http::ResponseMessageImpl(
+      Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
 
   EXPECT_CALL(*filter_,
               scriptLog(spdlog::level::err,
@@ -1075,14 +1075,14 @@ TEST_F(LuaHttpFilterTest, HttpCallFailure) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   Http::MockAsyncClientRequest request(&cluster_manager_.async_client_);
   Http::AsyncClient::Callbacks* callbacks;
   EXPECT_CALL(cluster_manager_, get(Eq("cluster")));
   EXPECT_CALL(cluster_manager_, httpAsyncClientForCluster("cluster"));
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
       .WillOnce(
-          Invoke([&](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
+          Invoke([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             callbacks = &cb;
             return &request;
@@ -1117,14 +1117,14 @@ TEST_F(LuaHttpFilterTest, HttpCallReset) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   Http::MockAsyncClientRequest request(&cluster_manager_.async_client_);
   Http::AsyncClient::Callbacks* callbacks;
   EXPECT_CALL(cluster_manager_, get(Eq("cluster")));
   EXPECT_CALL(cluster_manager_, httpAsyncClientForCluster("cluster"));
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
       .WillOnce(
-          Invoke([&](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
+          Invoke([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             callbacks = &cb;
             return &request;
@@ -1161,13 +1161,13 @@ TEST_F(LuaHttpFilterTest, HttpCallImmediateFailure) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   Http::MockAsyncClientRequest request(&cluster_manager_.async_client_);
   EXPECT_CALL(cluster_manager_, get(Eq("cluster")));
   EXPECT_CALL(cluster_manager_, httpAsyncClientForCluster("cluster"));
   EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
       .WillOnce(
-          Invoke([&](Http::MessagePtr&, Http::AsyncClient::Callbacks& cb,
+          Invoke([&](Http::RequestMessagePtr&, Http::AsyncClient::Callbacks& cb,
                      const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
             cb.onFailure(Http::AsyncClient::FailureReason::Reset);
             return nullptr;
@@ -1193,7 +1193,7 @@ TEST_F(LuaHttpFilterTest, HttpCallInvalidTimeout) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::err,
                                   StrEq("[string \"...\"]:3: http call timeout must be >= 0")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
@@ -1214,7 +1214,7 @@ TEST_F(LuaHttpFilterTest, HttpCallInvalidCluster) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(cluster_manager_, get(Eq("cluster"))).WillOnce(Return(nullptr));
   EXPECT_CALL(
       *filter_,
@@ -1238,7 +1238,7 @@ TEST_F(LuaHttpFilterTest, HttpCallInvalidHeaders) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(cluster_manager_, get(Eq("cluster")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::err,
                                   StrEq("[string \"...\"]:3: http call headers must include "
@@ -1277,7 +1277,7 @@ TEST_F(LuaHttpFilterTest, ImmediateResponse) {
 #endif
 
   for (uint64_t i = 0; i < num_loops; i++) {
-    Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+    Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
     Http::TestHeaderMapImpl expected_headers{{":status", "503"}, {"content-length", "4"}};
     EXPECT_CALL(decoder_callbacks_, encodeHeaders_(HeaderMapEqualRef(&expected_headers), false));
     EXPECT_CALL(decoder_callbacks_, encodeData(_, true));
@@ -1312,7 +1312,7 @@ TEST_F(LuaHttpFilterTest, ImmediateResponseBadStatus) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::err,
                                   StrEq("[string \"...\"]:3: :status must be between 200-599")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
@@ -1333,7 +1333,7 @@ TEST_F(LuaHttpFilterTest, RespondAfterHeadersContinued) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
 
   EXPECT_CALL(
@@ -1358,15 +1358,15 @@ TEST_F(LuaHttpFilterTest, RespondInResponsePath) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 
-  Http::TestHeaderMapImpl response_headers{{":status", "200"}};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   EXPECT_CALL(
       *filter_,
       scriptLog(spdlog::level::err,
                 StrEq("[string \"...\"]:3: respond not currently supported in the response path")));
-  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(request_headers, true));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->encodeHeaders(response_headers, true));
 }
 
 // bodyChunks() after body continued.
@@ -1381,7 +1381,7 @@ TEST_F(LuaHttpFilterTest, BodyChunksAfterBodyContinued) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
             filter_->decodeHeaders(request_headers, false));
 
@@ -1406,13 +1406,13 @@ TEST_F(LuaHttpFilterTest, BodyAfterTrailers) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
 
   Buffer::OwnedImpl data("hello");
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
 
-  Http::TestHeaderMapImpl request_trailers{{"foo", "bar"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"foo", "bar"}};
   EXPECT_CALL(
       *filter_,
       scriptLog(spdlog::level::err,
@@ -1433,7 +1433,7 @@ TEST_F(LuaHttpFilterTest, BodyAfterStreamingHasStarted) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
 
   Buffer::OwnedImpl data("hello");
@@ -1470,7 +1470,7 @@ TEST_F(LuaHttpFilterTest, GetMetadataFromHandle) {
   setup(SCRIPT);
   setupMetadata(METADATA);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("foo")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("bar")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("baz")));
@@ -1492,7 +1492,7 @@ TEST_F(LuaHttpFilterTest, GetMetadataFromHandleNoRoute) {
   ON_CALL(decoder_callbacks_, route()).WillByDefault(Return(nullptr));
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("ok")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 }
@@ -1519,7 +1519,7 @@ TEST_F(LuaHttpFilterTest, GetMetadataFromHandleNoLuaMetadata) {
   setup(SCRIPT);
   setupMetadata(METADATA);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("ok")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 }
@@ -1538,7 +1538,7 @@ TEST_F(LuaHttpFilterTest, GetCurrentProtocol) {
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillOnce(ReturnRef(stream_info_));
   EXPECT_CALL(stream_info_, protocol()).WillOnce(Return(Http::Protocol::Http11));
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("HTTP/1.1")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 }
@@ -1557,8 +1557,8 @@ TEST_F(LuaHttpFilterTest, SetGetDynamicMetadata) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
-  DangerousDeprecatedTestTime test_time;
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
+  Event::SimulatedTimeSystem test_time;
   StreamInfo::StreamInfoImpl stream_info(Http::Protocol::Http2, test_time.timeSystem());
   EXPECT_EQ(0, stream_info.dynamicMetadata().filter_metadata_size());
   EXPECT_CALL(decoder_callbacks_, streamInfo()).WillOnce(ReturnRef(stream_info));
@@ -1598,7 +1598,7 @@ TEST_F(LuaHttpFilterTest, CheckConnection) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
 
   setupSecureConnection(false);
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("plain")));
@@ -1632,7 +1632,7 @@ TEST_F(LuaHttpFilterTest, ImportPublicKey) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
 
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("succeeded to import public key")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
@@ -1661,7 +1661,7 @@ TEST_F(LuaHttpFilterTest, InvalidPublicKey) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
 
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("failed to import public key")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
@@ -1723,7 +1723,7 @@ TEST_F(LuaHttpFilterTest, SignatureVerify) {
   InSequence s;
   setup(SCRIPT);
 
-  Http::TestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
 
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("signature is valid")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("unknown is not supported.")));

--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -38,8 +38,9 @@ public:
     });
 
     config_helper_.addConfigModifier(
-        [domain](envoy::extensions::filters::network::http_connection_manager::v3::
-                     HttpConnectionManager& hcm) {
+        [domain](
+            envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+                hcm) {
           hcm.mutable_route_config()
               ->mutable_virtual_hosts(0)
               ->mutable_routes(0)
@@ -173,11 +174,11 @@ typed_config:
 
   initializeFilter(FILTER_AND_CODE);
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
-  Http::TestHeaderMapImpl request_headers{{":method", "POST"},
-                                          {":path", "/test/long/url"},
-                                          {":scheme", "http"},
-                                          {":authority", "host"},
-                                          {"x-forwarded-for", "10.0.0.1"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "POST"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"x-forwarded-for", "10.0.0.1"}};
 
   auto encoder_decoder = codec_client_->startRequest(request_headers);
   Http::StreamEncoder& encoder = encoder_decoder.first;
@@ -217,7 +218,7 @@ typed_config:
                        ->value()
                        .getStringView());
 
-  Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"foo", "bar"}};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"foo", "bar"}};
   upstream_request_->encodeHeaders(response_headers, false);
   Buffer::OwnedImpl response_data1("good");
   upstream_request_->encodeData(response_data1, false);
@@ -273,17 +274,17 @@ typed_config:
   initializeFilter(FILTER_AND_CODE);
 
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
-  Http::TestHeaderMapImpl request_headers{{":method", "GET"},
-                                          {":path", "/test/long/url"},
-                                          {":scheme", "http"},
-                                          {":authority", "host"},
-                                          {"x-forwarded-for", "10.0.0.1"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"x-forwarded-for", "10.0.0.1"}};
   auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
 
   ASSERT_TRUE(fake_upstreams_[1]->waitForHttpConnection(*dispatcher_, fake_lua_connection_));
   ASSERT_TRUE(fake_lua_connection_->waitForNewStream(*dispatcher_, lua_request_));
   ASSERT_TRUE(lua_request_->waitForEndStream(*dispatcher_));
-  Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"foo", "bar"}};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"foo", "bar"}};
   lua_request_->encodeHeaders(response_headers, false);
   Buffer::OwnedImpl response_data1("good");
   lua_request_->encodeData(response_data1, true);
@@ -333,17 +334,17 @@ typed_config:
   initializeFilter(FILTER_AND_CODE);
 
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
-  Http::TestHeaderMapImpl request_headers{{":method", "GET"},
-                                          {":path", "/test/long/url"},
-                                          {":scheme", "http"},
-                                          {":authority", "host"},
-                                          {"x-forwarded-for", "10.0.0.1"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"x-forwarded-for", "10.0.0.1"}};
   auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
 
   ASSERT_TRUE(fake_upstreams_[1]->waitForHttpConnection(*dispatcher_, fake_lua_connection_));
   ASSERT_TRUE(fake_lua_connection_->waitForNewStream(*dispatcher_, lua_request_));
   ASSERT_TRUE(lua_request_->waitForEndStream(*dispatcher_));
-  Http::TestHeaderMapImpl response_headers{{":status", "200"}, {"foo", "bar"}};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}, {"foo", "bar"}};
   lua_request_->encodeHeaders(response_headers, true);
 
   response->waitForEndStream();
@@ -371,11 +372,11 @@ typed_config:
   initializeFilter(FILTER_AND_CODE);
 
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
-  Http::TestHeaderMapImpl request_headers{{":method", "GET"},
-                                          {":path", "/test/long/url"},
-                                          {":scheme", "http"},
-                                          {":authority", "host"},
-                                          {"x-forwarded-for", "10.0.0.1"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"x-forwarded-for", "10.0.0.1"}};
   auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
 
   waitForNextUpstreamRequest(2);
@@ -404,11 +405,11 @@ typed_config:
   initializeFilter(FILTER_AND_CODE);
 
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
-  Http::TestHeaderMapImpl request_headers{{":method", "GET"},
-                                          {":path", "/test/long/url"},
-                                          {":scheme", "http"},
-                                          {":authority", "host"},
-                                          {"x-forwarded-for", "10.0.0.1"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"x-forwarded-for", "10.0.0.1"}};
 
   for (uint32_t i = 0; i < 30; ++i) {
     auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
@@ -472,7 +473,7 @@ typed_config:
       local sig = request_handle:headers():get("signature")
       local rawsig = sig:fromhex()
       local data = request_handle:headers():get("message")
-      local ok, error = request_handle:verifySignature(hash, pubkey, rawsig, string.len(rawsig), data, string.len(data))
+      local ok, error = request_handle:verifySignature(hash, pubkey, rawsig, string.len(rawsig), data, string.len(data)) 
 
       if ok then
         request_handle:headers():add("signature_verification", "approved")
@@ -496,7 +497,7 @@ typed_config:
       "295234f7c14fa46303b7e977d2c89ba8a39a46a35f33eb07a332";
 
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
-  Http::TestHeaderMapImpl request_headers{
+  Http::TestRequestHeaderMapImpl request_headers{
       {":method", "POST"},    {":path", "/test/long/url"},     {":scheme", "https"},
       {":authority", "host"}, {"x-forwarded-for", "10.0.0.1"}, {"message", "hello"},
       {"keyid", "foo"},       {"signature", signature},        {"hash", "sha256"}};

--- a/test/extensions/filters/http/lua/wrappers_test.cc
+++ b/test/extensions/filters/http/lua/wrappers_test.cc
@@ -254,7 +254,7 @@ protected:
     return metadata;
   }
 
-  DangerousDeprecatedTestTime test_time_;
+  Event::SimulatedTimeSystem test_time_;
 };
 
 // Return the current request protocol.

--- a/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
+++ b/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
@@ -198,20 +198,28 @@ public:
   void TearDown() override { SslIntegrationTestBase::TearDown(); };
 
   ClientSslTransportOptions rsaOnlyClientOptions() {
+    /*
     if (tls_version_ == envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_3) {
+    */
       return ClientSslTransportOptions().setSigningAlgorithmsForTest("rsa_pss_rsae_sha256");
+    /*
     } else {
       return ClientSslTransportOptions().setCipherSuites({"ECDHE-RSA-AES128-GCM-SHA256"});
     }
+    */
   }
 
   ClientSslTransportOptions ecdsaOnlyClientOptions() {
     auto options = ClientSslTransportOptions().setClientEcdsaCert(true);
+    /*
     if (tls_version_ == envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_3) {
+    */
       return options.setSigningAlgorithmsForTest("ecdsa_secp256r1_sha256");
+    /*
     } else {
       return options.setCipherSuites({"ECDHE-ECDSA-AES128-GCM-SHA256"});
     }
+    */
   }
 
   static std::string ipClientVersionTestParamsToString(

--- a/test/integration/ads_integration.cc
+++ b/test/integration/ads_integration.cc
@@ -88,7 +88,7 @@ AdsIntegrationTest::buildListener(const std::string& name, const std::string& ro
           port_value: 0
       filter_chains:
         filters:
-        - name: envoy.http_connection_manager
+        - name: envoy.filters.network.http_connection_manager
           typed_config:
             "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
             stat_prefix: {}
@@ -112,7 +112,7 @@ AdsIntegrationTest::buildRedisListener(const std::string& name, const std::strin
           port_value: 0
       filter_chains:
         filters:
-        - name: envoy.redis_proxy
+        - name: envoy.filters.network.redis_proxy
           typed_config:
             "@type": type.googleapis.com/envoy.config.filter.network.redis_proxy.v2.RedisProxy
             settings: 

--- a/test/integration/api_listener_integration_test.cc
+++ b/test/integration/api_listener_integration_test.cc
@@ -30,7 +30,6 @@ public:
       bootstrap.mutable_static_resources()->add_listeners()->MergeFrom(
           Server::parseListenerFromV2Yaml(api_listener_config()));
     });
-    BaseIntegrationTest::initialize();
   }
 
   void TearDown() override {
@@ -84,6 +83,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, ApiListenerIntegrationTest,
                          TestUtility::ipTestParamsToString);
 
 TEST_P(ApiListenerIntegrationTest, Basic) {
+  BaseIntegrationTest::initialize();
   absl::Notification done;
   test_server_->server().dispatcher().post([this, &done]() -> void {
     ASSERT_TRUE(test_server_->server().listenerManager().apiListener().has_value());
@@ -104,11 +104,39 @@ TEST_P(ApiListenerIntegrationTest, Basic) {
 
     // Send a headers-only request
     stream_decoder.decodeHeaders(
-        Http::HeaderMapPtr(new Http::TestHeaderMapImpl{
+        Http::RequestHeaderMapPtr(new Http::TestRequestHeaderMapImpl{
             {":method", "GET"}, {":path", "/api"}, {":scheme", "http"}, {":authority", "host"}}),
         true);
   });
   ASSERT_TRUE(done.WaitForNotificationWithTimeout(absl::Seconds(1)));
+}
+
+TEST_P(ApiListenerIntegrationTest, DestroyWithActiveStreams) {
+  autonomous_allow_incomplete_streams_ = true;
+  BaseIntegrationTest::initialize();
+  absl::Notification done;
+
+  test_server_->server().dispatcher().post([this, &done]() -> void {
+    ASSERT_TRUE(test_server_->server().listenerManager().apiListener().has_value());
+    ASSERT_EQ("api_listener", test_server_->server().listenerManager().apiListener()->get().name());
+    ASSERT_TRUE(test_server_->server().listenerManager().apiListener()->get().http().has_value());
+    auto& http_api_listener =
+        test_server_->server().listenerManager().apiListener()->get().http()->get();
+
+    ON_CALL(stream_encoder_, getStream()).WillByDefault(ReturnRef(stream_encoder_.stream_));
+    auto& stream_decoder = http_api_listener.newStream(stream_encoder_);
+
+    // Send a headers-only request
+    stream_decoder.decodeHeaders(
+        Http::RequestHeaderMapPtr(new Http::TestRequestHeaderMapImpl{
+            {":method", "GET"}, {":path", "/api"}, {":scheme", "http"}, {":authority", "host"}}),
+        false);
+
+    done.Notify();
+  });
+  ASSERT_TRUE(done.WaitForNotificationWithTimeout(absl::Seconds(1)));
+  // The server should shutdown the ApiListener at the right time during server termination such
+  // that no crashes occur if termination happens when the ApiListener still has ongoing streams.
 }
 
 } // namespace

--- a/test/integration/echo_integration_test.cc
+++ b/test/integration/echo_integration_test.cc
@@ -17,13 +17,13 @@ public:
     echo_config = ConfigHelper::BASE_CONFIG + R"EOF(
     filter_chains:
       filters:
-        name: envoy.ratelimit
+        name: envoy.filters.network.ratelimit
         config:
           domain: foo
           stats_prefix: name
           descriptors: [{"key": "foo", "value": "bar"}]
       filters:
-        name: envoy.echo
+        name: envoy.filters.network.echo
         config:
       )EOF";
   }
@@ -70,7 +70,7 @@ address:
     port_value: 0
 filter_chains:
 - filters:
-  - name: envoy.echo
+  - name: envoy.filters.network.echo
   )EOF",
                                                        GetParam());
 

--- a/test/integration/eds_integration_test.cc
+++ b/test/integration/eds_integration_test.cc
@@ -171,7 +171,7 @@ TEST_P(EdsIntegrationTest, Http2HcClusterRewarming) {
 
   // Wait for the first HC and verify the host is healthy. This should warm the initial cluster.
   waitForNextUpstreamRequest();
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, true);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
   test_server_->waitForGaugeEq("cluster.cluster_0.membership_healthy", 1);
   EXPECT_EQ(1, test_server_->gauge("cluster.cluster_0.membership_total")->value());
 
@@ -197,7 +197,7 @@ TEST_P(EdsIntegrationTest, Http2HcClusterRewarming) {
 
   // Respond with a health check. This will cause the previous cluster to be destroyed inline as
   // part of processing the response.
-  upstream_request->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, true);
+  upstream_request->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "503"}}, true);
   test_server_->waitForGaugeEq("cluster_manager.warming_clusters", 0);
   EXPECT_EQ(0, test_server_->gauge("cluster_manager.warming_clusters")->value());
 
@@ -221,7 +221,7 @@ TEST_P(EdsIntegrationTest, RemoveAfterHcFail) {
 
   // Wait for the first HC and verify the host is healthy.
   waitForNextUpstreamRequest();
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, true);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
   test_server_->waitForGaugeEq("cluster.cluster_0.membership_healthy", 1);
   EXPECT_EQ(1, test_server_->gauge("cluster.cluster_0.membership_total")->value());
 
@@ -233,7 +233,7 @@ TEST_P(EdsIntegrationTest, RemoveAfterHcFail) {
   // Fail HC and verify the host is gone.
   waitForNextUpstreamRequest();
   upstream_request_->encodeHeaders(
-      Http::TestHeaderMapImpl{{":status", "503"}, {"connection", "close"}}, true);
+      Http::TestResponseHeaderMapImpl{{":status", "503"}, {"connection", "close"}}, true);
   test_server_->waitForGaugeEq("cluster.cluster_0.membership_healthy", 0);
   EXPECT_EQ(0, test_server_->gauge("cluster.cluster_0.membership_total")->value());
 }
@@ -254,7 +254,7 @@ TEST_P(EdsIntegrationTest, EndpointWarmingSuccessfulHc) {
   // Wait for the first HC and verify the host is healthy and that it is no longer being excluded.
   // The other endpoint should still be excluded.
   waitForNextUpstreamRequest(0);
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, true);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
   test_server_->waitForGaugeEq("cluster.cluster_0.membership_excluded", 0);
   EXPECT_EQ(1, test_server_->gauge("cluster.cluster_0.membership_total")->value());
   EXPECT_EQ(1, test_server_->gauge("cluster.cluster_0.membership_healthy")->value());
@@ -277,7 +277,7 @@ TEST_P(EdsIntegrationTest, EndpointWarmingFailedHc) {
   // Wait for the first HC and verify the host is healthy and that it is no longer being excluded.
   // The other endpoint should still be excluded.
   waitForNextUpstreamRequest(0);
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, true);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "503"}}, true);
   test_server_->waitForGaugeEq("cluster.cluster_0.membership_excluded", 0);
   EXPECT_EQ(1, test_server_->gauge("cluster.cluster_0.membership_total")->value());
   EXPECT_EQ(0, test_server_->gauge("cluster.cluster_0.membership_healthy")->value());

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -44,7 +44,7 @@ FakeStream::FakeStream(FakeHttpConnection& parent, Http::ResponseEncoder& encode
   encoder.getStream().addCallbacks(*this);
 }
 
-void FakeStream::decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
+void FakeStream::decodeHeaders(Http::RequestHeaderMapPtr&& headers, bool end_stream) {
   Thread::LockGuard lock(lock_);
   headers_ = std::move(headers);
   setEndStream(end_stream);
@@ -59,7 +59,7 @@ void FakeStream::decodeData(Buffer::Instance& data, bool end_stream) {
   decoder_event_.notifyOne();
 }
 
-void FakeStream::decodeTrailers(Http::HeaderMapPtr&& trailers) {
+void FakeStream::decodeTrailers(Http::RequestTrailerMapPtr&& trailers) {
   Thread::LockGuard lock(lock_);
   setEndStream(true);
   trailers_ = std::move(trailers);
@@ -73,16 +73,16 @@ void FakeStream::decodeMetadata(Http::MetadataMapPtr&& metadata_map_ptr) {
   }
 }
 
-void FakeStream::encode100ContinueHeaders(const Http::HeaderMapImpl& headers) {
-  std::shared_ptr<Http::HeaderMapImpl> headers_copy(
-      new Http::HeaderMapImpl(static_cast<const Http::HeaderMap&>(headers)));
+void FakeStream::encode100ContinueHeaders(const Http::ResponseHeaderMap& headers) {
+  std::shared_ptr<Http::ResponseHeaderMap> headers_copy(
+      Http::createHeaderMap<Http::ResponseHeaderMapImpl>(headers));
   parent_.connection().dispatcher().post(
       [this, headers_copy]() -> void { encoder_.encode100ContinueHeaders(*headers_copy); });
 }
 
-void FakeStream::encodeHeaders(const Http::HeaderMapImpl& headers, bool end_stream) {
-  std::shared_ptr<Http::HeaderMapImpl> headers_copy(
-      new Http::HeaderMapImpl(static_cast<const Http::HeaderMap&>(headers)));
+void FakeStream::encodeHeaders(const Http::HeaderMap& headers, bool end_stream) {
+  std::shared_ptr<Http::ResponseHeaderMap> headers_copy(
+      Http::createHeaderMap<Http::ResponseHeaderMapImpl>(headers));
   if (add_served_by_header_) {
     headers_copy->addCopy(Http::LowerCaseString("x-served-by"),
                           parent_.connection().localAddress()->asString());
@@ -112,9 +112,9 @@ void FakeStream::encodeData(Buffer::Instance& data, bool end_stream) {
       [this, data_copy, end_stream]() -> void { encoder_.encodeData(*data_copy, end_stream); });
 }
 
-void FakeStream::encodeTrailers(const Http::HeaderMapImpl& trailers) {
-  std::shared_ptr<Http::HeaderMapImpl> trailers_copy(
-      new Http::HeaderMapImpl(static_cast<const Http::HeaderMap&>(trailers)));
+void FakeStream::encodeTrailers(const Http::HeaderMap& trailers) {
+  std::shared_ptr<Http::ResponseTrailerMap> trailers_copy(
+      Http::createHeaderMap<Http::ResponseTrailerMapImpl>(trailers));
   parent_.connection().dispatcher().post(
       [this, trailers_copy]() -> void { encoder_.encodeTrailers(*trailers_copy); });
 }
@@ -207,7 +207,7 @@ AssertionResult FakeStream::waitForReset(milliseconds timeout) {
 }
 
 void FakeStream::startGrpcStream() {
-  encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+  encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
 }
 
 void FakeStream::finishGrpcStream(Grpc::Status::GrpcStatus status) {

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -56,12 +56,12 @@ public:
     Thread::LockGuard lock(lock_);
     return end_stream_;
   }
-  void encode100ContinueHeaders(const Http::HeaderMapImpl& headers);
-  void encodeHeaders(const Http::HeaderMapImpl& headers, bool end_stream);
+  void encode100ContinueHeaders(const Http::ResponseHeaderMap& headers);
+  void encodeHeaders(const Http::HeaderMap& headers, bool end_stream);
   void encodeData(uint64_t size, bool end_stream);
   void encodeData(Buffer::Instance& data, bool end_stream);
   void encodeData(absl::string_view data, bool end_stream);
-  void encodeTrailers(const Http::HeaderMapImpl& trailers);
+  void encodeTrailers(const Http::HeaderMap& trailers);
   void encodeResetStream();
   void encodeMetadata(const Http::MetadataMapVector& metadata_map_vector);
   const Http::HeaderMap& headers() { return *headers_; }
@@ -156,8 +156,8 @@ public:
   void decodeMetadata(Http::MetadataMapPtr&& metadata_map_ptr) override;
 
   // Http::RequestDecoder
-  void decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) override;
-  void decodeTrailers(Http::HeaderMapPtr&& trailers) override;
+  void decodeHeaders(Http::RequestHeaderMapPtr&& headers, bool end_stream) override;
+  void decodeTrailers(Http::RequestTrailerMapPtr&& trailers) override;
 
   // Http::StreamCallbacks
   void onResetStream(Http::StreamResetReason reason,

--- a/test/integration/filter_manager_integration_test.cc
+++ b/test/integration/filter_manager_integration_test.cc
@@ -42,7 +42,8 @@ const std::regex invalid_param_name_regex() { return std::regex{"[^a-zA-Z0-9_]"}
  * Integration test with one of auxiliary filters (listed above)
  * added to the head of the filter chain.
  *
- * Shared by tests for "envoy.echo", "envoy.tcp_proxy" and "envoy.http_connection_manager".
+ * Shared by tests for "envoy.filters.network.echo", "envoy.filters.network.tcp_proxy" and
+ * "envoy.filters.network.http_connection_manager".
  */
 class TestWithAuxiliaryFilter {
 public:
@@ -55,8 +56,9 @@ protected:
   /**
    * Returns configuration for a given auxiliary filter.
    *
-   * Assuming that representative configurations differ in the context of "envoy.echo",
-   * "envoy.tcp_proxy" and "envoy.http_connection_manager".
+   * Assuming that representative configurations differ in the context of
+   * "envoy.filters.network.echo", "envoy.filters.network.tcp_proxy" and
+   * "envoy.filters.network.http_connection_manager".
    */
   virtual std::string filterConfig(const std::string& auxiliary_filter_name) PURE;
 
@@ -125,7 +127,7 @@ private:
 };
 
 /**
- * Base class for "envoy.echo" and "envoy.tcp_proxy" tests.
+ * Base class for "envoy.filters.network.echo" and "envoy.filters.network.tcp_proxy" tests.
  *
  * Inherits from BaseIntegrationTest; parameterized with IP version and auxiliary filter.
  */
@@ -170,7 +172,7 @@ protected:
 };
 
 /**
- * Integration test with an auxiliary filter in front of "envoy.echo".
+ * Integration test with an auxiliary filter in front of "envoy.filters.network.echo".
  */
 class InjectDataWithEchoFilterIntegrationTest : public InjectDataToFilterChainIntegrationTest {
 public:
@@ -178,7 +180,7 @@ public:
     return ConfigHelper::BASE_CONFIG + R"EOF(
     filter_chains:
       filters:
-      - name: envoy.echo
+      - name: envoy.filters.network.echo
       )EOF";
   }
 
@@ -203,7 +205,7 @@ TEST_P(InjectDataWithEchoFilterIntegrationTest, UsageOfInjectDataMethodsShouldBe
 }
 
 /**
- * Integration test with an auxiliary filter in front of "envoy.tcp_proxy".
+ * Integration test with an auxiliary filter in front of "envoy.filters.network.tcp_proxy".
  */
 class InjectDataWithTcpProxyFilterIntegrationTest : public InjectDataToFilterChainIntegrationTest {
 public:
@@ -248,7 +250,8 @@ TEST_P(InjectDataWithTcpProxyFilterIntegrationTest, UsageOfInjectDataMethodsShou
 }
 
 /**
- * Integration test with an auxiliary filter in front of "envoy.http_connection_manager".
+ * Integration test with an auxiliary filter in front of
+ * "envoy.filters.network.http_connection_manager".
  *
  * Inherits from HttpIntegrationTest;
  * parameterized with IP version, downstream HTTP version and auxiliary filter.
@@ -309,7 +312,7 @@ TEST_P(InjectDataWithHttpConnectionManagerIntegrationTest,
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  Http::TestHeaderMapImpl headers{
+  Http::TestRequestHeaderMapImpl headers{
       {":method", "POST"}, {":path", "/api"}, {":authority", "host"}, {":scheme", "http"}};
   auto response = codec_client_->makeRequestWithBody(headers, "hello!");
 
@@ -317,7 +320,7 @@ TEST_P(InjectDataWithHttpConnectionManagerIntegrationTest,
   EXPECT_TRUE(upstream_request_->complete());
   EXPECT_EQ("hello!", upstream_request_->body().toString());
 
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
   Buffer::OwnedImpl response_data{"greetings"};
   upstream_request_->encodeData(response_data, true);
 

--- a/test/integration/filters/call_decodedata_once_filter.cc
+++ b/test/integration/filters/call_decodedata_once_filter.cc
@@ -15,7 +15,7 @@ class CallDecodeDataOnceFilter : public Http::PassThroughFilter {
 public:
   constexpr static char name[] = "call-decodedata-once-filter";
 
-  Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap& header_map, bool) override {
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& header_map, bool) override {
     const Http::HeaderEntry* entry_content =
         header_map.get(Envoy::Http::LowerCaseString("content_size"));
     const Http::HeaderEntry* entry_added =
@@ -33,7 +33,7 @@ public:
     return Http::FilterDataStatus::Continue;
   }
 
-  Http::FilterTrailersStatus decodeTrailers(Http::HeaderMap&) override {
+  Http::FilterTrailersStatus decodeTrailers(Http::RequestTrailerMap&) override {
     return Http::FilterTrailersStatus::Continue;
   }
 

--- a/test/integration/filters/decode_headers_return_stop_all_filter.cc
+++ b/test/integration/filters/decode_headers_return_stop_all_filter.cc
@@ -26,7 +26,7 @@ public:
   // Returns Http::FilterHeadersStatus::StopAllIterationAndBuffer or
   // Http::FilterHeadersStatus::StopAllIterationAndWatermark for headers. Triggers a timer to
   // continue iteration after 5s.
-  Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap& header_map, bool) override {
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& header_map, bool) override {
     const Http::HeaderEntry* entry_content =
         header_map.get(Envoy::Http::LowerCaseString("content_size"));
     const Http::HeaderEntry* entry_added =
@@ -76,7 +76,7 @@ public:
     return Http::FilterDataStatus::Continue;
   }
 
-  Http::FilterTrailersStatus decodeTrailers(Http::HeaderMap&) override {
+  Http::FilterTrailersStatus decodeTrailers(Http::RequestTrailerMap&) override {
     ASSERT(timer_triggered_);
     if (is_first_trigger_) {
       Buffer::OwnedImpl data(std::string(added_size_, 'a'));

--- a/test/integration/filters/eds_ready_filter.cc
+++ b/test/integration/filters/eds_ready_filter.cc
@@ -20,7 +20,7 @@ class EdsReadyFilter : public Http::PassThroughFilter {
 public:
   EdsReadyFilter(const Stats::Scope& root_scope, Stats::SymbolTable& symbol_table)
       : root_scope_(root_scope), stat_name_("cluster.cluster_0.membership_healthy", symbol_table) {}
-  Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap&, bool) override {
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&, bool) override {
     Stats::GaugeOptConstRef gauge = root_scope_.findGauge(stat_name_.statName());
     if (!gauge.has_value()) {
       decoder_callbacks_->sendLocalReply(Envoy::Http::Code::InternalServerError,

--- a/test/integration/filters/encode_headers_return_stop_all_filter.cc
+++ b/test/integration/filters/encode_headers_return_stop_all_filter.cc
@@ -26,7 +26,7 @@ public:
   // Returns Http::FilterHeadersStatus::StopAllIterationAndBuffer or
   // Http::FilterHeadersStatus::StopAllIterationAndWatermark for headers. Triggers a timer to
   // continue iteration after 5s.
-  Http::FilterHeadersStatus encodeHeaders(Http::HeaderMap& header_map, bool) override {
+  Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap& header_map, bool) override {
     const Http::HeaderEntry* entry_content =
         header_map.get(Envoy::Http::LowerCaseString("content_size"));
     const Http::HeaderEntry* entry_added =
@@ -72,7 +72,7 @@ public:
     return Http::FilterDataStatus::Continue;
   }
 
-  Http::FilterTrailersStatus encodeTrailers(Http::HeaderMap&) override {
+  Http::FilterTrailersStatus encodeTrailers(Http::ResponseTrailerMap&) override {
     ASSERT(timer_triggered_);
     Http::MetadataMap metadata_map = {{"trailers", "trailers"}};
     Http::MetadataMapPtr metadata_map_ptr = std::make_unique<Http::MetadataMap>(metadata_map);

--- a/test/integration/filters/headers_only_filter.cc
+++ b/test/integration/filters/headers_only_filter.cc
@@ -15,7 +15,7 @@ class HeaderOnlyDecoderFilter : public Http::PassThroughFilter {
 public:
   constexpr static char name[] = "decode-headers-only";
 
-  Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap&, bool) override {
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&, bool) override {
     return Http::FilterHeadersStatus::ContinueAndEndStream;
   }
 };
@@ -29,7 +29,7 @@ class HeaderOnlyEncoderFilter : public Http::PassThroughFilter {
 public:
   constexpr static char name[] = "encode-headers-only";
 
-  Http::FilterHeadersStatus encodeHeaders(Http::HeaderMap&, bool) override {
+  Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap&, bool) override {
     return Http::FilterHeadersStatus::ContinueAndEndStream;
   }
 };

--- a/test/integration/filters/metadata_stop_all_filter.cc
+++ b/test/integration/filters/metadata_stop_all_filter.cc
@@ -21,7 +21,7 @@ class MetadataStopAllFilter : public Http::PassThroughFilter {
 public:
   constexpr static char name[] = "metadata-stop-all-filter";
 
-  Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap& header_map, bool) override {
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& header_map, bool) override {
     const Http::HeaderEntry* entry_content =
         header_map.get(Envoy::Http::LowerCaseString("content_size"));
     ASSERT(entry_content != nullptr);
@@ -37,7 +37,7 @@ public:
     return Http::FilterDataStatus::Continue;
   }
 
-  Http::FilterTrailersStatus decodeTrailers(Http::HeaderMap&) override {
+  Http::FilterTrailersStatus decodeTrailers(Http::RequestTrailerMap&) override {
     ASSERT(timer_triggered_);
     return Http::FilterTrailersStatus::Continue;
   }

--- a/test/integration/filters/process_context_filter.cc
+++ b/test/integration/filters/process_context_filter.cc
@@ -20,7 +20,7 @@ class ProcessContextFilter : public Http::PassThroughFilter {
 public:
   ProcessContextFilter(ProcessContext& process_context)
       : process_object_(dynamic_cast<ProcessObjectForFilter&>(process_context.get())) {}
-  Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap&, bool) override {
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&, bool) override {
     if (!process_object_.isHealthy()) {
       decoder_callbacks_->sendLocalReply(Envoy::Http::Code::InternalServerError,
                                          "ProcessObjectForFilter is unhealthy", nullptr,

--- a/test/integration/filters/request_metadata_filter.cc
+++ b/test/integration/filters/request_metadata_filter.cc
@@ -14,7 +14,7 @@ namespace Envoy {
 // "consume", the metadata will be consumed and not forwarded to the next hop.
 class RequestMetadataStreamFilter : public Http::PassThroughFilter {
 public:
-  Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap&, bool) override {
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&, bool) override {
     Http::MetadataMap metadata_map = {{"headers", "headers"}};
     Http::MetadataMapPtr metadata_map_ptr = std::make_unique<Http::MetadataMap>(metadata_map);
     decoder_callbacks_->addDecodedMetadata().emplace_back(std::move(metadata_map_ptr));
@@ -28,7 +28,7 @@ public:
     return Http::FilterDataStatus::Continue;
   }
 
-  Http::FilterTrailersStatus decodeTrailers(Http::HeaderMap&) override {
+  Http::FilterTrailersStatus decodeTrailers(Http::RequestTrailerMap&) override {
     Http::MetadataMap metadata_map = {{"trailers", "trailers"}};
     Http::MetadataMapPtr metadata_map_ptr = std::make_unique<Http::MetadataMap>(metadata_map);
     decoder_callbacks_->addDecodedMetadata().emplace_back(std::move(metadata_map_ptr));

--- a/test/integration/filters/response_metadata_filter.cc
+++ b/test/integration/filters/response_metadata_filter.cc
@@ -16,7 +16,7 @@ namespace Envoy {
 class ResponseMetadataStreamFilter : public Http::PassThroughFilter {
 public:
   // Inserts one new metadata_map.
-  Http::FilterHeadersStatus encodeHeaders(Http::HeaderMap&, bool) override {
+  Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap&, bool) override {
     Http::MetadataMap metadata_map = {{"headers", "headers"}, {"duplicate", "duplicate"}};
     Http::MetadataMapPtr metadata_map_ptr = std::make_unique<Http::MetadataMap>(metadata_map);
     encoder_callbacks_->addEncodedMetadata(std::move(metadata_map_ptr));
@@ -32,7 +32,7 @@ public:
   }
 
   // Inserts two metadata_maps by calling decoder_callbacks_->encodeMetadata() twice.
-  Http::FilterTrailersStatus encodeTrailers(Http::HeaderMap&) override {
+  Http::FilterTrailersStatus encodeTrailers(Http::ResponseTrailerMap&) override {
     Http::MetadataMap metadata_map = {{"trailers", "trailers"}};
     Http::MetadataMapPtr metadata_map_ptr = std::make_unique<Http::MetadataMap>(metadata_map);
     encoder_callbacks_->addEncodedMetadata(std::move(metadata_map_ptr));
@@ -43,7 +43,7 @@ public:
   }
 
   // Inserts two metadata_maps by calling decoder_callbacks_->encodeMetadata() twice.
-  Http::FilterHeadersStatus encode100ContinueHeaders(Http::HeaderMap&) override {
+  Http::FilterHeadersStatus encode100ContinueHeaders(Http::ResponseHeaderMap&) override {
     Http::MetadataMap metadata_map = {{"100-continue", "100-continue"}, {"duplicate", "duplicate"}};
     Http::MetadataMapPtr metadata_map_ptr = std::make_unique<Http::MetadataMap>(metadata_map);
     encoder_callbacks_->addEncodedMetadata(std::move(metadata_map_ptr));

--- a/test/integration/filters/stop_iteration_and_continue_filter.cc
+++ b/test/integration/filters/stop_iteration_and_continue_filter.cc
@@ -27,7 +27,7 @@ public:
     encode_delay_timer_->enableTimer(std::chrono::seconds(0));
   }
 
-  Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap&, bool end_stream) override {
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap&, bool end_stream) override {
     if (end_stream) {
       setEndStreamAndDecodeTimer();
       return Http::FilterHeadersStatus::StopIteration;
@@ -43,7 +43,7 @@ public:
     return Http::FilterDataStatus::StopIterationNoBuffer;
   }
 
-  Http::FilterHeadersStatus encodeHeaders(Http::HeaderMap&, bool end_stream) override {
+  Http::FilterHeadersStatus encodeHeaders(Http::ResponseHeaderMap&, bool end_stream) override {
     if (end_stream) {
       setEndStreamAndEncodeTimer();
       return Http::FilterHeadersStatus::StopIteration;

--- a/test/integration/hds_integration_test.cc
+++ b/test/integration/hds_integration_test.cc
@@ -257,7 +257,7 @@ TEST_P(HdsIntegrationTest, SingleEndpointHealthyHttp) {
   healthcheckEndpoints();
 
   // Endpoint responds to the health check
-  host_stream_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+  host_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
   host_stream_->encodeData(1024, true);
 
   // Receive updates until the one we expect arrives
@@ -328,7 +328,7 @@ TEST_P(HdsIntegrationTest, SingleEndpointUnhealthyHttp) {
   healthcheckEndpoints();
 
   // Endpoint responds to the health check
-  host_stream_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "404"}}, false);
+  host_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "404"}}, false);
   host_stream_->encodeData(1024, true);
 
   // Receive updates until the one we expect arrives
@@ -473,9 +473,9 @@ TEST_P(HdsIntegrationTest, TwoEndpointsSameLocality) {
   healthcheckEndpoints("anna");
 
   // Endpoints respond to the health check
-  host_stream_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "404"}}, false);
+  host_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "404"}}, false);
   host_stream_->encodeData(1024, true);
-  host2_stream_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+  host2_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
   host2_stream_->encodeData(1024, true);
 
   // Receive updates until the one we expect arrives
@@ -525,9 +525,9 @@ TEST_P(HdsIntegrationTest, TwoEndpointsDifferentLocality) {
   healthcheckEndpoints("anna");
 
   // Endpoint responds to the health check
-  host_stream_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "404"}}, false);
+  host_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "404"}}, false);
   host_stream_->encodeData(1024, true);
-  host2_stream_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+  host2_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
   host2_stream_->encodeData(1024, true);
 
   // Receive updates until the one we expect arrives
@@ -588,9 +588,9 @@ TEST_P(HdsIntegrationTest, TwoEndpointsDifferentClusters) {
   healthcheckEndpoints("cat");
 
   // Endpoint responds to the health check
-  host_stream_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "404"}}, false);
+  host_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "404"}}, false);
   host_stream_->encodeData(1024, true);
-  host2_stream_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+  host2_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
   host2_stream_->encodeData(1024, true);
 
   // Receive updates until the one we expect arrives
@@ -632,7 +632,7 @@ TEST_P(HdsIntegrationTest, TestUpdateMessage) {
   healthcheckEndpoints();
 
   // Endpoint responds to the health check
-  host_stream_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+  host_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
   host_stream_->encodeData(1024, true);
 
   // Receive updates until the one we expect arrives
@@ -678,7 +678,7 @@ TEST_P(HdsIntegrationTest, TestUpdateMessage) {
   ASSERT_TRUE(host2_stream_->waitForEndStream(*dispatcher_));
 
   // Endpoint responds to the health check
-  host2_stream_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "404"}}, false);
+  host2_stream_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "404"}}, false);
   host2_stream_->encodeData(1024, true);
 
   // Receive updates until the one we expect arrives

--- a/test/integration/http2_integration_test.h
+++ b/test/integration/http2_integration_test.h
@@ -37,7 +37,7 @@ public:
 
   void createUpstreams() override;
 
-  void sendMultipleRequests(int request_bytes, Http::TestHeaderMapImpl headers,
+  void sendMultipleRequests(int request_bytes, Http::TestRequestHeaderMapImpl headers,
                             std::function<void(IntegrationStreamDecoder&)> cb);
 
   std::vector<FakeHttpConnectionPtr> fake_upstream_connections_;

--- a/test/integration/http2_upstream_integration_test.cc
+++ b/test/integration/http2_upstream_integration_test.cc
@@ -64,10 +64,10 @@ void Http2UpstreamIntegrationTest::bidirectionalStreaming(uint32_t bytes) {
 
   // Start the request.
   auto encoder_decoder =
-      codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                          {":path", "/test/long/url"},
-                                                          {":scheme", "http"},
-                                                          {":authority", "host"}});
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                                 {":path", "/test/long/url"},
+                                                                 {":scheme", "http"},
+                                                                 {":authority", "host"}});
   auto response = std::move(encoder_decoder.second);
   request_encoder_ = &encoder_decoder.first;
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
@@ -78,12 +78,13 @@ void Http2UpstreamIntegrationTest::bidirectionalStreaming(uint32_t bytes) {
   ASSERT_TRUE(upstream_request_->waitForData(*dispatcher_, bytes));
 
   // Start sending the response and ensure it is received downstream.
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
   upstream_request_->encodeData(bytes, false);
   response->waitForBodyData(bytes);
 
   // Finish the request.
-  codec_client_->sendTrailers(*request_encoder_, Http::TestHeaderMapImpl{{"trailer", "foo"}});
+  codec_client_->sendTrailers(*request_encoder_,
+                              Http::TestRequestTrailerMapImpl{{"trailer", "foo"}});
   ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
 
   // Finish the response.
@@ -105,10 +106,10 @@ TEST_P(Http2UpstreamIntegrationTest, BidirectionalStreamingReset) {
 
   // Start sending the request.
   auto encoder_decoder =
-      codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                          {":path", "/test/long/url"},
-                                                          {":scheme", "http"},
-                                                          {":authority", "host"}});
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                                 {":path", "/test/long/url"},
+                                                                 {":scheme", "http"},
+                                                                 {":authority", "host"}});
   auto response = std::move(encoder_decoder.second);
   request_encoder_ = &encoder_decoder.first;
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
@@ -119,12 +120,13 @@ TEST_P(Http2UpstreamIntegrationTest, BidirectionalStreamingReset) {
   ASSERT_TRUE(upstream_request_->waitForData(*dispatcher_, 1024));
 
   // Start sending the response.
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
   upstream_request_->encodeData(1024, false);
   response->waitForBodyData(1024);
 
   // Finish sending the request.
-  codec_client_->sendTrailers(*request_encoder_, Http::TestHeaderMapImpl{{"trailer", "foo"}});
+  codec_client_->sendTrailers(*request_encoder_,
+                              Http::TestRequestTrailerMapImpl{{"trailer", "foo"}});
   ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
 
   // Reset the stream.
@@ -144,10 +146,10 @@ void Http2UpstreamIntegrationTest::simultaneousRequest(uint32_t request1_bytes,
 
   // Start request 1
   auto encoder_decoder1 =
-      codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                          {":path", "/test/long/url"},
-                                                          {":scheme", "http"},
-                                                          {":authority", "host"}});
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                                 {":path", "/test/long/url"},
+                                                                 {":scheme", "http"},
+                                                                 {":authority", "host"}});
   Http::RequestEncoder* encoder1 = &encoder_decoder1.first;
   auto response1 = std::move(encoder_decoder1.second);
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
@@ -155,10 +157,10 @@ void Http2UpstreamIntegrationTest::simultaneousRequest(uint32_t request1_bytes,
 
   // Start request 2
   auto encoder_decoder2 =
-      codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                          {":path", "/test/long/url"},
-                                                          {":scheme", "http"},
-                                                          {":authority", "host"}});
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                                 {":path", "/test/long/url"},
+                                                                 {":scheme", "http"},
+                                                                 {":authority", "host"}});
   Http::RequestEncoder* encoder2 = &encoder_decoder2.first;
   auto response2 = std::move(encoder_decoder2.second);
   ASSERT_TRUE(fake_upstream_connection_->waitForNewStream(*dispatcher_, upstream_request2));
@@ -172,7 +174,7 @@ void Http2UpstreamIntegrationTest::simultaneousRequest(uint32_t request1_bytes,
   ASSERT_TRUE(upstream_request2->waitForEndStream(*dispatcher_));
 
   // Respond to request 2
-  upstream_request2->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request2->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
   upstream_request2->encodeData(response2_bytes, true);
   response2->waitForEndStream();
   EXPECT_TRUE(upstream_request2->complete());
@@ -182,7 +184,7 @@ void Http2UpstreamIntegrationTest::simultaneousRequest(uint32_t request1_bytes,
   EXPECT_EQ(response2_bytes, response2->body().size());
 
   // Respond to request 1
-  upstream_request1->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request1->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
   upstream_request1->encodeData(response1_bytes, true);
   response1->waitForEndStream();
   EXPECT_TRUE(upstream_request1->complete());
@@ -213,7 +215,7 @@ void Http2UpstreamIntegrationTest::manySimultaneousRequests(uint32_t request_byt
   codec_client_ = makeHttpConnection(lookupPort("http"));
   for (uint32_t i = 0; i < num_requests; ++i) {
     response_bytes.push_back(rand.random() % (1024 * 2));
-    auto headers = Http::TestHeaderMapImpl{
+    auto headers = Http::TestRequestHeaderMapImpl{
         {":method", "POST"},
         {":path", "/test/long/url"},
         {":scheme", "http"},
@@ -271,10 +273,10 @@ TEST_P(Http2UpstreamIntegrationTest, UpstreamConnectionCloseWithManyStreams) {
   codec_client_ = makeHttpConnection(lookupPort("http"));
   for (uint32_t i = 0; i < num_requests; ++i) {
     auto encoder_decoder =
-        codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                            {":path", "/test/long/url"},
-                                                            {":scheme", "http"},
-                                                            {":authority", "host"}});
+        codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                                   {":path", "/test/long/url"},
+                                                                   {":scheme", "http"},
+                                                                   {":authority", "host"}});
     encoders.push_back(&encoder_decoder.first);
     responses.push_back(std::move(encoder_decoder.second));
 
@@ -305,7 +307,7 @@ TEST_P(Http2UpstreamIntegrationTest, UpstreamConnectionCloseWithManyStreams) {
   }
   for (uint32_t i = 1; i < num_requests; ++i) {
     ASSERT_TRUE(upstream_requests[i]->waitForEndStream(*dispatcher_));
-    upstream_requests[i]->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+    upstream_requests[i]->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
     upstream_requests[i]->encodeData(100, false);
   }
   // Close the connection.
@@ -330,7 +332,7 @@ name: envoy.router
 typed_config:
   "@type": type.googleapis.com/envoy.config.filter.http.router.v2.Router
   upstream_log:
-    name: envoy.access_loggers.file
+    name: accesslog
     filter:
       not_health_check_filter: {}
     typed_config:
@@ -351,11 +353,11 @@ typed_config:
   // Send the request.
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto encoder_decoder =
-      codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                          {":path", "/test/long/url"},
-                                                          {":scheme", "http"},
-                                                          {":authority", "host"},
-                                                          {"te", "trailers"}});
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                                 {":path", "/test/long/url"},
+                                                                 {":scheme", "http"},
+                                                                 {":authority", "host"},
+                                                                 {"te", "trailers"}});
   auto downstream_request = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
   Buffer::OwnedImpl data(R"({"TableName":"locations"})");
@@ -406,7 +408,7 @@ TEST_P(Http2UpstreamIntegrationTest, ManyResponseHeadersAccepted) {
     auto* http_protocol_options = cluster->mutable_common_http_protocol_options();
     http_protocol_options->mutable_max_headers_count()->set_value(200);
   });
-  Http::TestHeaderMapImpl response_headers(default_response_headers_);
+  Http::TestResponseHeaderMapImpl response_headers(default_response_headers_);
   for (int i = 0; i < 150; i++) {
     response_headers.addCopy(std::to_string(i), std::string(1, 'a'));
   }
@@ -455,7 +457,7 @@ name: envoy.router
 typed_config:
   "@type": type.googleapis.com/envoy.config.filter.http.router.v2.Router
   upstream_log:
-    name: envoy.access_loggers.http_grpc
+    name: grpc_accesslog
     filter:
       not_health_check_filter: {}
     typed_config:

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -75,7 +75,7 @@ void IntegrationCodecClient::flushWrite() {
 }
 
 IntegrationStreamDecoderPtr
-IntegrationCodecClient::makeHeaderOnlyRequest(const Http::HeaderMap& headers) {
+IntegrationCodecClient::makeHeaderOnlyRequest(const Http::RequestHeaderMap& headers) {
   auto response = std::make_unique<IntegrationStreamDecoder>(dispatcher_);
   Http::RequestEncoder& encoder = newStream(*response);
   encoder.getStream().addCallbacks(*response);
@@ -85,12 +85,13 @@ IntegrationCodecClient::makeHeaderOnlyRequest(const Http::HeaderMap& headers) {
 }
 
 IntegrationStreamDecoderPtr
-IntegrationCodecClient::makeRequestWithBody(const Http::HeaderMap& headers, uint64_t body_size) {
+IntegrationCodecClient::makeRequestWithBody(const Http::RequestHeaderMap& headers,
+                                            uint64_t body_size) {
   return makeRequestWithBody(headers, std::string(body_size, 'a'));
 }
 
 IntegrationStreamDecoderPtr
-IntegrationCodecClient::makeRequestWithBody(const Http::HeaderMap& headers,
+IntegrationCodecClient::makeRequestWithBody(const Http::RequestHeaderMap& headers,
                                             const std::string& body) {
   auto response = std::make_unique<IntegrationStreamDecoder>(dispatcher_);
   Http::RequestEncoder& encoder = newStream(*response);
@@ -122,7 +123,7 @@ void IntegrationCodecClient::sendData(Http::RequestEncoder& encoder, uint64_t si
 }
 
 void IntegrationCodecClient::sendTrailers(Http::RequestEncoder& encoder,
-                                          const Http::HeaderMap& trailers) {
+                                          const Http::RequestTrailerMap& trailers) {
   encoder.encodeTrailers(trailers);
   flushWrite();
 }
@@ -142,7 +143,7 @@ void IntegrationCodecClient::sendMetadata(Http::RequestEncoder& encoder,
 }
 
 std::pair<Http::RequestEncoder&, IntegrationStreamDecoderPtr>
-IntegrationCodecClient::startRequest(const Http::HeaderMap& headers) {
+IntegrationCodecClient::startRequest(const Http::RequestHeaderMap& headers) {
   auto response = std::make_unique<IntegrationStreamDecoder>(dispatcher_);
   Http::RequestEncoder& encoder = newStream(*response);
   encoder.getStream().addCallbacks(*response);
@@ -289,9 +290,9 @@ ConfigHelper::ConfigModifierFunction HttpIntegrationTest::setEnableUpstreamTrail
 }
 
 IntegrationStreamDecoderPtr HttpIntegrationTest::sendRequestAndWaitForResponse(
-    const Http::TestHeaderMapImpl& request_headers, uint32_t request_body_size,
-    const Http::TestHeaderMapImpl& response_headers, uint32_t response_size, int upstream_index,
-    std::chrono::milliseconds time) {
+    const Http::TestRequestHeaderMapImpl& request_headers, uint32_t request_body_size,
+    const Http::TestResponseHeaderMapImpl& response_headers, uint32_t response_size,
+    int upstream_index, std::chrono::milliseconds time) {
   ASSERT(codec_client_ != nullptr);
   // Send the request to Envoy.
   IntegrationStreamDecoderPtr response;
@@ -415,7 +416,7 @@ void HttpIntegrationTest::testRouterRequestAndResponseWithBody(
   initialize();
   codec_client_ = makeHttpConnection(
       create_connection ? ((*create_connection)()) : makeClientConnection((lookupPort("http"))));
-  Http::TestHeaderMapImpl request_headers{
+  Http::TestRequestHeaderMapImpl request_headers{
       {":method", "POST"},    {":path", "/test/long/url"}, {":scheme", "http"},
       {":authority", "host"}, {"x-lyft-user-id", "123"},   {"x-forwarded-for", "10.0.0.1"}};
   if (big_header) {
@@ -437,11 +438,11 @@ HttpIntegrationTest::makeHeaderOnlyRequest(ConnectionCreationFunction* create_co
   }
   codec_client_ = makeHttpConnection(
       create_connection ? ((*create_connection)()) : makeClientConnection((lookupPort("http"))));
-  Http::TestHeaderMapImpl request_headers{{":method", "GET"},
-                                          {":path", path},
-                                          {":scheme", "http"},
-                                          {":authority", authority},
-                                          {"x-lyft-user-id", "123"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", path},
+                                                 {":scheme", "http"},
+                                                 {":authority", authority},
+                                                 {"x-lyft-user-id", "123"}};
   return sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0,
                                        upstream_index);
 }
@@ -631,16 +632,16 @@ void HttpIntegrationTest::testRouterUpstreamResponseBeforeRequestComplete() {
 void HttpIntegrationTest::testRetry() {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto response =
-      codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                                 {":path", "/test/long/url"},
-                                                                 {":scheme", "http"},
-                                                                 {":authority", "host"},
-                                                                 {"x-forwarded-for", "10.0.0.1"},
-                                                                 {"x-envoy-retry-on", "5xx"}},
-                                         1024);
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"x-forwarded-for", "10.0.0.1"},
+                                     {"x-envoy-retry-on", "5xx"}},
+      1024);
   waitForNextUpstreamRequest();
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, false);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "503"}}, false);
 
   if (fake_upstreams_[0]->httpType() == FakeHttpConnection::Type::HTTP1) {
     ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
@@ -670,16 +671,16 @@ void HttpIntegrationTest::testRetryAttemptCountHeader() {
 
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto response =
-      codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                                 {":path", "/test_retry"},
-                                                                 {":scheme", "http"},
-                                                                 {":authority", "host"},
-                                                                 {"x-forwarded-for", "10.0.0.1"},
-                                                                 {"x-envoy-retry-on", "5xx"}},
-                                         1024);
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/test_retry"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"x-forwarded-for", "10.0.0.1"},
+                                     {"x-envoy-retry-on", "5xx"}},
+      1024);
   waitForNextUpstreamRequest();
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, false);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "503"}}, false);
 
   EXPECT_EQ(
       atoi(std::string(upstream_request_->headers().EnvoyAttemptCount()->value().getStringView())
@@ -710,22 +711,23 @@ void HttpIntegrationTest::testRetryAttemptCountHeader() {
 }
 
 void HttpIntegrationTest::testGrpcRetry() {
-  Http::TestHeaderMapImpl response_trailers{{"response1", "trailer1"}, {"grpc-status", "0"}};
+  Http::TestResponseTrailerMapImpl response_trailers{{"response1", "trailer1"},
+                                                     {"grpc-status", "0"}};
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto encoder_decoder =
-      codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                          {":path", "/test/long/url"},
-                                                          {":scheme", "http"},
-                                                          {":authority", "host"},
-                                                          {"x-forwarded-for", "10.0.0.1"},
-                                                          {"x-envoy-retry-grpc-on", "cancelled"}});
+  auto encoder_decoder = codec_client_->startRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"x-forwarded-for", "10.0.0.1"},
+                                     {"x-envoy-retry-grpc-on", "cancelled"}});
   request_encoder_ = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
   codec_client_->sendData(*request_encoder_, 1024, true);
   waitForNextUpstreamRequest();
   upstream_request_->encodeHeaders(
-      Http::TestHeaderMapImpl{{":status", "200"}, {"grpc-status", "1"}}, false);
+      Http::TestResponseHeaderMapImpl{{":status", "200"}, {"grpc-status", "1"}}, false);
   if (fake_upstreams_[0]->httpType() == FakeHttpConnection::Type::HTTP1) {
     ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
     ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
@@ -759,11 +761,11 @@ void HttpIntegrationTest::testEnvoyHandling100Continue(bool additional_continue_
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   auto encoder_decoder =
-      codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                          {":path", "/dynamo/url"},
-                                                          {":scheme", "http"},
-                                                          {":authority", "host"},
-                                                          {"expect", "100-continue"}});
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                                 {":path", "/dynamo/url"},
+                                                                 {":scheme", "http"},
+                                                                 {":authority", "host"},
+                                                                 {"expect", "100-continue"}});
   request_encoder_ = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
   ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
@@ -786,7 +788,8 @@ void HttpIntegrationTest::testEnvoyHandling100Continue(bool additional_continue_
   if (additional_continue_from_upstream) {
     // Make sure if upstream sends an 100-Continue Envoy doesn't send its own and proxy the one
     // from upstream!
-    upstream_request_->encode100ContinueHeaders(Http::TestHeaderMapImpl{{":status", "100"}});
+    upstream_request_->encode100ContinueHeaders(
+        Http::TestResponseHeaderMapImpl{{":status", "100"}});
   }
   upstream_request_->encodeHeaders(default_response_headers_, false);
   upstream_request_->encodeData(12, true);
@@ -829,11 +832,11 @@ void HttpIntegrationTest::testEnvoyProxying100Continue(bool continue_before_upst
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto encoder_decoder =
-      codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "GET"},
-                                                          {":path", "/dynamo/url"},
-                                                          {":scheme", "http"},
-                                                          {":authority", "host"},
-                                                          {"expect", "100-continue"}});
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                                                 {":path", "/dynamo/url"},
+                                                                 {":scheme", "http"},
+                                                                 {":authority", "host"},
+                                                                 {"expect", "100-continue"}});
   request_encoder_ = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
 
@@ -844,7 +847,8 @@ void HttpIntegrationTest::testEnvoyProxying100Continue(bool continue_before_upst
   if (continue_before_upstream_complete) {
     // This case tests sending on 100-Continue headers before the client has sent all the
     // request data.
-    upstream_request_->encode100ContinueHeaders(Http::TestHeaderMapImpl{{":status", "100"}});
+    upstream_request_->encode100ContinueHeaders(
+        Http::TestResponseHeaderMapImpl{{":status", "100"}});
     response->waitForContinueHeaders();
   }
   // Send all of the request data and wait for it to be received upstream.
@@ -853,7 +857,8 @@ void HttpIntegrationTest::testEnvoyProxying100Continue(bool continue_before_upst
 
   if (!continue_before_upstream_complete) {
     // This case tests forwarding 100-Continue after the client has sent all data.
-    upstream_request_->encode100ContinueHeaders(Http::TestHeaderMapImpl{{":status", "100"}});
+    upstream_request_->encode100ContinueHeaders(
+        Http::TestResponseHeaderMapImpl{{":status", "100"}});
     response->waitForContinueHeaders();
   }
   // Now send the rest of the response.
@@ -930,7 +935,7 @@ void HttpIntegrationTest::testLargeRequestHeaders(uint32_t size, uint32_t count,
   max_request_headers_kb_ = max_size;
   max_request_headers_count_ = max_count;
 
-  Http::TestHeaderMapImpl big_headers{
+  Http::TestRequestHeaderMapImpl big_headers{
       {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
 
   // Already added four headers.
@@ -969,7 +974,7 @@ void HttpIntegrationTest::testLargeRequestTrailers(uint32_t size, uint32_t max_s
       [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
               hcm) -> void { hcm.mutable_max_request_headers_kb()->set_value(max_size); });
   max_request_headers_kb_ = max_size;
-  Http::TestHeaderMapImpl request_trailers{{"trailer", "trailer"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"trailer", "trailer"}};
   request_trailers.addCopy("big", std::string(size * 1024, 'a'));
 
   initialize();
@@ -1017,10 +1022,8 @@ void HttpIntegrationTest::testManyRequestHeaders(std::chrono::milliseconds time)
             max_request_headers_count_);
       });
 
-  Http::HeaderMapImpl big_headers{{Http::Headers::get().Method, "GET"},
-                                  {Http::Headers::get().Path, "/test/long/url"},
-                                  {Http::Headers::get().Scheme, "http"},
-                                  {Http::Headers::get().Host, "host"}};
+  Http::TestRequestHeaderMapImpl big_headers{
+      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
 
   for (int i = 0; i < 20000; i++) {
     big_headers.addCopy(Http::LowerCaseString(std::to_string(i)), std::string(0, 'a'));
@@ -1041,12 +1044,12 @@ void HttpIntegrationTest::testDownstreamResetBeforeResponseComplete() {
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   auto encoder_decoder =
-      codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "GET"},
-                                                          {":path", "/test/long/url"},
-                                                          {":scheme", "http"},
-                                                          {":authority", "host"},
-                                                          {"cookie", "a=b"},
-                                                          {"cookie", "c=d"}});
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                                                 {":path", "/test/long/url"},
+                                                                 {":scheme", "http"},
+                                                                 {":authority", "host"},
+                                                                 {"cookie", "a=b"},
+                                                                 {"cookie", "c=d"}});
   request_encoder_ = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
   codec_client_->sendData(*request_encoder_, 0, true);
@@ -1080,16 +1083,18 @@ void HttpIntegrationTest::testDownstreamResetBeforeResponseComplete() {
 
 void HttpIntegrationTest::testTrailers(uint64_t request_size, uint64_t response_size,
                                        bool check_request, bool check_response) {
-  Http::TestHeaderMapImpl request_trailers{{"request1", "trailer1"}, {"request2", "trailer2"}};
-  Http::TestHeaderMapImpl response_trailers{{"response1", "trailer1"}, {"response2", "trailer2"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"request1", "trailer1"},
+                                                   {"request2", "trailer2"}};
+  Http::TestResponseTrailerMapImpl response_trailers{{"response1", "trailer1"},
+                                                     {"response2", "trailer2"}};
 
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto encoder_decoder =
-      codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                          {":path", "/test/long/url"},
-                                                          {":scheme", "http"},
-                                                          {":authority", "host"}});
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                                 {":path", "/test/long/url"},
+                                                                 {":scheme", "http"},
+                                                                 {":authority", "host"}});
   request_encoder_ = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
   codec_client_->sendData(*request_encoder_, request_size, false);

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -22,22 +22,22 @@ public:
                          Upstream::HostDescriptionConstSharedPtr host_description,
                          Http::CodecClient::Type type);
 
-  IntegrationStreamDecoderPtr makeHeaderOnlyRequest(const Http::HeaderMap& headers);
-  IntegrationStreamDecoderPtr makeRequestWithBody(const Http::HeaderMap& headers,
+  IntegrationStreamDecoderPtr makeHeaderOnlyRequest(const Http::RequestHeaderMap& headers);
+  IntegrationStreamDecoderPtr makeRequestWithBody(const Http::RequestHeaderMap& headers,
                                                   uint64_t body_size);
-  IntegrationStreamDecoderPtr makeRequestWithBody(const Http::HeaderMap& headers,
+  IntegrationStreamDecoderPtr makeRequestWithBody(const Http::RequestHeaderMap& headers,
                                                   const std::string& body);
   bool sawGoAway() const { return saw_goaway_; }
   bool connected() const { return connected_; }
   void sendData(Http::RequestEncoder& encoder, absl::string_view data, bool end_stream);
   void sendData(Http::RequestEncoder& encoder, Buffer::Instance& data, bool end_stream);
   void sendData(Http::RequestEncoder& encoder, uint64_t size, bool end_stream);
-  void sendTrailers(Http::RequestEncoder& encoder, const Http::HeaderMap& trailers);
+  void sendTrailers(Http::RequestEncoder& encoder, const Http::RequestTrailerMap& trailers);
   void sendReset(Http::RequestEncoder& encoder);
   // Intentionally makes a copy of metadata_map.
   void sendMetadata(Http::RequestEncoder& encoder, Http::MetadataMap metadata_map);
   std::pair<Http::RequestEncoder&, IntegrationStreamDecoderPtr>
-  startRequest(const Http::HeaderMap& headers);
+  startRequest(const Http::RequestHeaderMap& headers);
   bool waitForDisconnect(std::chrono::milliseconds time_to_wait = std::chrono::milliseconds(0));
   Network::ClientConnection* connection() const { return connection_.get(); }
   Network::ConnectionEvent last_connection_event() const { return last_connection_event_; }
@@ -129,8 +129,8 @@ protected:
   // Waits for the complete downstream response before returning.
   // Requires |codec_client_| to be initialized.
   IntegrationStreamDecoderPtr sendRequestAndWaitForResponse(
-      const Http::TestHeaderMapImpl& request_headers, uint32_t request_body_size,
-      const Http::TestHeaderMapImpl& response_headers, uint32_t response_body_size,
+      const Http::TestRequestHeaderMapImpl& request_headers, uint32_t request_body_size,
+      const Http::TestResponseHeaderMapImpl& response_headers, uint32_t response_body_size,
       int upstream_index = 0, std::chrono::milliseconds time = TestUtility::DefaultTimeout);
 
   // Wait for the end of stream on the next upstream stream on any of the provided fake upstreams.
@@ -194,8 +194,9 @@ protected:
   void testRouterUpstreamResponseBeforeRequestComplete();
 
   void testTwoRequests(bool force_network_backup = false);
-  void testLargeHeaders(Http::TestHeaderMapImpl request_headers,
-                        Http::TestHeaderMapImpl request_trailers, uint32_t size, uint32_t max_size);
+  void testLargeHeaders(Http::TestRequestHeaderMapImpl request_headers,
+                        Http::TestRequestTrailerMapImpl request_trailers, uint32_t size,
+                        uint32_t max_size);
   void testLargeRequestHeaders(uint32_t size, uint32_t count, uint32_t max_size = 60,
                                uint32_t max_count = 100);
   void testLargeRequestTrailers(uint32_t size, uint32_t max_size = 60);
@@ -233,8 +234,8 @@ protected:
   // A pointer to the request encoder, if used.
   Http::RequestEncoder* request_encoder_{nullptr};
   // The response headers sent by sendRequestAndWaitForResponse() by default.
-  Http::TestHeaderMapImpl default_response_headers_{{":status", "200"}};
-  Http::TestHeaderMapImpl default_request_headers_{
+  Http::TestResponseHeaderMapImpl default_response_headers_{{":status", "200"}};
+  Http::TestRequestHeaderMapImpl default_request_headers_{
       {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
   // The codec type for the client-to-Envoy connection
   Http::CodecClient::Type downstream_protocol_{Http::CodecClient::Type::HTTP1};

--- a/test/integration/http_subset_lb_integration_test.cc
+++ b/test/integration/http_subset_lb_integration_test.cc
@@ -145,13 +145,13 @@ public:
   // the given type ("a" or "b"). If is_hash_lb_, verifies that a single host is selected over n
   // iterations (e.g. for maglev/hash-ring policies). Otherwise, expected more than one host to be
   // selected over at least n iterations and at most m.
-  void runTest(Http::TestHeaderMapImpl& request_headers, const std::string expected_host_type,
-               const int n = 100, const int m = 1000) {
+  void runTest(Http::TestRequestHeaderMapImpl& request_headers,
+               const std::string expected_host_type, const int n = 100, const int m = 1000) {
     ASSERT_LT(n, m);
 
     std::set<std::string> hosts;
     for (int i = 0; i < m; i++) {
-      Http::TestHeaderMapImpl response_headers{{":status", "200"}};
+      Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
 
       // Send header only request.
       IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(request_headers);
@@ -195,12 +195,12 @@ public:
   const std::string type_header_{"x-type"};
   const std::string type_key_{"type"};
 
-  Http::TestHeaderMapImpl type_a_request_headers_{{":method", "GET"},  {":path", "/test"},
-                                                  {":scheme", "http"}, {":authority", "host"},
-                                                  {"x-type", "a"},     {"x-hash", "hash-a"}};
-  Http::TestHeaderMapImpl type_b_request_headers_{{":method", "GET"},  {":path", "/test"},
-                                                  {":scheme", "http"}, {":authority", "host"},
-                                                  {"x-type", "b"},     {"x-hash", "hash-b"}};
+  Http::TestRequestHeaderMapImpl type_a_request_headers_{
+      {":method", "GET"},     {":path", "/test"}, {":scheme", "http"},
+      {":authority", "host"}, {"x-type", "a"},    {"x-hash", "hash-a"}};
+  Http::TestRequestHeaderMapImpl type_b_request_headers_{
+      {":method", "GET"},     {":path", "/test"}, {":scheme", "http"},
+      {":authority", "host"}, {"x-type", "b"},    {"x-hash", "hash-b"}};
 };
 
 INSTANTIATE_TEST_SUITE_P(SubsetCompatibleLoadBalancers, HttpSubsetLbIntegrationTest,

--- a/test/integration/http_timeout_integration_test.cc
+++ b/test/integration/http_timeout_integration_test.cc
@@ -15,12 +15,12 @@ TEST_P(HttpTimeoutIntegrationTest, GlobalTimeout) {
 
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
   auto encoder_decoder = codec_client_->startRequest(
-      Http::TestHeaderMapImpl{{":method", "POST"},
-                              {":path", "/test/long/url"},
-                              {":scheme", "http"},
-                              {":authority", "host"},
-                              {"x-forwarded-for", "10.0.0.1"},
-                              {"x-envoy-upstream-rq-timeout-ms", "500"}});
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"x-forwarded-for", "10.0.0.1"},
+                                     {"x-envoy-upstream-rq-timeout-ms", "500"}});
   auto response = std::move(encoder_decoder.second);
   request_encoder_ = &encoder_decoder.first;
 
@@ -55,13 +55,13 @@ TEST_P(HttpTimeoutIntegrationTest, UseTimeoutSetByEgressEnvoy) {
   initialize();
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
   auto encoder_decoder = codec_client_->startRequest(
-      Http::TestHeaderMapImpl{{":method", "POST"},
-                              {":path", "/test/long/url"},
-                              {":scheme", "http"},
-                              {":authority", "host"},
-                              {"x-forwarded-for", "10.0.0.1"},
-                              {"x-envoy-upstream-rq-timeout-ms", "500"},
-                              {"x-envoy-expected-rq-timeout-ms", "300"}});
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"x-forwarded-for", "10.0.0.1"},
+                                     {"x-envoy-upstream-rq-timeout-ms", "500"},
+                                     {"x-envoy-expected-rq-timeout-ms", "300"}});
   auto response = std::move(encoder_decoder.second);
   request_encoder_ = &encoder_decoder.first;
 
@@ -97,12 +97,12 @@ TEST_P(HttpTimeoutIntegrationTest, DeriveTimeoutInIngressEnvoy) {
   initialize();
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
   auto encoder_decoder = codec_client_->startRequest(
-      Http::TestHeaderMapImpl{{":method", "POST"},
-                              {":path", "/test/long/url"},
-                              {":scheme", "http"},
-                              {":authority", "host"},
-                              {"x-forwarded-for", "10.0.0.1"},
-                              {"x-envoy-upstream-rq-timeout-ms", "500"}});
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"x-forwarded-for", "10.0.0.1"},
+                                     {"x-envoy-upstream-rq-timeout-ms", "500"}});
   auto response = std::move(encoder_decoder.second);
   request_encoder_ = &encoder_decoder.first;
 
@@ -138,13 +138,13 @@ TEST_P(HttpTimeoutIntegrationTest, IgnoreTimeoutSetByEgressEnvoy) {
 
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
   auto encoder_decoder = codec_client_->startRequest(
-      Http::TestHeaderMapImpl{{":method", "POST"},
-                              {":path", "/test/long/url"},
-                              {":scheme", "http"},
-                              {":authority", "host"},
-                              {"x-forwarded-for", "10.0.0.1"},
-                              {"x-envoy-upstream-rq-timeout-ms", "500"},
-                              {"x-envoy-expected-rq-timeout-ms", "600"}});
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"x-forwarded-for", "10.0.0.1"},
+                                     {"x-envoy-upstream-rq-timeout-ms", "500"},
+                                     {"x-envoy-expected-rq-timeout-ms", "600"}});
   auto response = std::move(encoder_decoder.second);
   request_encoder_ = &encoder_decoder.first;
 
@@ -179,12 +179,12 @@ TEST_P(HttpTimeoutIntegrationTest, GlobalTimeoutAfterHeadersBeforeBodyResetsUpst
   initialize();
 
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
-  Http::TestHeaderMapImpl request_headers{{":method", "POST"},
-                                          {":path", "/test/long/url"},
-                                          {":scheme", "http"},
-                                          {":authority", "host"},
-                                          {"x-forwarded-for", "10.0.0.1"},
-                                          {"x-envoy-upstream-rq-timeout-ms", "100"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "POST"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"x-forwarded-for", "10.0.0.1"},
+                                                 {"x-envoy-upstream-rq-timeout-ms", "100"}};
   auto encoder_decoder = codec_client_->startRequest(request_headers);
   auto response = std::move(encoder_decoder.second);
   request_encoder_ = &encoder_decoder.first;
@@ -198,7 +198,7 @@ TEST_P(HttpTimeoutIntegrationTest, GlobalTimeoutAfterHeadersBeforeBodyResetsUpst
   ASSERT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
 
   // Respond with headers, not end of stream.
-  Http::TestHeaderMapImpl response_headers{{":status", "200"}};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   upstream_request_->encodeHeaders(response_headers, false);
 
   response->waitForHeaders();
@@ -225,14 +225,14 @@ TEST_P(HttpTimeoutIntegrationTest, PerTryTimeout) {
 
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
   auto encoder_decoder = codec_client_->startRequest(
-      Http::TestHeaderMapImpl{{":method", "POST"},
-                              {":path", "/test/long/url"},
-                              {":scheme", "http"},
-                              {":authority", "host"},
-                              {"x-forwarded-for", "10.0.0.1"},
-                              {"x-envoy-retry-on", "5xx"},
-                              {"x-envoy-upstream-rq-timeout-ms", "500"},
-                              {"x-envoy-upstream-rq-per-try-timeout-ms", "400"}});
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"x-forwarded-for", "10.0.0.1"},
+                                     {"x-envoy-retry-on", "5xx"},
+                                     {"x-envoy-upstream-rq-timeout-ms", "500"},
+                                     {"x-envoy-upstream-rq-per-try-timeout-ms", "400"}});
   auto response = std::move(encoder_decoder.second);
   request_encoder_ = &encoder_decoder.first;
 
@@ -274,15 +274,15 @@ TEST_P(HttpTimeoutIntegrationTest, HedgedPerTryTimeout) {
 
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
   auto encoder_decoder = codec_client_->startRequest(
-      Http::TestHeaderMapImpl{{":method", "POST"},
-                              {":path", "/test/long/url"},
-                              {":scheme", "http"},
-                              {":authority", "host"},
-                              {"x-forwarded-for", "10.0.0.1"},
-                              {"x-envoy-retry-on", "5xx"},
-                              {"x-envoy-hedge-on-per-try-timeout", "true"},
-                              {"x-envoy-upstream-rq-timeout-ms", "500"},
-                              {"x-envoy-upstream-rq-per-try-timeout-ms", "400"}});
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"x-forwarded-for", "10.0.0.1"},
+                                     {"x-envoy-retry-on", "5xx"},
+                                     {"x-envoy-hedge-on-per-try-timeout", "true"},
+                                     {"x-envoy-upstream-rq-timeout-ms", "500"},
+                                     {"x-envoy-upstream-rq-per-try-timeout-ms", "400"}});
   auto response = std::move(encoder_decoder.second);
   request_encoder_ = &encoder_decoder.first;
 
@@ -306,7 +306,7 @@ TEST_P(HttpTimeoutIntegrationTest, HedgedPerTryTimeout) {
   ASSERT_TRUE(upstream_request2->waitForEndStream(*dispatcher_));
 
   // Encode 200 response headers for the first (timed out) request.
-  Http::TestHeaderMapImpl response_headers{{":status", "200"}};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   upstream_request_->encodeHeaders(response_headers, true);
 
   response->waitForHeaders();
@@ -368,15 +368,15 @@ void HttpTimeoutIntegrationTest::testRouterRequestAndResponseWithHedgedPerTryTim
   initialize();
 
   codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
-  Http::TestHeaderMapImpl request_headers{{":method", "POST"},
-                                          {":path", "/test/long/url"},
-                                          {":scheme", "http"},
-                                          {":authority", "host"},
-                                          {"x-forwarded-for", "10.0.0.1"},
-                                          {"x-envoy-retry-on", "5xx"},
-                                          {"x-envoy-hedge-on-per-try-timeout", "true"},
-                                          {"x-envoy-upstream-rq-timeout-ms", "5000"},
-                                          {"x-envoy-upstream-rq-per-try-timeout-ms", "400"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "POST"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"x-forwarded-for", "10.0.0.1"},
+                                                 {"x-envoy-retry-on", "5xx"},
+                                                 {"x-envoy-hedge-on-per-try-timeout", "true"},
+                                                 {"x-envoy-upstream-rq-timeout-ms", "5000"},
+                                                 {"x-envoy-upstream-rq-per-try-timeout-ms", "400"}};
   auto encoder_decoder = codec_client_->startRequest(request_headers);
 
   auto response = std::move(encoder_decoder.second);
@@ -402,7 +402,7 @@ void HttpTimeoutIntegrationTest::testRouterRequestAndResponseWithHedgedPerTryTim
   ASSERT_TRUE(upstream_request2->waitForHeadersComplete());
   ASSERT_TRUE(upstream_request2->waitForEndStream(*dispatcher_));
 
-  Http::TestHeaderMapImpl response_headers{{":status", "200"}};
+  Http::TestResponseHeaderMapImpl response_headers{{":status", "200"}};
   if (first_request_wins) {
     // Encode 200 response headers for the first (timed out) request.
     upstream_request_->encodeHeaders(response_headers, response_size == 0);

--- a/test/integration/idle_timeout_integration_test.cc
+++ b/test/integration/idle_timeout_integration_test.cc
@@ -43,10 +43,10 @@ public:
     fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
     codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
     auto encoder_decoder =
-        codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", method},
-                                                            {":path", "/test/long/url"},
-                                                            {":scheme", "http"},
-                                                            {":authority", "host"}});
+        codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", method},
+                                                                   {":path", "/test/long/url"},
+                                                                   {":scheme", "http"},
+                                                                   {":authority", "host"}});
     request_encoder_ = &encoder_decoder.first;
     auto response = std::move(encoder_decoder.second);
     AssertionResult result =
@@ -234,7 +234,7 @@ TEST_P(IdleTimeoutIntegrationTest, PerStreamIdleTimeoutAfterUpstreamHeaders) {
   enable_per_stream_idle_timeout_ = true;
   auto response = setupPerStreamIdleTimeoutTest();
 
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
 
   waitForTimeout(*response, "downstream_rq_idle_timeout");
 
@@ -251,10 +251,10 @@ TEST_P(IdleTimeoutIntegrationTest, PerStreamIdleTimeoutAfterBidiData) {
   auto response = setupPerStreamIdleTimeoutTest();
 
   sleep();
-  upstream_request_->encode100ContinueHeaders(Http::TestHeaderMapImpl{{":status", "100"}});
+  upstream_request_->encode100ContinueHeaders(Http::TestResponseHeaderMapImpl{{":status", "100"}});
 
   sleep();
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
 
   sleep();
   upstream_request_->encodeData(1, false);
@@ -263,7 +263,8 @@ TEST_P(IdleTimeoutIntegrationTest, PerStreamIdleTimeoutAfterBidiData) {
   codec_client_->sendData(*request_encoder_, 1, false);
 
   sleep();
-  Http::TestHeaderMapImpl request_trailers{{"request1", "trailer1"}, {"request2", "trailer2"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"request1", "trailer1"},
+                                                   {"request2", "trailer2"}};
   codec_client_->sendTrailers(*request_encoder_, request_trailers);
 
   sleep();
@@ -358,7 +359,7 @@ TEST_P(IdleTimeoutIntegrationTest, RequestTimeoutIsDisarmedByPrematureEncodeHead
   enable_per_stream_idle_timeout_ = true;
 
   auto response = setupPerStreamIdleTimeoutTest("POST");
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, false);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, false);
 
   waitForTimeout(*response);
 
@@ -371,7 +372,7 @@ TEST_P(IdleTimeoutIntegrationTest, RequestTimeoutIsNotDisarmedByEncode100Continu
   enable_request_timeout_ = true;
 
   auto response = setupPerStreamIdleTimeoutTest("POST");
-  upstream_request_->encode100ContinueHeaders(Http::TestHeaderMapImpl{{":status", "100"}});
+  upstream_request_->encode100ContinueHeaders(Http::TestResponseHeaderMapImpl{{":status", "100"}});
 
   waitForTimeout(*response, "downstream_rq_timeout");
 

--- a/test/integration/integration.cc
+++ b/test/integration/integration.cc
@@ -94,14 +94,15 @@ void IntegrationStreamDecoder::waitForReset() {
   }
 }
 
-void IntegrationStreamDecoder::decode100ContinueHeaders(Http::HeaderMapPtr&& headers) {
+void IntegrationStreamDecoder::decode100ContinueHeaders(Http::ResponseHeaderMapPtr&& headers) {
   continue_headers_ = std::move(headers);
   if (waiting_for_continue_headers_) {
     dispatcher_.exit();
   }
 }
 
-void IntegrationStreamDecoder::decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
+void IntegrationStreamDecoder::decodeHeaders(Http::ResponseHeaderMapPtr&& headers,
+                                             bool end_stream) {
   saw_end_stream_ = end_stream;
   headers_ = std::move(headers);
   if ((end_stream && waiting_for_end_stream_) || waiting_for_headers_) {
@@ -123,7 +124,7 @@ void IntegrationStreamDecoder::decodeData(Buffer::Instance& data, bool end_strea
   }
 }
 
-void IntegrationStreamDecoder::decodeTrailers(Http::HeaderMapPtr&& trailers) {
+void IntegrationStreamDecoder::decodeTrailers(Http::ResponseTrailerMapPtr&& trailers) {
   saw_end_stream_ = true;
   trailers_ = std::move(trailers);
   if (waiting_for_end_stream_) {
@@ -447,7 +448,7 @@ void BaseIntegrationTest::createGeneratedApiTestServer(const std::string& bootst
     const char* success = "listener_manager.listener_create_success";
     const char* rejected = "listener_manager.lds.update_rejected";
     while ((test_server_->counter(success) == nullptr ||
-            test_server_->counter(success)->value() == 0) &&
+            test_server_->counter(success)->value() < concurrency_) &&
            (!allow_lds_rejection || test_server_->counter(rejected) == nullptr ||
             test_server_->counter(rejected)->value() == 0)) {
       if (time_system_.monotonicTime() >= end_time) {

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -57,11 +57,13 @@ public:
   void clearBody() { body_.clear(); }
 
   // Http::StreamDecoder
-  void decode100ContinueHeaders(Http::HeaderMapPtr&& headers) override;
-  void decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) override;
   void decodeData(Buffer::Instance& data, bool end_stream) override;
-  void decodeTrailers(Http::HeaderMapPtr&& trailers) override;
   void decodeMetadata(Http::MetadataMapPtr&& metadata_map) override;
+
+  // Http::ResponseDecoder
+  void decode100ContinueHeaders(Http::ResponseHeaderMapPtr&& headers) override;
+  void decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bool end_stream) override;
+  void decodeTrailers(Http::ResponseTrailerMapPtr&& trailers) override;
 
   // Http::StreamCallbacks
   void onResetStream(Http::StreamResetReason reason,

--- a/test/integration/load_stats_integration_test.cc
+++ b/test/integration/load_stats_integration_test.cc
@@ -145,9 +145,9 @@ public:
   void initiateClientConnection() {
     auto conn = makeClientConnection(lookupPort("http"));
     codec_client_ = makeHttpConnection(std::move(conn));
-    Http::TestHeaderMapImpl headers{{":method", "POST"},       {":path", "/test/long/url"},
-                                    {":scheme", "http"},       {":authority", "host"},
-                                    {"x-lyft-user-id", "123"}, {"x-forwarded-for", "10.0.0.1"}};
+    Http::TestRequestHeaderMapImpl headers{
+        {":method", "POST"},    {":path", "/test/long/url"}, {":scheme", "http"},
+        {":authority", "host"}, {"x-lyft-user-id", "123"},   {"x-forwarded-for", "10.0.0.1"}};
     response_ = codec_client_->makeRequestWithBody(headers, request_size_);
   }
 
@@ -287,7 +287,7 @@ public:
     RELEASE_ASSERT(result, result.message());
 
     upstream_request_->encodeHeaders(
-        Http::TestHeaderMapImpl{{":status", std::to_string(response_code)}}, false);
+        Http::TestResponseHeaderMapImpl{{":status", std::to_string(response_code)}}, false);
     upstream_request_->encodeData(response_size_, true);
     response_->waitForEndStream();
 

--- a/test/integration/overload_integration_test.cc
+++ b/test/integration/overload_integration_test.cc
@@ -68,7 +68,7 @@ TEST_P(OverloadIntegrationTest, CloseStreamsWhenOverloaded) {
   updateResource(0.9);
   test_server_->waitForGaugeEq("overload.envoy.overload_actions.stop_accepting_requests.active", 1);
 
-  Http::TestHeaderMapImpl request_headers{
+  Http::TestRequestHeaderMapImpl request_headers{
       {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
   auto response = codec_client_->makeRequestWithBody(request_headers, 10);
@@ -115,7 +115,7 @@ TEST_P(OverloadIntegrationTest, DisableKeepaliveWhenOverloaded) {
   test_server_->waitForGaugeEq("overload.envoy.overload_actions.disable_http_keepalive.active", 1);
 
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
-  Http::TestHeaderMapImpl request_headers{
+  Http::TestRequestHeaderMapImpl request_headers{
       {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
   auto response = sendRequestAndWaitForResponse(request_headers, 1, default_response_headers_, 1);
   codec_client_->waitForDisconnect();
@@ -145,7 +145,7 @@ TEST_P(OverloadIntegrationTest, StopAcceptingConnectionsWhenOverloaded) {
   test_server_->waitForGaugeEq("overload.envoy.overload_actions.stop_accepting_connections.active",
                                1);
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
-  Http::TestHeaderMapImpl request_headers{
+  Http::TestRequestHeaderMapImpl request_headers{
       {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
   auto response = codec_client_->makeRequestWithBody(request_headers, 10);
   EXPECT_FALSE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_,

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -55,7 +55,7 @@ void setDoNotValidateRouteConfig(
 // downstream"?
 class DownstreamProtocolIntegrationTest : public HttpProtocolIntegrationTest {
 protected:
-  void changeHeadersForStopAllTests(Http::TestHeaderMapImpl& headers, bool set_buffer_limit) {
+  template <class T> void changeHeadersForStopAllTests(T& headers, bool set_buffer_limit) {
     headers.addCopy("content_size", std::to_string(count_ * size_));
     headers.addCopy("added_size", std::to_string(added_decoded_data_size_));
     headers.addCopy("is_first_trigger", "value");
@@ -166,7 +166,7 @@ typed_config:
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto response = codec_client_->makeHeaderOnlyRequest(Http::TestHeaderMapImpl{
+  auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
       {":method", "GET"}, {":path", "/healthcheck"}, {":scheme", "http"}, {":authority", "host"}});
   response->waitForEndStream();
 
@@ -187,7 +187,7 @@ typed_config:
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto response = codec_client_->makeHeaderOnlyRequest(Http::TestHeaderMapImpl{
+  auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
       {":method", "GET"}, {":path", "/healthcheck"}, {":scheme", "http"}, {":authority", "host"}});
   response->waitForEndStream();
 
@@ -206,7 +206,7 @@ typed_config:
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response = codec_client_->makeRequestWithBody(default_request_headers_, 128);
   waitForNextUpstreamRequest();
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, false);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "503"}}, false);
   upstream_request_->encodeData(128, true);
   response->waitForEndStream();
 
@@ -240,19 +240,38 @@ TEST_P(ProtocolIntegrationTest, DrainClose) {
   test_server_->drainManager().draining_ = false;
 }
 
+// Regression test for https://github.com/envoyproxy/envoy/issues/9873
+TEST_P(ProtocolIntegrationTest, ResponseWithHostHeader) {
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeHeaderOnlyRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"}});
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(
+      Http::TestResponseHeaderMapImpl{{":status", "200"}, {"host", "host"}}, true);
+  response->waitForEndStream();
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  EXPECT_EQ("host",
+            response->headers().get(Http::LowerCaseString("host"))->value().getStringView());
+}
+
 TEST_P(ProtocolIntegrationTest, Retry) {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto response =
-      codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                                 {":path", "/test/long/url"},
-                                                                 {":scheme", "http"},
-                                                                 {":authority", "host"},
-                                                                 {"x-forwarded-for", "10.0.0.1"},
-                                                                 {"x-envoy-retry-on", "5xx"}},
-                                         1024);
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"x-forwarded-for", "10.0.0.1"},
+                                     {"x-envoy-retry-on", "5xx"}},
+      1024);
   waitForNextUpstreamRequest();
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, false);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "503"}}, false);
 
   if (fake_upstreams_[0]->httpType() == FakeHttpConnection::Type::HTTP1) {
     ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
@@ -281,16 +300,16 @@ TEST_P(DownstreamProtocolIntegrationTest, RetryAttemptCountHeader) {
   config_helper_.addVirtualHost(host);
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto response =
-      codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                                 {":path", "/test_retry"},
-                                                                 {":scheme", "http"},
-                                                                 {":authority", "host"},
-                                                                 {"x-forwarded-for", "10.0.0.1"},
-                                                                 {"x-envoy-retry-on", "5xx"}},
-                                         1024);
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/test_retry"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"x-forwarded-for", "10.0.0.1"},
+                                     {"x-envoy-retry-on", "5xx"}},
+      1024);
   waitForNextUpstreamRequest();
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, false);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "503"}}, false);
 
   EXPECT_EQ(
       atoi(std::string(upstream_request_->headers().EnvoyAttemptCount()->value().getStringView())
@@ -357,18 +376,18 @@ TEST_P(DownstreamProtocolIntegrationTest, RetryPriority) {
   fake_upstreams_count_ = 2;
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto response =
-      codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                                 {":path", "/test_retry"},
-                                                                 {":scheme", "http"},
-                                                                 {":authority", "host"},
-                                                                 {"x-forwarded-for", "10.0.0.1"},
-                                                                 {"x-envoy-retry-on", "5xx"}},
-                                         1024);
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/test_retry"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"x-forwarded-for", "10.0.0.1"},
+                                     {"x-envoy-retry-on", "5xx"}},
+      1024);
 
   // Note how we're expecting each upstream request to hit the same upstream.
   waitForNextUpstreamRequest(0);
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, false);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "503"}}, false);
 
   if (fake_upstreams_[0]->httpType() == FakeHttpConnection::Type::HTTP1) {
     ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
@@ -419,19 +438,19 @@ TEST_P(DownstreamProtocolIntegrationTest, RetryHostPredicateFilter) {
   fake_upstreams_count_ = 2;
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto response =
-      codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                                 {":path", "/test_retry"},
-                                                                 {":scheme", "http"},
-                                                                 {":authority", "host"},
-                                                                 {"x-forwarded-for", "10.0.0.1"},
-                                                                 {"x-envoy-retry-on", "5xx"}},
-                                         1024);
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/test_retry"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"x-forwarded-for", "10.0.0.1"},
+                                     {"x-envoy-retry-on", "5xx"}},
+      1024);
 
   // Note how we're expecting each upstream request to hit the same upstream.
   auto upstream_idx = waitForNextUpstreamRequest({0, 1});
   ASSERT_TRUE(upstream_idx.has_value());
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, false);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "503"}}, false);
 
   if (fake_upstreams_[*upstream_idx]->httpType() == FakeHttpConnection::Type::HTTP1) {
     ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
@@ -461,17 +480,17 @@ TEST_P(ProtocolIntegrationTest, RetryHittingBufferLimit) {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  auto response =
-      codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                                 {":path", "/test/long/url"},
-                                                                 {":scheme", "http"},
-                                                                 {":authority", "host"},
-                                                                 {"x-forwarded-for", "10.0.0.1"},
-                                                                 {"x-envoy-retry-on", "5xx"}},
-                                         1024 * 65);
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/test/long/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"x-forwarded-for", "10.0.0.1"},
+                                     {"x-envoy-retry-on", "5xx"}},
+      1024 * 65);
   waitForNextUpstreamRequest();
 
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, true);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "503"}}, true);
 
   response->waitForEndStream();
   EXPECT_TRUE(upstream_request_->complete());
@@ -489,17 +508,17 @@ TEST_P(ProtocolIntegrationTest, RetryHittingRouteLimits) {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  auto response =
-      codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                                 {":path", "/"},
-                                                                 {":scheme", "http"},
-                                                                 {":authority", "nobody.com"},
-                                                                 {"x-forwarded-for", "10.0.0.1"},
-                                                                 {"x-envoy-retry-on", "5xx"}},
-                                         1);
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/"},
+                                     {":scheme", "http"},
+                                     {":authority", "nobody.com"},
+                                     {"x-forwarded-for", "10.0.0.1"},
+                                     {"x-envoy-retry-on", "5xx"}},
+      1);
   waitForNextUpstreamRequest();
 
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, true);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "503"}}, true);
 
   response->waitForEndStream();
   EXPECT_TRUE(upstream_request_->complete());
@@ -522,14 +541,14 @@ TEST_P(DownstreamProtocolIntegrationTest, HittingDecoderFilterLimit) {
   // Envoy will likely connect and proxy some unspecified amount of data before
   // hitting the buffer limit and disconnecting. Ignore this if it happens.
   fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
-  auto response =
-      codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                                 {":path", "/dynamo/url"},
-                                                                 {":scheme", "http"},
-                                                                 {":authority", "host"},
-                                                                 {"x-forwarded-for", "10.0.0.1"},
-                                                                 {"x-envoy-retry-on", "5xx"}},
-                                         1024 * 65);
+  auto response = codec_client_->makeRequestWithBody(
+      Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                     {":path", "/dynamo/url"},
+                                     {":scheme", "http"},
+                                     {":authority", "host"},
+                                     {"x-forwarded-for", "10.0.0.1"},
+                                     {"x-envoy-retry-on", "5xx"}},
+      1024 * 65);
 
   response->waitForEndStream();
   // With HTTP/1 there's a possible race where if the connection backs up early,
@@ -580,6 +599,9 @@ TEST_P(ProtocolIntegrationTest, HittingEncoderFilterLimit) {
   response->waitForEndStream();
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("500", response->headers().Status()->value().getStringView());
+  // Regression test https://github.com/envoyproxy/envoy/issues/9881 by making
+  // sure this path does standard HCM header transformations.
+  EXPECT_TRUE(response->headers().Date() != nullptr);
   EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("500"));
   test_server_->waitForCounterEq("http.config_test.downstream_rq_5xx", 1);
 }
@@ -607,11 +629,11 @@ TEST_P(DownstreamProtocolIntegrationTest, ValidZeroLengthContent) {
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  Http::TestHeaderMapImpl request_headers{{":method", "POST"},
-                                          {":path", "/test/long/url"},
-                                          {":scheme", "http"},
-                                          {":authority", "host"},
-                                          {"content-length", "0"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "POST"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"content-length", "0"}};
   auto response = sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0);
 
   ASSERT_TRUE(response->complete());
@@ -623,11 +645,11 @@ TEST_P(DownstreamProtocolIntegrationTest, LargeCookieParsingConcatenated) {
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  Http::TestHeaderMapImpl request_headers{{":method", "POST"},
-                                          {":path", "/test/long/url"},
-                                          {":scheme", "http"},
-                                          {":authority", "host"},
-                                          {"content-length", "0"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "POST"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"content-length", "0"}};
   std::vector<std::string> cookie_pieces;
   cookie_pieces.reserve(7000);
   for (int i = 0; i < 7000; i++) {
@@ -655,11 +677,11 @@ TEST_P(DownstreamProtocolIntegrationTest, LargeCookieParsingMany) {
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  Http::TestHeaderMapImpl request_headers{{":method", "POST"},
-                                          {":path", "/test/long/url"},
-                                          {":scheme", "http"},
-                                          {":authority", "host"},
-                                          {"content-length", "0"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "POST"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"content-length", "0"}};
   for (int i = 0; i < 2000; i++) {
     request_headers.addCopy("cookie", fmt::sprintf("a%x=b", i));
   }
@@ -675,10 +697,10 @@ TEST_P(DownstreamProtocolIntegrationTest, InvalidContentLength) {
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   auto encoder_decoder =
-      codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                          {":path", "/test/long/url"},
-                                                          {":authority", "host"},
-                                                          {"content-length", "-1"}});
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                                 {":path", "/test/long/url"},
+                                                                 {":authority", "host"},
+                                                                 {"content-length", "-1"}});
   auto response = std::move(encoder_decoder.second);
 
   codec_client_->waitForDisconnect();
@@ -705,10 +727,10 @@ TEST_P(DownstreamProtocolIntegrationTest, InvalidContentLengthAllowed) {
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   auto encoder_decoder =
-      codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                          {":path", "/test/long/url"},
-                                                          {":authority", "host"},
-                                                          {"content-length", "-1"}});
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                                 {":path", "/test/long/url"},
+                                                                 {":authority", "host"},
+                                                                 {"content-length", "-1"}});
   auto response = std::move(encoder_decoder.second);
 
   if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
@@ -731,10 +753,10 @@ TEST_P(DownstreamProtocolIntegrationTest, MultipleContentLengths) {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto encoder_decoder =
-      codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                          {":path", "/test/long/url"},
-                                                          {":authority", "host"},
-                                                          {"content-length", "3,2"}});
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                                 {":path", "/test/long/url"},
+                                                                 {":authority", "host"},
+                                                                 {"content-length", "3,2"}});
   auto response = std::move(encoder_decoder.second);
 
   codec_client_->waitForDisconnect();
@@ -759,10 +781,10 @@ TEST_P(DownstreamProtocolIntegrationTest, MultipleContentLengthsAllowed) {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto encoder_decoder =
-      codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                          {":path", "/test/long/url"},
-                                                          {":authority", "host"},
-                                                          {"content-length", "3,2"}});
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                                 {":path", "/test/long/url"},
+                                                                 {":authority", "host"},
+                                                                 {"content-length", "3,2"}});
   auto response = std::move(encoder_decoder.second);
 
   if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
@@ -789,13 +811,13 @@ name: encode-headers-only
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response =
-      codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "GET"},
-                                                                 {":path", "/test/long/url"},
-                                                                 {":scheme", "http"},
-                                                                 {":authority", "host"}},
+      codec_client_->makeRequestWithBody(Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                                                        {":path", "/test/long/url"},
+                                                                        {":scheme", "http"},
+                                                                        {":authority", "host"}},
                                          128);
   waitForNextUpstreamRequest();
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, false);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "503"}}, false);
   response->waitForEndStream();
   EXPECT_TRUE(upstream_request_->waitForEndStream(*dispatcher_));
   if (upstreamProtocol() == FakeHttpConnection::Type::HTTP1) {
@@ -819,13 +841,13 @@ name: decode-headers-only
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response =
-      codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                                 {":path", "/test/long/url"},
-                                                                 {":scheme", "http"},
-                                                                 {":authority", "host"}},
+      codec_client_->makeRequestWithBody(Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                                        {":path", "/test/long/url"},
+                                                                        {":scheme", "http"},
+                                                                        {":authority", "host"}},
                                          128);
   waitForNextUpstreamRequest();
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, false);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "503"}}, false);
   upstream_request_->encodeData(128, true);
   response->waitForEndStream();
 
@@ -848,13 +870,13 @@ name: passthrough-filter
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response =
-      codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "GET"},
-                                                                 {":path", "/test/long/url"},
-                                                                 {":scheme", "http"},
-                                                                 {":authority", "host"}},
+      codec_client_->makeRequestWithBody(Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                                                        {":path", "/test/long/url"},
+                                                                        {":scheme", "http"},
+                                                                        {":authority", "host"}},
                                          128);
   waitForNextUpstreamRequest();
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, false);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "503"}}, false);
   response->waitForEndStream();
   if (upstreamProtocol() == FakeHttpConnection::Type::HTTP1) {
     ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
@@ -883,13 +905,13 @@ name: passthrough-filter
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response =
-      codec_client_->makeRequestWithBody(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                                 {":path", "/test/long/url"},
-                                                                 {":scheme", "http"},
-                                                                 {":authority", "host"}},
+      codec_client_->makeRequestWithBody(Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                                        {":path", "/test/long/url"},
+                                                                        {":scheme", "http"},
+                                                                        {":authority", "host"}},
                                          128);
   waitForNextUpstreamRequest();
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, false);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "503"}}, false);
   upstream_request_->encodeData(128, true);
   response->waitForEndStream();
 
@@ -911,16 +933,16 @@ name: decode-headers-only
   // First send the request headers. The filter should turn this into a header-only
   // request.
   auto encoder_decoder =
-      codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "GET"},
-                                                          {":path", "/test/long/url"},
-                                                          {":scheme", "http"},
-                                                          {":authority", "host"}});
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                                                 {":path", "/test/long/url"},
+                                                                 {":scheme", "http"},
+                                                                 {":authority", "host"}});
   request_encoder_ = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
 
   // Wait for the upstream request and begin sending a response with end_stream = false.
   waitForNextUpstreamRequest();
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "503"}}, false);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "503"}}, false);
 
   // Simulate additional data after the request has been turned into a headers only request.
   Buffer::OwnedImpl data(std::string(128, 'a'));
@@ -959,7 +981,7 @@ TEST_P(DownstreamProtocolIntegrationTest, ManyRequestTrailersRejected) {
   // Default header (and trailer) count limit is 100.
   config_helper_.addConfigModifier(setEnableDownstreamTrailersHttp1());
   config_helper_.addConfigModifier(setEnableUpstreamTrailersHttp1());
-  Http::TestHeaderMapImpl request_trailers;
+  Http::TestRequestTrailerMapImpl request_trailers;
   for (int i = 0; i < 150; i++) {
     request_trailers.addCopy("trailer", std::string(1, 'a'));
   }
@@ -994,7 +1016,7 @@ TEST_P(DownstreamProtocolIntegrationTest, ManyRequestTrailersAccepted) {
       });
   config_helper_.addConfigModifier(setEnableUpstreamTrailersHttp1());
   max_request_headers_count_ = max_count;
-  Http::TestHeaderMapImpl request_trailers;
+  Http::TestRequestTrailerMapImpl request_trailers;
   for (int i = 0; i < 150; i++) {
     request_trailers.addCopy("trailer", std::string(1, 'a'));
   }
@@ -1045,7 +1067,7 @@ TEST_P(DownstreamProtocolIntegrationTest, ManyTrailerHeaders) {
             max_request_headers_count_);
       });
 
-  Http::HeaderMapImpl request_trailers{};
+  Http::RequestTrailerMapImpl request_trailers;
   for (int i = 0; i < 20000; i++) {
     request_trailers.addCopy(Http::LowerCaseString(std::to_string(i)), "");
   }
@@ -1053,10 +1075,10 @@ TEST_P(DownstreamProtocolIntegrationTest, ManyTrailerHeaders) {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto encoder_decoder =
-      codec_client_->startRequest(Http::TestHeaderMapImpl{{":method", "POST"},
-                                                          {":path", "/test/long/url"},
-                                                          {":scheme", "http"},
-                                                          {":authority", "host"}});
+      codec_client_->startRequest(Http::TestRequestHeaderMapImpl{{":method", "POST"},
+                                                                 {":path", "/test/long/url"},
+                                                                 {":scheme", "http"},
+                                                                 {":authority", "host"}});
   request_encoder_ = &encoder_decoder.first;
   auto response = std::move(encoder_decoder.second);
   codec_client_->sendTrailers(*request_encoder_, request_trailers);
@@ -1085,10 +1107,10 @@ TEST_P(DownstreamProtocolIntegrationTest, ManyTrailerHeaders) {
 // H2            H2         Success
 TEST_P(ProtocolIntegrationTest, LargeRequestMethod) {
   const std::string long_method = std::string(48 * 1024, 'a');
-  const Http::TestHeaderMapImpl request_headers{{":method", long_method},
-                                                {":path", "/test/long/url"},
-                                                {":scheme", "http"},
-                                                {":authority", "host"}};
+  const Http::TestRequestHeaderMapImpl request_headers{{":method", long_method},
+                                                       {":path", "/test/long/url"},
+                                                       {":scheme", "http"},
+                                                       {":authority", "host"}};
 
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -1160,7 +1182,7 @@ name: passthrough-filter
   for (int i = 0; i < count_; i++) {
     codec_client_->sendData(*request_encoder_, size_, false);
   }
-  Http::TestHeaderMapImpl request_trailers{{"trailer", "trailer"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"trailer", "trailer"}};
   codec_client_->sendTrailers(*request_encoder_, request_trailers);
   waitForNextUpstreamRequest();
 
@@ -1219,7 +1241,7 @@ name: passthrough-filter
   // Gives buffer 1s to react to buffer limit.
   absl::SleepFor(absl::Seconds(1));
   codec_client_->sendData(*request_encoder_, size_, false);
-  Http::TestHeaderMapImpl request_trailers{{"trailer", "trailer"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"trailer", "trailer"}};
   codec_client_->sendTrailers(*request_encoder_, request_trailers);
   waitForNextUpstreamRequest();
 
@@ -1267,7 +1289,7 @@ name: passthrough-filter
   for (int i = 0; i < count_; i++) {
     codec_client_->sendData(*request_encoder_, size_, false);
   }
-  Http::TestHeaderMapImpl request_trailers{{"trailer", "trailer"}};
+  Http::TestRequestTrailerMapImpl request_trailers{{"trailer", "trailer"}};
   codec_client_->sendTrailers(*request_encoder_, request_trailers);
   waitForNextUpstreamRequest();
 
@@ -1300,7 +1322,7 @@ name: encode-headers-return-stop-all-filter
   // Sleeps for 1s in order to be consistent with testEncodeHeadersReturnsStopAllWatermark.
   absl::SleepFor(absl::Seconds(1));
   upstream_request_->encodeData(size_, false);
-  Http::TestHeaderMapImpl response_trailers{{"response", "trailer"}};
+  Http::TestResponseTrailerMapImpl response_trailers{{"response", "trailer"}};
   upstream_request_->encodeTrailers(response_trailers);
 
   response->waitForEndStream();
@@ -1340,7 +1362,7 @@ name: encode-headers-return-stop-all-filter
   // Gives buffer 1s to react to buffer limit.
   absl::SleepFor(absl::Seconds(1));
   upstream_request_->encodeData(size_, false);
-  Http::TestHeaderMapImpl response_trailers{{"response", "trailer"}};
+  Http::TestResponseTrailerMapImpl response_trailers{{"response", "trailer"}};
   upstream_request_->encodeTrailers(response_trailers);
 
   response->waitForEndStream();
@@ -1355,7 +1377,7 @@ TEST_P(ProtocolIntegrationTest, MultipleSetCookies) {
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  Http::TestHeaderMapImpl response_headers{
+  Http::TestResponseHeaderMapImpl response_headers{
       {":status", "200"}, {"set-cookie", "foo"}, {"set-cookie", "bar"}};
 
   auto response = sendRequestAndWaitForResponse(default_request_headers_, 0, response_headers, 0);
@@ -1475,10 +1497,10 @@ TEST_P(DownstreamProtocolIntegrationTest, InvalidAuthority) {
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
-  Http::TestHeaderMapImpl request_headers{{":method", "POST"},
-                                          {":path", "/test/long/url"},
-                                          {":scheme", "http"},
-                                          {":authority", "ho|st|"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "POST"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "ho|st|"}};
 
   auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
   if (downstreamProtocol() == Http::CodecClient::Type::HTTP1) {
@@ -1497,8 +1519,8 @@ TEST_P(DownstreamProtocolIntegrationTest, InvalidAuthority) {
 TEST_P(DownstreamProtocolIntegrationTest, ConnectIsBlocked) {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto response = codec_client_->makeHeaderOnlyRequest(
-      Http::TestHeaderMapImpl{{":method", "CONNECT"}, {":path", "/"}, {":authority", "host"}});
+  auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "CONNECT"}, {":path", "/"}, {":authority", "host"}});
 
   if (downstreamProtocol() == Http::CodecClient::Type::HTTP1) {
     response->waitForEndStream();
@@ -1524,8 +1546,8 @@ TEST_P(DownstreamProtocolIntegrationTest, ConnectStreamRejection) {
 
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto response = codec_client_->makeHeaderOnlyRequest(
-      Http::TestHeaderMapImpl{{":method", "CONNECT"}, {":path", "/"}, {":authority", "host"}});
+  auto response = codec_client_->makeHeaderOnlyRequest(Http::TestRequestHeaderMapImpl{
+      {":method", "CONNECT"}, {":path", "/"}, {":authority", "host"}});
 
   response->waitForReset();
   EXPECT_FALSE(codec_client_->disconnected());

--- a/test/integration/scoped_rds_integration_test.cc
+++ b/test/integration/scoped_rds_integration_test.cc
@@ -272,11 +272,11 @@ key:
   // No scope key matches "xyz-route".
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response = codec_client_->makeHeaderOnlyRequest(
-      Http::TestHeaderMapImpl{{":method", "GET"},
-                              {":path", "/meh"},
-                              {":authority", "host"},
-                              {":scheme", "http"},
-                              {"Addr", "x-foo-key=xyz-route"}});
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/meh"},
+                                     {":authority", "host"},
+                                     {":scheme", "http"},
+                                     {"Addr", "x-foo-key=xyz-route"}});
   response->waitForEndStream();
   verifyResponse(std::move(response), "404", Http::TestHeaderMapImpl{}, "");
   cleanupUpstreamAndDownstream();
@@ -285,12 +285,12 @@ key:
   test_server_->waitForCounterGe("http.config_test.rds.foo_route1.update_success", 1);
   for (const std::string& scope_key : std::vector<std::string>{"foo-route", "bar-route"}) {
     sendRequestAndVerifyResponse(
-        Http::TestHeaderMapImpl{{":method", "GET"},
-                                {":path", "/meh"},
-                                {":authority", "host"},
-                                {":scheme", "http"},
-                                {"Addr", fmt::format("x-foo-key={}", scope_key)}},
-        456, Http::TestHeaderMapImpl{{":status", "200"}, {"service", scope_key}}, 123,
+        Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                       {":path", "/meh"},
+                                       {":authority", "host"},
+                                       {":scheme", "http"},
+                                       {"Addr", fmt::format("x-foo-key={}", scope_key)}},
+        456, Http::TestResponseHeaderMapImpl{{":status", "200"}, {"service", scope_key}}, 123,
         /*cluster_0*/ 0);
   }
   test_server_->waitForCounterGe("http.config_test.scoped_rds.foo-scoped-routes.update_attempt",
@@ -320,22 +320,22 @@ key:
   // 'cluster_1'.
   for (const std::string& scope_key : std::vector<std::string>{"foo-route", "bar-route"}) {
     sendRequestAndVerifyResponse(
-        Http::TestHeaderMapImpl{{":method", "GET"},
-                                {":path", "/meh"},
-                                {":authority", "host"},
-                                {":scheme", "http"},
-                                {"Addr", fmt::format("x-foo-key={}", scope_key)}},
-        456, Http::TestHeaderMapImpl{{":status", "200"}, {"service", scope_key}}, 123,
+        Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                       {":path", "/meh"},
+                                       {":authority", "host"},
+                                       {":scheme", "http"},
+                                       {"Addr", fmt::format("x-foo-key={}", scope_key)}},
+        456, Http::TestResponseHeaderMapImpl{{":status", "200"}, {"service", scope_key}}, 123,
         /*cluster_1*/ 1);
   }
   // Now requests within scope 'foo_scope3' get routed to 'cluster_0'.
   sendRequestAndVerifyResponse(
-      Http::TestHeaderMapImpl{{":method", "GET"},
-                              {":path", "/meh"},
-                              {":authority", "host"},
-                              {":scheme", "http"},
-                              {"Addr", fmt::format("x-foo-key={}", "baz-route")}},
-      456, Http::TestHeaderMapImpl{{":status", "200"}, {"service", "bluh"}}, 123,
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/meh"},
+                                     {":authority", "host"},
+                                     {":scheme", "http"},
+                                     {"Addr", fmt::format("x-foo-key={}", "baz-route")}},
+      456, Http::TestResponseHeaderMapImpl{{":status", "200"}, {"service", "bluh"}}, 123,
       /*cluster_0*/ 0);
 
   // Delete foo_scope1 and requests within the scope gets 400s.
@@ -343,11 +343,11 @@ key:
   test_server_->waitForCounterGe("http.config_test.scoped_rds.foo-scoped-routes.update_success", 3);
   codec_client_ = makeHttpConnection(lookupPort("http"));
   response = codec_client_->makeHeaderOnlyRequest(
-      Http::TestHeaderMapImpl{{":method", "GET"},
-                              {":path", "/meh"},
-                              {":authority", "host"},
-                              {":scheme", "http"},
-                              {"Addr", "x-foo-key=foo-route"}});
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/meh"},
+                                     {":authority", "host"},
+                                     {":scheme", "http"},
+                                     {"Addr", "x-foo-key=foo-route"}});
   response->waitForEndStream();
   verifyResponse(std::move(response), "404", Http::TestHeaderMapImpl{}, "");
   cleanupUpstreamAndDownstream();
@@ -358,11 +358,11 @@ key:
   test_server_->waitForCounterGe("http.config_test.scoped_rds.foo-scoped-routes.update_success", 4);
   codec_client_ = makeHttpConnection(lookupPort("http"));
   response = codec_client_->makeHeaderOnlyRequest(
-      Http::TestHeaderMapImpl{{":method", "GET"},
-                              {":path", "/meh"},
-                              {":authority", "host"},
-                              {":scheme", "http"},
-                              {"Addr", "x-foo-key=xyz-route"}});
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/meh"},
+                                     {":authority", "host"},
+                                     {":scheme", "http"},
+                                     {"Addr", "x-foo-key=xyz-route"}});
   response->waitForEndStream();
   // Get 404 because RDS hasn't pushed route configuration "foo_route4" yet.
   // But scope is found and the Router::NullConfigImpl is returned.
@@ -375,12 +375,12 @@ key:
   sendRdsResponse(fmt::format(route_config_tmpl, "foo_route4", "cluster_1"), "3");
   test_server_->waitForCounterGe("http.config_test.rds.foo_route4.update_success", 1);
   sendRequestAndVerifyResponse(
-      Http::TestHeaderMapImpl{{":method", "GET"},
-                              {":path", "/meh"},
-                              {":authority", "host"},
-                              {":scheme", "http"},
-                              {"Addr", "x-foo-key=xyz-route"}},
-      456, Http::TestHeaderMapImpl{{":status", "200"}, {"service", "xyz-route"}}, 123,
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/meh"},
+                                     {":authority", "host"},
+                                     {":scheme", "http"},
+                                     {"Addr", "x-foo-key=xyz-route"}},
+      456, Http::TestResponseHeaderMapImpl{{":status", "200"}, {"service", "xyz-route"}}, 123,
       /*cluster_1 */ 1);
 }
 
@@ -403,12 +403,12 @@ key:
   test_server_->waitForCounterGe("http.config_test.scoped_rds.foo-scoped-routes.update_rejected",
                                  1);
   codec_client_ = makeHttpConnection(lookupPort("http"));
-  auto response =
-      codec_client_->makeHeaderOnlyRequest(Http::TestHeaderMapImpl{{":method", "GET"},
-                                                                   {":path", "/meh"},
-                                                                   {":authority", "host"},
-                                                                   {":scheme", "http"},
-                                                                   {"Addr", "x-foo-key=foo"}});
+  auto response = codec_client_->makeHeaderOnlyRequest(
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/meh"},
+                                     {":authority", "host"},
+                                     {":scheme", "http"},
+                                     {"Addr", "x-foo-key=foo"}});
   response->waitForEndStream();
   verifyResponse(std::move(response), "404", Http::TestHeaderMapImpl{}, "");
   cleanupUpstreamAndDownstream();
@@ -436,12 +436,13 @@ key:
   sendRdsResponse(fmt::format(route_config_tmpl, "foo_route1", "cluster_0"), "1");
   test_server_->waitForCounterGe("http.config_test.rds.foo_route1.update_success", 1);
   sendRequestAndVerifyResponse(
-      Http::TestHeaderMapImpl{{":method", "GET"},
-                              {":path", "/meh"},
-                              {":authority", "host"},
-                              {":scheme", "http"},
-                              {"Addr", "x-foo-key=foo"}},
-      456, Http::TestHeaderMapImpl{{":status", "200"}, {"service", "bluh"}}, 123, /*cluster_0*/ 0);
+      Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                     {":path", "/meh"},
+                                     {":authority", "host"},
+                                     {":scheme", "http"},
+                                     {"Addr", "x-foo-key=foo"}},
+      456, Http::TestResponseHeaderMapImpl{{":status", "200"}, {"service", "bluh"}}, 123,
+      /*cluster_0*/ 0);
 }
 
 } // namespace

--- a/test/integration/sds_generic_secret_integration_test.cc
+++ b/test/integration/sds_generic_secret_integration_test.cc
@@ -29,7 +29,7 @@ public:
   void onDestroy() override{};
 
   // Http::StreamDecoderFilter
-  Http::FilterHeadersStatus decodeHeaders(Http::HeaderMap& headers, bool) override {
+  Http::FilterHeadersStatus decodeHeaders(Http::RequestHeaderMap& headers, bool) override {
     headers.addCopy(Http::LowerCaseString("secret"),
                     Config::DataSource::read(config_provider_->secret()->secret(), true, api_));
     return Http::FilterHeadersStatus::Continue;
@@ -39,7 +39,7 @@ public:
     return Http::FilterDataStatus::Continue;
   }
 
-  Http::FilterTrailersStatus decodeTrailers(Http::HeaderMap&) override {
+  Http::FilterTrailersStatus decodeTrailers(Http::RequestTrailerMap&) override {
     return Http::FilterTrailersStatus::Continue;
   }
 
@@ -146,7 +146,7 @@ TEST_P(SdsGenericSecretIntegrationTest, FilterFetchSuccess) {
   initialize();
 
   codec_client_ = makeHttpConnection((lookupPort("http")));
-  Http::TestHeaderMapImpl request_headers{
+  Http::TestRequestHeaderMapImpl request_headers{
       {":method", "GET"}, {":path", "/"}, {":scheme", "http"}, {":authority", "host"}};
   sendRequestAndWaitForResponse(request_headers, 0, default_response_headers_, 0);
 

--- a/test/integration/tcp_proxy_integration_test.cc
+++ b/test/integration/tcp_proxy_integration_test.cc
@@ -248,7 +248,7 @@ TEST_P(TcpProxyIntegrationTest, AccessLog) {
         envoy::config::filter::network::tcp_proxy::v2::TcpProxy)>(*config_blob);
 
     auto* access_log = tcp_proxy_config.add_access_log();
-    access_log->set_name("envoy.access_loggers.file");
+    access_log->set_name("accesslog");
     envoy::extensions::access_loggers::file::v3::FileAccessLog access_log_config;
     access_log_config.set_path(access_log_path);
     access_log_config.set_format(

--- a/test/integration/transport_socket_match_integration_test.cc
+++ b/test/integration/transport_socket_match_integration_test.cc
@@ -164,16 +164,16 @@ require_client_certificate: true
   }
 
   const uint32_t num_hosts_;
-  Http::TestHeaderMapImpl type_a_request_headers_{{":method", "GET"},
-                                                  {":path", "/test"},
-                                                  {":scheme", "http"},
-                                                  {":authority", "host"},
-                                                  {"x-type", "a"}};
-  Http::TestHeaderMapImpl type_b_request_headers_{{":method", "GET"},
-                                                  {":path", "/test"},
-                                                  {":scheme", "http"},
-                                                  {":authority", "host"},
-                                                  {"x-type", "b"}};
+  Http::TestRequestHeaderMapImpl type_a_request_headers_{{":method", "GET"},
+                                                         {":path", "/test"},
+                                                         {":scheme", "http"},
+                                                         {":authority", "host"},
+                                                         {"x-type", "a"}};
+  Http::TestRequestHeaderMapImpl type_b_request_headers_{{":method", "GET"},
+                                                         {":path", "/test"},
+                                                         {":scheme", "http"},
+                                                         {":authority", "host"},
+                                                         {"x-type", "b"}};
   const std::string host_type_header_{"x-host-type"};
   const std::string host_header_{"x-host"};
   const std::string type_header_{"x-type"};

--- a/test/integration/uds_integration_test.cc
+++ b/test/integration/uds_integration_test.cc
@@ -89,7 +89,7 @@ TEST_P(UdsListenerIntegrationTest, TestPeerCredentials) {
   initialize();
   auto client_connection = createConnectionFn()();
   codec_client_ = makeHttpConnection(std::move(client_connection));
-  Http::TestHeaderMapImpl request_headers{
+  Http::TestRequestHeaderMapImpl request_headers{
       {":method", "POST"},    {":path", "/test/long/url"}, {":scheme", "http"},
       {":authority", "host"}, {"x-lyft-user-id", "123"},   {"x-forwarded-for", "10.0.0.1"}};
   auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
@@ -104,7 +104,7 @@ TEST_P(UdsListenerIntegrationTest, TestPeerCredentials) {
   EXPECT_EQ(credentials->gid, getgid());
 #endif
 
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, true);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
 
   response->waitForEndStream();
 }

--- a/test/integration/utility.cc
+++ b/test/integration/utility.cc
@@ -27,7 +27,7 @@
 #include "absl/strings/match.h"
 
 namespace Envoy {
-void BufferingStreamDecoder::decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) {
+void BufferingStreamDecoder::decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bool end_stream) {
   ASSERT(!complete_);
   complete_ = end_stream;
   headers_ = std::move(headers);
@@ -45,7 +45,7 @@ void BufferingStreamDecoder::decodeData(Buffer::Instance& data, bool end_stream)
   }
 }
 
-void BufferingStreamDecoder::decodeTrailers(Http::HeaderMapPtr&&) {
+void BufferingStreamDecoder::decodeTrailers(Http::ResponseTrailerMapPtr&&) {
   NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
 }
 
@@ -84,7 +84,7 @@ IntegrationUtil::makeSingleRequest(const Network::Address::InstanceConstSharedPt
   Http::RequestEncoder& encoder = client.newStream(*response);
   encoder.getStream().addCallbacks(*response);
 
-  Http::HeaderMapImpl headers;
+  Http::RequestHeaderMapImpl headers;
   headers.setMethod(method);
   headers.setPath(url);
   headers.setHost(host);

--- a/test/integration/utility.h
+++ b/test/integration/utility.h
@@ -31,11 +31,13 @@ public:
   const std::string& body() { return body_; }
 
   // Http::StreamDecoder
-  void decode100ContinueHeaders(Http::HeaderMapPtr&&) override {}
-  void decodeHeaders(Http::HeaderMapPtr&& headers, bool end_stream) override;
   void decodeData(Buffer::Instance&, bool end_stream) override;
-  void decodeTrailers(Http::HeaderMapPtr&& trailers) override;
   void decodeMetadata(Http::MetadataMapPtr&&) override {}
+
+  // Http::ResponseDecoder
+  void decode100ContinueHeaders(Http::ResponseHeaderMapPtr&&) override {}
+  void decodeHeaders(Http::ResponseHeaderMapPtr&& headers, bool end_stream) override;
+  void decodeTrailers(Http::ResponseTrailerMapPtr&& trailers) override;
 
   // Http::StreamCallbacks
   void onResetStream(Http::StreamResetReason reason,

--- a/test/integration/vhds_integration_test.cc
+++ b/test/integration/vhds_integration_test.cc
@@ -65,7 +65,7 @@ static_resources:
         port_value: 0
     filter_chains:
     - filters:
-      - name: envoy.http_connection_manager
+      - name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           stat_prefix: config_test
@@ -439,11 +439,11 @@ TEST_P(VhdsIntegrationTest, VhdsVirtualHostAddUpdateRemove) {
 
   // an upstream request to an (now) unknown domain
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
-  Http::TestHeaderMapImpl request_headers{{":method", "GET"},
-                                          {":path", "/"},
-                                          {":scheme", "http"},
-                                          {":authority", "vhost.first"},
-                                          {"x-lyft-user-id", "123"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "vhost.first"},
+                                                 {"x-lyft-user-id", "123"}};
   IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(request_headers);
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost,
                                            {vhdsRequestResourceName("vhost.first")}, {},
@@ -506,11 +506,11 @@ TEST_P(VhdsIntegrationTest, RdsWithVirtualHostsVhdsVirtualHostAddUpdateRemove) {
   codec_client_->waitForDisconnect();
 
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
-  Http::TestHeaderMapImpl request_headers{{":method", "GET"},
-                                          {":path", "/"},
-                                          {":scheme", "http"},
-                                          {":authority", "vhost.first"},
-                                          {"x-lyft-user-id", "123"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "vhost.first"},
+                                                 {"x-lyft-user-id", "123"}};
   IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(request_headers);
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost,
                                            {vhdsRequestResourceName("vhost.first")}, {},
@@ -547,11 +547,11 @@ TEST_P(VhdsIntegrationTest, VhdsOnDemandUpdateWithResourceNameAsAlias) {
 
   // Attempt to make a request to an unknown host
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
-  Http::TestHeaderMapImpl request_headers{{":method", "GET"},
-                                          {":path", "/"},
-                                          {":scheme", "http"},
-                                          {":authority", "vhost_1"},
-                                          {"x-lyft-user-id", "123"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "vhost_1"},
+                                                 {"x-lyft-user-id", "123"}};
   IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(request_headers);
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost,
                                            {vhdsRequestResourceName("vhost_1")}, {}, vhds_stream_));
@@ -593,11 +593,11 @@ TEST_P(VhdsIntegrationTest, VhdsOnDemandUpdateFailToResolveTheAlias) {
 
   // Attempt to make a request to an unknown host
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
-  Http::TestHeaderMapImpl request_headers{{":method", "GET"},
-                                          {":path", "/"},
-                                          {":scheme", "http"},
-                                          {":authority", "vhost.third"},
-                                          {"x-lyft-user-id", "123"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "vhost.third"},
+                                                 {"x-lyft-user-id", "123"}};
   IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(request_headers);
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost,
                                            {vhdsRequestResourceName("vhost.third")}, {},
@@ -634,11 +634,11 @@ TEST_P(VhdsIntegrationTest, VhdsOnDemandUpdateFailToResolveOneAliasOutOfSeveral)
 
   // Attempt to make a request to an unknown host
   codec_client_ = makeHttpConnection(makeClientConnection((lookupPort("http"))));
-  Http::TestHeaderMapImpl request_headers{{":method", "GET"},
-                                          {":path", "/"},
-                                          {":scheme", "http"},
-                                          {":authority", "vhost.third"},
-                                          {"x-lyft-user-id", "123"}};
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "vhost.third"},
+                                                 {"x-lyft-user-id", "123"}};
   IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(request_headers);
   EXPECT_TRUE(compareDeltaDiscoveryRequest(Config::TypeUrl::get().VirtualHost,
                                            {vhdsRequestResourceName("vhost.third")}, {},

--- a/test/integration/websocket_integration_test.cc
+++ b/test/integration/websocket_integration_test.cc
@@ -19,8 +19,8 @@
 namespace Envoy {
 namespace {
 
-Http::TestHeaderMapImpl upgradeRequestHeaders(const char* upgrade_type = "websocket",
-                                              uint32_t content_length = 0) {
+Http::TestRequestHeaderMapImpl upgradeRequestHeaders(const char* upgrade_type = "websocket",
+                                                     uint32_t content_length = 0) {
   return Http::TestHeaderMapImpl{{":authority", "host"},
                                  {"content-length", fmt::format("{}", content_length)},
                                  {":path", "/websocket/test"},
@@ -30,11 +30,11 @@ Http::TestHeaderMapImpl upgradeRequestHeaders(const char* upgrade_type = "websoc
                                  {"connection", "keep-alive, upgrade"}};
 }
 
-Http::TestHeaderMapImpl upgradeResponseHeaders(const char* upgrade_type = "websocket") {
-  return Http::TestHeaderMapImpl{{":status", "101"},
-                                 {"connection", "upgrade"},
-                                 {"upgrade", upgrade_type},
-                                 {"content-length", "0"}};
+Http::TestResponseHeaderMapImpl upgradeResponseHeaders(const char* upgrade_type = "websocket") {
+  return Http::TestResponseHeaderMapImpl{{":status", "101"},
+                                         {"connection", "upgrade"},
+                                         {"upgrade", upgrade_type},
+                                         {"content-length", "0"}};
 }
 
 } // namespace
@@ -131,8 +131,8 @@ void WebsocketIntegrationTest::initialize() {
 }
 
 void WebsocketIntegrationTest::performUpgrade(
-    const Http::TestHeaderMapImpl& upgrade_request_headers,
-    const Http::TestHeaderMapImpl& upgrade_response_headers) {
+    const Http::TestRequestHeaderMapImpl& upgrade_request_headers,
+    const Http::TestResponseHeaderMapImpl& upgrade_response_headers) {
   // Establish the initial connection.
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
@@ -371,11 +371,11 @@ TEST_P(WebsocketIntegrationTest, WebsocketCustomFilterChain) {
 
   // HTTP requests are configured to disallow large bodies.
   {
-    Http::TestHeaderMapImpl request_headers{{":method", "GET"},
-                                            {":path", "/"},
-                                            {"content-length", "2048"},
-                                            {":authority", "host"},
-                                            {":scheme", "https"}};
+    Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                   {":path", "/"},
+                                                   {"content-length", "2048"},
+                                                   {":authority", "host"},
+                                                   {":scheme", "https"}};
     codec_client_ = makeHttpConnection(lookupPort("http"));
     auto encoder_decoder = codec_client_->startRequest(request_headers);
     response_ = std::move(encoder_decoder.second);

--- a/test/integration/websocket_integration_test.h
+++ b/test/integration/websocket_integration_test.h
@@ -17,8 +17,8 @@ public:
   void initialize() override;
 
 protected:
-  void performUpgrade(const Http::TestHeaderMapImpl& upgrade_request_headers,
-                      const Http::TestHeaderMapImpl& upgrade_response_headers);
+  void performUpgrade(const Http::TestRequestHeaderMapImpl& upgrade_request_headers,
+                      const Http::TestResponseHeaderMapImpl& upgrade_response_headers);
   void sendBidirectionalData();
 
   void validateUpgradeRequestHeaders(const Http::HeaderMap& proxied_request_headers,

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -156,18 +156,18 @@ void XfccIntegrationTest::initialize() {
 void XfccIntegrationTest::testRequestAndResponseWithXfccHeader(std::string previous_xfcc,
                                                                std::string expected_xfcc) {
   Network::ClientConnectionPtr conn = tls_ ? makeMtlsClientConnection() : makeTcpClientConnection();
-  Http::TestHeaderMapImpl header_map;
+  Http::TestRequestHeaderMapImpl header_map;
   if (previous_xfcc.empty()) {
-    header_map = Http::TestHeaderMapImpl{{":method", "GET"},
-                                         {":path", "/test/long/url"},
-                                         {":scheme", "http"},
-                                         {":authority", "host"}};
+    header_map = Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                                {":path", "/test/long/url"},
+                                                {":scheme", "http"},
+                                                {":authority", "host"}};
   } else {
-    header_map = Http::TestHeaderMapImpl{{":method", "GET"},
-                                         {":path", "/test/long/url"},
-                                         {":scheme", "http"},
-                                         {":authority", "host"},
-                                         {"x-forwarded-client-cert", previous_xfcc.c_str()}};
+    header_map = Http::TestRequestHeaderMapImpl{{":method", "GET"},
+                                                {":path", "/test/long/url"},
+                                                {":scheme", "http"},
+                                                {":authority", "host"},
+                                                {"x-forwarded-client-cert", previous_xfcc.c_str()}};
   }
 
   codec_client_ = makeHttpConnection(std::move(conn));
@@ -181,7 +181,7 @@ void XfccIntegrationTest::testRequestAndResponseWithXfccHeader(std::string previ
     EXPECT_EQ(expected_xfcc,
               upstream_request_->headers().ForwardedClientCert()->value().getStringView());
   }
-  upstream_request_->encodeHeaders(Http::TestHeaderMapImpl{{":status", "200"}}, true);
+  upstream_request_->encodeHeaders(Http::TestResponseHeaderMapImpl{{":status", "200"}}, true);
   response->waitForEndStream();
   EXPECT_TRUE(upstream_request_->complete());
   EXPECT_TRUE(response->complete());


### PR DESCRIPTION
This updates Envoy to the latest commit. Changes include the following.

```
  > tools: reorg tools dir (#10092)
  > Plumb the flaky flag from envoy_cc_test to the native.cc_test (#10009)
  > router check tool: response headers (#10090)
  > Update gRPC SHA (#10056)
  > http: use typed headers in encoding path (#10081)
  > test: use semantic names for access log extensions (#10071)
  > Introduce os_fd_t and windows port of os_sys_calls_impl (#10036)
  > runtime: Add support for setting default value when parsing string value (#10058)
  > tracing: Add source IP address to XRay trace (#10014)
  > quiche: update quiche tar (#10040)
  > api: introduce WiP file-level annotations. (#9971)
  > tracing: google grpc service support for ocagent/opencensus (#9955)
  > Add parsing for ASAN error stack output. (#10069)
  > Update Datadog tracer version to v1.1.3 (#10077)
  > Rewriting HeaderString to use absl::variant. See #9593 (#9952)
  > dns resolver: invoke resolve callback if not cancelled (#10060)
  > Tools: group spelling files under new folder in tools (#10065)
  > fuzz: Add dictionary support to fuzzers and package for OSS-Fuzz (#9720)
  > [utility] redundant case insensitive comparisons (#10068)
  > kafka: 2.4.0 support - add support for new message types added in 2.4 (#10000)
  > Add upstream and downstream info in parent read callbacks in tcp too (#9949)
  > http: only convert host -> :authority for request headers (#10039)
  > docs: fix reference configurations example (#10062)
  > docs: fix yaml indentation (#10067)
  > Use zero copy gRPC frame protector for TSI socket (#9957)
  > Fixes proxy_protocol_test failures under gcc due to the order in which destrcutors are called. (#10052)
  > network filters: use new style names (#10043)
  > tls: follow dns matching semantics in match subject alt names (#10005)
  > Tools: group code formatting files under new folder in tools (#9978)
  > docs: fix incorrect description (#10045)
  > Typo fixes in gRPC-JSON Transcoder example (#10031)
  > docs: Clarify meaning of per_try_timeout. (#10029)
  > matcher: add PathMatcher and use in routing, jwt and rbac (#10010)
  > http: split header decoding into concrete types (#10001)
```