### PR TITLE
Update to Envoy HEAD

### DIFF
--- a/.github/workflows/envoy.yml
+++ b/.github/workflows/envoy.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Check Envoy submodule status
       shell: bash
       run: |
-        git submodule status envoy
+        git submodule summary envoy
         git rev-parse HEAD
     - name: Configure docker IPv6
       shell: bash

--- a/envoy_build_config/extensions_build_config.bzl
+++ b/envoy_build_config/extensions_build_config.bzl
@@ -1,6 +1,5 @@
 # See bazel/README.md for details on how this system works.
 EXTENSIONS = {
-
     #
     # Access loggers
     #
@@ -12,6 +11,8 @@ EXTENSIONS = {
     #
     # Clusters
     #
+
+    "envoy.clusters.aggregate":                         "@envoy//source/extensions/clusters/aggregate:cluster",
     "envoy.clusters.dynamic_forward_proxy":             "@envoy//source/extensions/clusters/dynamic_forward_proxy:cluster",
     "envoy.clusters.redis":                             "@envoy//source/extensions/clusters/redis:redis_cluster",
 
@@ -35,6 +36,7 @@ EXTENSIONS = {
     "envoy.filters.http.adaptive_concurrency":          "@envoy//source/extensions/filters/http/adaptive_concurrency:config",
     "envoy.filters.http.aws_request_signing":           "@envoy_openssl//source/extensions/filters/http/aws_request_signing:config",
     "envoy.filters.http.buffer":                        "@envoy//source/extensions/filters/http/buffer:config",
+    "envoy.filters.http.cache":                         "@envoy//source/extensions/filters/http/cache:config",
     "envoy.filters.http.cors":                          "@envoy//source/extensions/filters/http/cors:config",
     "envoy.filters.http.csrf":                          "@envoy//source/extensions/filters/http/csrf:config",
     "envoy.filters.http.dynamic_forward_proxy":         "@envoy//source/extensions/filters/http/dynamic_forward_proxy:config",
@@ -52,6 +54,7 @@ EXTENSIONS = {
     "envoy.filters.http.ip_tagging":                    "@envoy//source/extensions/filters/http/ip_tagging:config",
     "envoy.filters.http.jwt_authn":                     "@envoy//source/extensions/filters/http/jwt_authn:config",
     "envoy.filters.http.lua":                           "@envoy_openssl//source/extensions/filters/http/lua:config",
+    "envoy.filters.http.on_demand":                     "@envoy//source/extensions/filters/http/on_demand:config",
     "envoy.filters.http.original_src":                  "@envoy//source/extensions/filters/http/original_src:config",
     "envoy.filters.http.ratelimit":                     "@envoy//source/extensions/filters/http/ratelimit:config",
     "envoy.filters.http.rbac":                          "@envoy//source/extensions/filters/http/rbac:config",
@@ -82,9 +85,9 @@ EXTENSIONS = {
     "envoy.filters.network.echo":                       "@envoy//source/extensions/filters/network/echo:config",
     "envoy.filters.network.ext_authz":                  "@envoy//source/extensions/filters/network/ext_authz:config",
     "envoy.filters.network.http_connection_manager":    "@envoy//source/extensions/filters/network/http_connection_manager:config",
-    # NOTE: Kafka filter does not have a proper filter implemented right now. We are referencing to
-    #       codec implementation that is going to be used by the filter.
-    "envoy.filters.network.kafka":                      "@envoy//source/extensions/filters/network/kafka:kafka_request_codec_lib",
+    # WiP
+    "envoy.filters.network.kafka_broker":               "@envoy//source/extensions/filters/network/kafka:kafka_broker_config_lib",
+    "envoy.filters.network.local_ratelimit":            "@envoy//source/extensions/filters/network/local_ratelimit:config",
     "envoy.filters.network.mongo_proxy":                "@envoy//source/extensions/filters/network/mongo_proxy:config",
     "envoy.filters.network.mysql_proxy":                "@envoy//source/extensions/filters/network/mysql_proxy:config",
     "envoy.filters.network.ratelimit":                  "@envoy//source/extensions/filters/network/ratelimit:config",
@@ -96,17 +99,22 @@ EXTENSIONS = {
     "envoy.filters.network.zookeeper_proxy":            "@envoy//source/extensions/filters/network/zookeeper_proxy:config",
 
     #
+    # UDP filters
+    #
+
+    "envoy.filters.udp_listener.udp_proxy":             "@envoy//source/extensions/filters/udp/udp_proxy:config",
+
+    #
+    # SSL
+    #
+    "envoy.common.crypto.utility_lib":                  "@envoy_openssl//source/extensions/common/crypto:utility_lib",
+
+    #
     # Resource monitors
     #
 
     "envoy.resource_monitors.fixed_heap":               "@envoy//source/extensions/resource_monitors/fixed_heap:config",
     "envoy.resource_monitors.injected_resource":        "@envoy//source/extensions/resource_monitors/injected_resource:config",
-
-    #
-    # SSL
-    #
-
-    "envoy.common.crypto.utility_lib":                  "@envoy_openssl//source/extensions/common/crypto:utility_lib",
 
     #
     # Stat sinks
@@ -133,6 +141,7 @@ EXTENSIONS = {
     "envoy.tracers.datadog":                            "@envoy//source/extensions/tracers/datadog:config",
     "envoy.tracers.zipkin":                             "@envoy//source/extensions/tracers/zipkin:config",
     "envoy.tracers.opencensus":                         "@envoy//source/extensions/tracers/opencensus:config",
+    # WiP
     "envoy.tracers.xray":                               "@envoy//source/extensions/tracers/xray:config",
 
     #
@@ -140,15 +149,29 @@ EXTENSIONS = {
     #
 
     "envoy.transport_sockets.alts":                     "@envoy//source/extensions/transport_sockets/alts:config",
+    "envoy.transport_sockets.raw_buffer":               "@envoy//source/extensions/transport_sockets/raw_buffer:config",
     "envoy.transport_sockets.tap":                      "@envoy//source/extensions/transport_sockets/tap:config",
     "envoy.transport_sockets.tls":                      "@envoy_openssl//source/extensions/transport_sockets/tls:config",
 
+    #
     # Retry host predicates
-    "envoy.retry_host_predicates.previous_hosts":          "@envoy//source/extensions/retry/host/previous_hosts:config",
-    "envoy.retry_host_predicates.omit_canary_hosts":            "@envoy//source/extensions/retry/host/omit_canary_hosts:config",
-    
+    #
+
+    "envoy.retry_host_predicates.previous_hosts":       "@envoy//source/extensions/retry/host/previous_hosts:config",
+    "envoy.retry_host_predicates.omit_canary_hosts":    "@envoy//source/extensions/retry/host/omit_canary_hosts:config",
+    "envoy.retry_host_predicates.omit_host_metadata":   "@envoy//source/extensions/retry/host/omit_host_metadata:config",
+
+    #
     # Retry priorities
+    #
+
     "envoy.retry_priorities.previous_priorities":       "@envoy//source/extensions/retry/priority/previous_priorities:config",
+
+    #
+    # CacheFilter plugins
+    #
+
+    "envoy.filters.http.cache.simple_http_cache":       "@envoy//source/extensions/filters/http/cache/simple_http_cache:simple_http_cache_lib",
 }
 
 WINDOWS_EXTENSIONS = {


### PR DESCRIPTION
```
* envoy a5c6d90...10d40f5 (32):
  > router: implement new regex_rewrite route action (#10050)
  > fix typo in route componenets proto (#10175)
  > Add server.memory_physical_bytes stats (#10156)
  > tracing: use X-Ray cluster_name if segment_name is not specified (#10149)
  > Add client capability for not supporting overprovisioning. (#10136)
  > route test tool: remove JSON schema references (#10170)
  > build: clean up absl external deps (#10157)
  > [api] [fuzz] fix many header related config fuzz bugs (#10093)
  >  server: expose flushStats() method  (#10097)
  > Metadata object is share across different clusters and hosts (#10042)
  > ext_authz: Deprecate LowerCaseStringMatcher (#9715)
  > stats: fix hot restart with real symbol tables, and dynamic stats (#9888)
  > Allow per_try_timeout when global route timeout is disabled. (#10082)
  > rbac: log requestedServerName in debug (#10123)
  > filter: Add CacheFilter: a pluggable HTTP caching filter (#10019)
  > Fix not passing enough arguments to logger (#10129)
  > fix uses of 'throw new' (#10116)
  > TestHeaderMapImplBase: avoid virtual call during construction (#10121)
  > Fix for MGET crash when upstream Redis Command Stats are enabled (#9954)
  > stats: remove comments/dead code related to name truncation (#10118)
  > config: merge DeltaSubscriptionImpl and GrpcSubscriptionImpl (#9892)
  > HTTP filter fuzzer base class and POC buffer filter fuzzer (#9400)
  > [http codec] case-insensetive transfer-encoding checks (#10055)
  > export locality to host_status in Admin/ cluster dump (#10109)
  > stack_decode.py: Adjust to work with Python < 3.7 (#10113)
  > squash: const member variables (#10114)
  > kafka: simplify declaration of ArrayDeserializer (#10074)
  > assertions: add new class of known issue assertions (#10015)
  > tools: add @yavlasov to maintainers in check_format.py for owned directories (#10115)
  > [tools] nuke LowerTable, use absl for lowercasing (#10101)
  > HTTP2: add error details on some NGHTTP2 errors. (#10006)
  > ci: mark coverage flaky and multiple attempts in CI (#10098)
```
Also, sync with Envoy's extensions_build_config.bzl.

Fixes: #24

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>