### PR TITLE
Update to Envoy HEAD

### DIFF
--- a/.azure-pipelines/linux.yaml
+++ b/.azure-pipelines/linux.yaml
@@ -28,8 +28,8 @@ jobs:
     matrix:
       dev:
         CI_TARGET: 'bazel.dev'
-      release:
-        CI_TARGET: 'bazel.release'
+      sizeopt:
+        CI_TARGET: 'bazel.sizeopt'
   timeoutInMinutes: 360
   pool:
     vmImage: 'Ubuntu 16.04'

--- a/.azure-pipelines/linux.yaml
+++ b/.azure-pipelines/linux.yaml
@@ -36,6 +36,12 @@ jobs:
   steps:
   - checkout: self
     submodules: true
+
+  - bash: |
+      echo "disk space at beginning of build:"
+      df -h
+    displayName: "Check disk space at beginning"
+
   - bash: |
       sudo mkdir -p /etc/docker
       echo '{
@@ -52,3 +58,9 @@ jobs:
       ENVOY_SRCDIR: "/source/envoy"
       BAZEL_BUILD_EXTRA_OPTIONS: "--curses=no"
     displayName: "Run CI script"
+
+  - bash: |
+      echo "disk space at end of build:"
+      df -h
+    displayName: "Check disk space at end"
+    condition: always()

--- a/.azure-pipelines/linux.yaml
+++ b/.azure-pipelines/linux.yaml
@@ -28,8 +28,6 @@ jobs:
     matrix:
       dev:
         CI_TARGET: 'bazel.dev'
-      sizeopt:
-        CI_TARGET: 'bazel.sizeopt'
   timeoutInMinutes: 360
   pool:
     vmImage: 'Ubuntu 16.04'

--- a/jwt_verify-make-compatible-with-openssl.patch
+++ b/jwt_verify-make-compatible-with-openssl.patch
@@ -1,4 +1,4 @@
-From e6c4e2327264ebe725ed4346a9f101087ae34fe2 Mon Sep 17 00:00:00 2001
+From 524cb52b23cd284f9f2c6c7db3b46bb2167cba4b Mon Sep 17 00:00:00 2001
 From: Venil Noronha <veniln@vmware.com>
 Date: Fri, 1 Nov 2019 10:10:10 -0700
 Subject: [PATCH] make compatible with openssl
@@ -7,12 +7,12 @@ Signed-off-by: Venil Noronha <veniln@vmware.com>
 ---
  BUILD                 |  2 ++
  jwt_verify_lib/jwks.h |  4 ++++
- src/jwks.cc           | 20 ++++++++++++++++----
+ src/jwks.cc           | 22 +++++++++++++++++-----
  src/verify.cc         | 13 +++++++++++--
- 4 files changed, 33 insertions(+), 6 deletions(-)
+ 4 files changed, 34 insertions(+), 7 deletions(-)
 
 diff --git a/BUILD b/BUILD
-index 96ba16c..43d1b4e 100644
+index 532dd5d..8d96da7 100644
 --- a/BUILD
 +++ b/BUILD
 @@ -27,6 +27,8 @@ cc_library(
@@ -25,7 +25,7 @@ index 96ba16c..43d1b4e 100644
  )
  
 diff --git a/jwt_verify_lib/jwks.h b/jwt_verify_lib/jwks.h
-index 6094e2b..3a5c478 100644
+index b77478b..f7293d4 100644
 --- a/jwt_verify_lib/jwks.h
 +++ b/jwt_verify_lib/jwks.h
 @@ -23,6 +23,10 @@
@@ -40,10 +40,10 @@ index 6094e2b..3a5c478 100644
  namespace jwt_verify {
  
 diff --git a/src/jwks.cc b/src/jwks.cc
-index e5d6c45..edf2caf 100644
+index 1aaecc4..4b5d4c2 100644
 --- a/src/jwks.cc
 +++ b/src/jwks.cc
-@@ -28,6 +28,11 @@
+@@ -30,6 +30,11 @@
  #include "openssl/rsa.h"
  #include "openssl/sha.h"
  
@@ -55,7 +55,7 @@ index e5d6c45..edf2caf 100644
  namespace google {
  namespace jwt_verify {
  
-@@ -124,18 +129,25 @@ class EvpPkeyGetter : public WithStatus {
+@@ -96,18 +101,25 @@ class KeyGetter : public WithStatus {
    bssl::UniquePtr<RSA> createRsaFromJwk(const std::string& n,
                                          const std::string& e) {
      bssl::UniquePtr<RSA> rsa(RSA_new());
@@ -84,9 +84,18 @@ index e5d6c45..edf2caf 100644
 +    }
      return rsa;
    }
- };
+ 
+@@ -404,7 +416,7 @@ void Jwks::createFromPemCore(const std::string& pkey_pem) {
+   }
+   assert(e.getStatus() == Status::Ok);
+ 
+-  switch (EVP_PKEY_type(evp_pkey->type)) {
++  switch (EVP_PKEY_base_id(evp_pkey.get())) {
+     case EVP_PKEY_RSA:
+       key_ptr->rsa_.reset(EVP_PKEY_get1_RSA(evp_pkey.get()));
+       key_ptr->kty_ = "RSA";
 diff --git a/src/verify.cc b/src/verify.cc
-index 4d26c25..10fb175 100644
+index e2fdd7a..70bf556 100644
 --- a/src/verify.cc
 +++ b/src/verify.cc
 @@ -22,7 +22,13 @@
@@ -103,7 +112,7 @@ index 4d26c25..10fb175 100644
  #include "openssl/rsa.h"
  #include "openssl/sha.h"
  
-@@ -91,9 +97,12 @@ bool verifySignatureEC(EC_KEY* key, const EVP_MD* md, const uint8_t* signature,
+@@ -95,9 +101,12 @@ bool verifySignatureEC(EC_KEY* key, const EVP_MD* md, const uint8_t* signature,
      return false;
    }
  

--- a/source/extensions/common/aws/signer.h
+++ b/source/extensions/common/aws/signer.h
@@ -26,6 +26,14 @@ public:
    * @throws EnvoyException if the request cannot be signed.
    */
   virtual void sign(Http::RequestHeaderMap& headers) PURE;
+
+  /**
+   * Sign an AWS request.
+   * @param headers AWS API request headers.
+   * @param content_hash The Hex encoded SHA-256 of the body of the AWS API request.
+   * @throws EnvoyException if the request cannot be signed.
+   */
+  virtual void sign(Http::RequestHeaderMap& headers, const std::string& content_hash) PURE;
 };
 
 using SignerPtr = std::unique_ptr<Signer>;

--- a/source/extensions/common/aws/signer_impl.cc
+++ b/source/extensions/common/aws/signer_impl.cc
@@ -24,10 +24,20 @@ void SignerImpl::sign(Http::RequestMessage& message, bool sign_body) {
 }
 
 void SignerImpl::sign(Http::RequestHeaderMap& headers) {
-  sign(headers, SignatureConstants::get().HashedEmptyString);
+  // S3 payloads require special treatment.
+  if (service_name_ == "s3") {
+    headers.setReference(SignatureHeaders::get().ContentSha256,
+                         SignatureConstants::get().UnsignedPayload);
+    sign(headers, SignatureConstants::get().UnsignedPayload);
+  } else {
+    headers.setReference(SignatureHeaders::get().ContentSha256,
+                         SignatureConstants::get().HashedEmptyString);
+    sign(headers, SignatureConstants::get().HashedEmptyString);
+  }
 }
 
 void SignerImpl::sign(Http::RequestHeaderMap& headers, const std::string& content_hash) {
+  headers.setReferenceKey(SignatureHeaders::get().ContentSha256, content_hash);
   const auto& credentials = credentials_provider_->getCredentials();
   if (!credentials.accessKeyId() || !credentials.secretAccessKey()) {
     // Empty or "anonymous" credentials are a valid use-case for non-production environments.
@@ -76,7 +86,6 @@ std::string SignerImpl::createContentHash(Http::RequestMessage& message, bool si
   const auto content_hash = message.body()
                                 ? Hex::encode(crypto_util.getSha256Digest(*message.body()))
                                 : SignatureConstants::get().HashedEmptyString;
-  message.headers().addCopy(SignatureHeaders::get().ContentSha256, content_hash);
   return content_hash;
 }
 

--- a/source/extensions/common/aws/signer_impl.h
+++ b/source/extensions/common/aws/signer_impl.h
@@ -34,6 +34,7 @@ public:
 
   const std::string LongDateFormat{"%Y%m%dT%H%M00Z"};
   const std::string ShortDateFormat{"%Y%m%d"};
+  const std::string UnsignedPayload{"UNSIGNED-PAYLOAD"};
 };
 
 using SignatureConstants = ConstSingleton<SignatureConstantValues>;
@@ -69,7 +70,7 @@ private:
                                         const std::map<std::string, std::string>& canonical_headers,
                                         absl::string_view signature) const;
 
-  void sign(Http::RequestHeaderMap& headers, const std::string& content_hash);
+  void sign(Http::RequestHeaderMap& headers, const std::string& content_hash) override;
 
   const std::string service_name_;
   const std::string region_;

--- a/source/extensions/common/aws/utility.cc
+++ b/source/extensions/common/aws/utility.cc
@@ -11,7 +11,8 @@ namespace Extensions {
 namespace Common {
 namespace Aws {
 
-std::map<std::string, std::string> Utility::canonicalizeHeaders(const Http::HeaderMap& headers) {
+std::map<std::string, std::string>
+Utility::canonicalizeHeaders(const Http::RequestHeaderMap& headers) {
   std::map<std::string, std::string> out;
   headers.iterate(
       [](const Http::HeaderEntry& entry, void* context) -> Http::HeaderMap::Iterate {
@@ -24,6 +25,13 @@ std::map<std::string, std::string> Utility::canonicalizeHeaders(const Http::Head
         if (!entry.key().getStringView().empty() && entry.key().getStringView()[0] == ':') {
           return Http::HeaderMap::Iterate::Continue;
         }
+        // Skip headers that are likely to mutate, when crossing proxies
+        const auto key = entry.key().getStringView();
+        if (key == Http::Headers::get().ForwardedFor.get() ||
+            key == Http::Headers::get().ForwardedProto.get()) {
+          return Http::HeaderMap::Iterate::Continue;
+        }
+
         std::string value(entry.value().getStringView());
         // Remove leading, trailing, and deduplicate repeated ascii spaces
         absl::RemoveExtraAsciiWhitespace(&value);

--- a/source/extensions/common/aws/utility.h
+++ b/source/extensions/common/aws/utility.h
@@ -15,7 +15,8 @@ public:
    * @param headers a header map to canonicalize.
    * @return a std::map of canonicalized headers to be used in building a canonical request.
    */
-  static std::map<std::string, std::string> canonicalizeHeaders(const Http::HeaderMap& headers);
+  static std::map<std::string, std::string>
+  canonicalizeHeaders(const Http::RequestHeaderMap& headers);
 
   /**
    * Creates an AWS Signature V4 canonical request string.

--- a/source/extensions/filters/http/aws_request_signing/aws_request_signing_filter.cc
+++ b/source/extensions/filters/http/aws_request_signing/aws_request_signing_filter.cc
@@ -8,8 +8,10 @@ namespace HttpFilters {
 namespace AwsRequestSigningFilter {
 
 FilterConfigImpl::FilterConfigImpl(Extensions::Common::Aws::SignerPtr&& signer,
-                                   const std::string& stats_prefix, Stats::Scope& scope)
-    : signer_(std::move(signer)), stats_(Filter::generateStats(stats_prefix, scope)) {}
+                                   const std::string& stats_prefix, Stats::Scope& scope,
+                                   const std::string& host_rewrite)
+    : signer_(std::move(signer)), stats_(Filter::generateStats(stats_prefix, scope)),
+      host_rewrite_(host_rewrite) {}
 
 Filter::Filter(const std::shared_ptr<FilterConfig>& config) : config_(config) {}
 
@@ -17,12 +19,19 @@ Extensions::Common::Aws::Signer& FilterConfigImpl::signer() { return *signer_; }
 
 FilterStats& FilterConfigImpl::stats() { return stats_; }
 
+const std::string& FilterConfigImpl::hostRewrite() const { return host_rewrite_; }
+
 FilterStats Filter::generateStats(const std::string& prefix, Stats::Scope& scope) {
   const std::string final_prefix = prefix + "aws_request_signing.";
   return {ALL_AWS_REQUEST_SIGNING_FILTER_STATS(POOL_COUNTER_PREFIX(scope, final_prefix))};
 }
 
 Http::FilterHeadersStatus Filter::decodeHeaders(Http::RequestHeaderMap& headers, bool) {
+  const auto& host_rewrite = config_->hostRewrite();
+  if (!host_rewrite.empty()) {
+    headers.setHost(host_rewrite);
+  }
+
   try {
     config_->signer().sign(headers);
     config_->stats().signing_added_.inc();

--- a/source/extensions/filters/http/aws_request_signing/aws_request_signing_filter.h
+++ b/source/extensions/filters/http/aws_request_signing/aws_request_signing_filter.h
@@ -45,6 +45,11 @@ public:
    * @return the filter stats.
    */
   virtual FilterStats& stats() PURE;
+
+  /**
+   * @return the host rewrite value.
+   */
+  virtual const std::string& hostRewrite() const PURE;
 };
 
 using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
@@ -55,14 +60,16 @@ using FilterConfigSharedPtr = std::shared_ptr<FilterConfig>;
 class FilterConfigImpl : public FilterConfig {
 public:
   FilterConfigImpl(Extensions::Common::Aws::SignerPtr&& signer, const std::string& stats_prefix,
-                   Stats::Scope& scope);
+                   Stats::Scope& scope, const std::string& host_rewrite);
 
   Extensions::Common::Aws::Signer& signer() override;
   FilterStats& stats() override;
+  const std::string& hostRewrite() const override;
 
 private:
   Extensions::Common::Aws::SignerPtr signer_;
   FilterStats stats_;
+  std::string host_rewrite_;
 };
 
 /**

--- a/source/extensions/filters/http/aws_request_signing/config.cc
+++ b/source/extensions/filters/http/aws_request_signing/config.cc
@@ -25,8 +25,8 @@ Http::FilterFactoryCb AwsRequestSigningFilterFactory::createFilterFactoryFromPro
       config.service_name(), config.region(), credentials_provider,
       context.dispatcher().timeSource());
 
-  auto filter_config =
-      std::make_shared<FilterConfigImpl>(std::move(signer), stats_prefix, context.scope());
+  auto filter_config = std::make_shared<FilterConfigImpl>(std::move(signer), stats_prefix,
+                                                          context.scope(), config.host_rewrite());
   return [filter_config](Http::FilterChainFactoryCallbacks& callbacks) -> void {
     auto filter = std::make_shared<Filter>(filter_config);
     callbacks.addStreamDecoderFilter(filter);

--- a/source/extensions/filters/http/lua/BUILD
+++ b/source/extensions/filters/http/lua/BUILD
@@ -26,6 +26,7 @@ envoy_cc_library(
         "@envoy//source/common/common:enum_to_int",
         "@envoy//source/common/crypto:utility_lib",
         "@envoy//source/common/http:message_lib",
+        "@envoy//source/extensions/common:utility_lib",
         "@envoy//source/extensions/filters/common/lua:lua_lib",
         "@envoy//source/extensions/filters/common/lua:wrappers_lib",
         "@envoy//source/extensions/filters/http:well_known_names",

--- a/source/extensions/filters/http/lua/config.cc
+++ b/source/extensions/filters/http/lua/config.cc
@@ -24,7 +24,7 @@ Http::FilterFactoryCb LuaFilterConfig::createFilterFactoryFromProtoTyped(
 /**
  * Static registration for the Lua filter. @see RegisterFactory.
  */
-REGISTER_FACTORY(LuaFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory);
+REGISTER_FACTORY(LuaFilterConfig, Server::Configuration::NamedHttpFilterConfigFactory){"envoy.lua"};
 
 } // namespace Lua
 } // namespace HttpFilters

--- a/source/extensions/filters/http/lua/config.h
+++ b/source/extensions/filters/http/lua/config.h
@@ -14,8 +14,7 @@ namespace Lua {
 /**
  * Config registration for the Lua filter. @see NamedHttpFilterConfigFactory.
  */
-class LuaFilterConfig
-    : public Common::FactoryBase<envoy::extensions::filters::http::lua::v3::Lua> {
+class LuaFilterConfig : public Common::FactoryBase<envoy::extensions::filters::http::lua::v3::Lua> {
 public:
   LuaFilterConfig() : FactoryBase(HttpFilterNames::get().Lua) {}
 

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -1,5 +1,6 @@
 #include "extensions/filters/http/lua/lua_filter.h"
 
+#include <atomic>
 #include <memory>
 
 #include "envoy/http/codes.h"
@@ -14,6 +15,130 @@ namespace Envoy {
 namespace Extensions {
 namespace HttpFilters {
 namespace Lua {
+
+namespace {
+
+const std::string DEPRECATED_LUA_NAME = "envoy.lua";
+
+std::atomic<bool>& deprecatedNameLogged() {
+  MUTABLE_CONSTRUCT_ON_FIRST_USE(std::atomic<bool>, false);
+}
+
+// Checks if deprecated metadata names are allowed. On the first check only it will log either
+// a warning (indicating the name should be updated) or an error (the feature is off and the
+// name is not allowed). When warning, the deprecated feature stat is incremented. Subsequent
+// checks do not log since this check is done in potentially high-volume request paths.
+bool allowDeprecatedMetadataName() {
+  if (!deprecatedNameLogged().exchange(true)) {
+    // Have not logged yet, so use the logging test.
+    return Extensions::Common::Utility::ExtensionNameUtil::allowDeprecatedExtensionName(
+        "http filter", DEPRECATED_LUA_NAME, Extensions::HttpFilters::HttpFilterNames::get().Lua);
+  }
+
+  // We have logged (or another thread will do so momentarily), so just check whether the
+  // deprecated name is allowed.
+  auto status = Extensions::Common::Utility::ExtensionNameUtil::deprecatedExtensionNameStatus();
+  return status == Extensions::Common::Utility::ExtensionNameUtil::Status::Warn;
+}
+
+const ProtobufWkt::Struct& getMetadata(Http::StreamFilterCallbacks* callbacks) {
+  if (callbacks->route() == nullptr || callbacks->route()->routeEntry() == nullptr) {
+    return ProtobufWkt::Struct::default_instance();
+  }
+  const auto& metadata = callbacks->route()->routeEntry()->metadata();
+
+  {
+    const auto& filter_it = metadata.filter_metadata().find(HttpFilterNames::get().Lua);
+    if (filter_it != metadata.filter_metadata().end()) {
+      return filter_it->second;
+    }
+  }
+
+  // TODO(zuercher): Remove this block when deprecated filter names are removed.
+  {
+    const auto& filter_it = metadata.filter_metadata().find(DEPRECATED_LUA_NAME);
+    if (filter_it != metadata.filter_metadata().end()) {
+      // Use the non-throwing check here because this happens at request time.
+      if (allowDeprecatedMetadataName()) {
+        return filter_it->second;
+      }
+    }
+  }
+
+  return ProtobufWkt::Struct::default_instance();
+}
+
+// Okay to return non-const reference because this doesn't ever get changed.
+NoopCallbacks& noopCallbacks() {
+  static NoopCallbacks* callbacks = new NoopCallbacks();
+  return *callbacks;
+}
+
+void buildHeadersFromTable(Http::HeaderMap& headers, lua_State* state, int table_index) {
+  // Build a header map to make the request. We iterate through the provided table to do this and
+  // check that we are getting strings.
+  lua_pushnil(state);
+  while (lua_next(state, table_index) != 0) {
+    // Uses 'key' (at index -2) and 'value' (at index -1).
+    const char* key = luaL_checkstring(state, -2);
+    // Check if the current value is a table, we iterate through the table and add each element of
+    // it as a header entry value for the current key.
+    if (lua_istable(state, -1)) {
+      lua_pushnil(state);
+      while (lua_next(state, -2) != 0) {
+        const char* value = luaL_checkstring(state, -1);
+        headers.addCopy(Http::LowerCaseString(key), value);
+        lua_pop(state, 1);
+      }
+    } else {
+      const char* value = luaL_checkstring(state, -1);
+      headers.addCopy(Http::LowerCaseString(key), value);
+    }
+    // Removes 'value'; keeps 'key' for next iteration. This is the input for lua_next() so that
+    // it can push the next key/value pair onto the stack.
+    lua_pop(state, 1);
+  }
+}
+
+Http::AsyncClient::Request* makeHttpCall(lua_State* state, Filter& filter,
+                                         Http::AsyncClient::Callbacks& callbacks) {
+  const std::string cluster = luaL_checkstring(state, 2);
+  luaL_checktype(state, 3, LUA_TTABLE);
+  size_t body_size;
+  const char* body = luaL_optlstring(state, 4, nullptr, &body_size);
+  int timeout_ms = luaL_checkint(state, 5);
+  if (timeout_ms < 0) {
+    luaL_error(state, "http call timeout must be >= 0");
+  }
+
+  if (filter.clusterManager().get(cluster) == nullptr) {
+    luaL_error(state, "http call cluster invalid. Must be configured");
+  }
+
+  auto headers = std::make_unique<Http::RequestHeaderMapImpl>();
+  buildHeadersFromTable(*headers, state, 3);
+  Http::RequestMessagePtr message(new Http::RequestMessageImpl(std::move(headers)));
+
+  // Check that we were provided certain headers.
+  if (message->headers().Path() == nullptr || message->headers().Method() == nullptr ||
+      message->headers().Host() == nullptr) {
+    luaL_error(state, "http call headers must include ':path', ':method', and ':authority'");
+  }
+
+  if (body != nullptr) {
+    message->body() = std::make_unique<Buffer::OwnedImpl>(body, body_size);
+    message->headers().setContentLength(body_size);
+  }
+
+  absl::optional<std::chrono::milliseconds> timeout;
+  if (timeout_ms > 0) {
+    timeout = std::chrono::milliseconds(timeout_ms);
+  }
+
+  return filter.clusterManager().httpAsyncClientForCluster(cluster).send(
+      std::move(message), callbacks, Http::AsyncClient::RequestOptions().setTimeout(timeout));
+}
+} // namespace
 
 StreamHandleWrapper::StreamHandleWrapper(Filters::Common::Lua::Coroutine& coroutine,
                                          Http::HeaderMap& headers, bool end_stream, Filter& filter,
@@ -138,71 +263,23 @@ int StreamHandleWrapper::luaRespond(lua_State* state) {
   return lua_yield(state, 0);
 }
 
-void StreamHandleWrapper::buildHeadersFromTable(Http::HeaderMap& headers, lua_State* state,
-                                                int table_index) {
-  // Build a header map to make the request. We iterate through the provided table to do this and
-  // check that we are getting strings.
-  lua_pushnil(state);
-  while (lua_next(state, table_index) != 0) {
-    // Uses 'key' (at index -2) and 'value' (at index -1).
-    const char* key = luaL_checkstring(state, -2);
-    // Check if the current value is a table, we iterate through the table and add each element of
-    // it as a header entry value for the current key.
-    if (lua_istable(state, -1)) {
-      lua_pushnil(state);
-      while (lua_next(state, -2) != 0) {
-        const char* value = luaL_checkstring(state, -1);
-        headers.addCopy(Http::LowerCaseString(key), value);
-        lua_pop(state, 1);
-      }
-    } else {
-      const char* value = luaL_checkstring(state, -1);
-      headers.addCopy(Http::LowerCaseString(key), value);
-    }
-    // Removes 'value'; keeps 'key' for next iteration. This is the input for lua_next() so that
-    // it can push the next key/value pair onto the stack.
-    lua_pop(state, 1);
-  }
-}
-
 int StreamHandleWrapper::luaHttpCall(lua_State* state) {
   ASSERT(state_ == State::Running);
 
-  const std::string cluster = luaL_checkstring(state, 2);
-  luaL_checktype(state, 3, LUA_TTABLE);
-  size_t body_size;
-  const char* body = luaL_optlstring(state, 4, nullptr, &body_size);
-  int timeout_ms = luaL_checkint(state, 5);
-  if (timeout_ms < 0) {
-    return luaL_error(state, "http call timeout must be >= 0");
+  const int async_flag_index = 6;
+  if (!lua_isnone(state, async_flag_index) && !lua_isboolean(state, async_flag_index)) {
+    luaL_error(state, "http call asynchronous flag must be 'true', 'false', or empty");
   }
 
-  if (filter_.clusterManager().get(cluster) == nullptr) {
-    return luaL_error(state, "http call cluster invalid. Must be configured");
+  if (lua_toboolean(state, async_flag_index)) {
+    return luaHttpCallAsynchronous(state);
+  } else {
+    return luaHttpCallSynchronous(state);
   }
+}
 
-  auto headers = std::make_unique<Http::RequestHeaderMapImpl>();
-  buildHeadersFromTable(*headers, state, 3);
-  Http::RequestMessagePtr message(new Http::RequestMessageImpl(std::move(headers)));
-
-  // Check that we were provided certain headers.
-  if (message->headers().Path() == nullptr || message->headers().Method() == nullptr ||
-      message->headers().Host() == nullptr) {
-    return luaL_error(state, "http call headers must include ':path', ':method', and ':authority'");
-  }
-
-  if (body != nullptr) {
-    message->body() = std::make_unique<Buffer::OwnedImpl>(body, body_size);
-    message->headers().setContentLength(body_size);
-  }
-
-  absl::optional<std::chrono::milliseconds> timeout;
-  if (timeout_ms > 0) {
-    timeout = std::chrono::milliseconds(timeout_ms);
-  }
-
-  http_request_ = filter_.clusterManager().httpAsyncClientForCluster(cluster).send(
-      std::move(message), *this, Http::AsyncClient::RequestOptions().setTimeout(timeout));
+int StreamHandleWrapper::luaHttpCallSynchronous(lua_State* state) {
+  http_request_ = makeHttpCall(state, filter_, *this);
   if (http_request_) {
     state_ = State::HttpCall;
     return lua_yield(state, 0);
@@ -211,6 +288,11 @@ int StreamHandleWrapper::luaHttpCall(lua_State* state) {
     ASSERT(lua_gettop(state) >= 2);
     return 2;
   }
+}
+
+int StreamHandleWrapper::luaHttpCallAsynchronous(lua_State* state) {
+  makeHttpCall(state, filter_, noopCallbacks());
+  return 0;
 }
 
 void StreamHandleWrapper::onSuccess(Http::ResponseMessagePtr&& response) {
@@ -457,7 +539,7 @@ int StreamHandleWrapper::luaVerifySignature(lua_State* state) {
   int text_len = luaL_checknumber(state, 7);
   const std::vector<uint8_t> text_vec(clear_text, clear_text + text_len);
   // Step 5: verify signature
-  auto crypto = reinterpret_cast<Common::Crypto::CryptoObject*>(ptr);
+  auto crypto = reinterpret_cast<Envoy::Common::Crypto::CryptoObject*>(ptr);
   auto& crypto_util = Envoy::Common::Crypto::UtilitySingleton::get();
   auto output = crypto_util.verifySignature(hash, *crypto, sig_vec, text_vec);
   lua_pushboolean(state, output.result_);
@@ -478,7 +560,7 @@ int StreamHandleWrapper::luaImportPublicKey(lua_State* state) {
     public_key_wrapper_.pushStack();
   } else {
     auto& crypto_util = Envoy::Common::Crypto::UtilitySingleton::get();
-    Common::Crypto::CryptoObjectPtr crypto_ptr = crypto_util.importPublicKey(key);
+    Envoy::Common::Crypto::CryptoObjectPtr crypto_ptr = crypto_util.importPublicKey(key);
     public_key_wrapper_.reset(PublicKeyWrapper::create(state, std::move(crypto_ptr)), true);
   }
 
@@ -616,11 +698,19 @@ void Filter::DecoderCallbacks::respond(Http::ResponseHeaderMapPtr&& headers, Buf
   }
 }
 
+const ProtobufWkt::Struct& Filter::DecoderCallbacks::metadata() const {
+  return getMetadata(callbacks_);
+}
+
 void Filter::EncoderCallbacks::respond(Http::ResponseHeaderMapPtr&&, Buffer::Instance*,
                                        lua_State* state) {
   // TODO(mattklein123): Support response in response path if nothing has been continued
   // yet.
   luaL_error(state, "respond not currently supported in the response path");
+}
+
+const ProtobufWkt::Struct& Filter::EncoderCallbacks::metadata() const {
+  return getMetadata(callbacks_);
 }
 
 } // namespace Lua

--- a/source/extensions/filters/listener/tls_inspector/config.cc
+++ b/source/extensions/filters/listener/tls_inspector/config.cc
@@ -40,7 +40,8 @@ public:
  * Static registration for the TLS inspector filter. @see RegisterFactory.
  */
 REGISTER_FACTORY(TlsInspectorConfigFactory,
-                 Server::Configuration::NamedListenerFilterConfigFactory);
+                 Server::Configuration::NamedListenerFilterConfigFactory){
+    "envoy.listener.tls_inspector"};
 
 } // namespace TlsInspector
 } // namespace ListenerFilters

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "envoy/common/exception.h"
+#include "envoy/common/platform.h"
 #include "envoy/event/dispatcher.h"
 #include "envoy/network/listen_socket.h"
 #include "envoy/stats/scope.h"

--- a/source/extensions/transport_sockets/tls/BUILD
+++ b/source/extensions/transport_sockets/tls/BUILD
@@ -33,6 +33,8 @@ envoy_cc_library(
     srcs = ["ssl_socket.cc"],
     hdrs = ["ssl_socket.h"],
     external_deps = [
+        "abseil_hash",
+        "abseil_node_hash_map",
         "abseil_synchronization",
         "ssl",
     ],
@@ -128,6 +130,7 @@ envoy_cc_library(
         ":openssl_impl_lib",
         "@envoy//source/common/common:assert_lib",
         "@envoy//source/common/common:utility_lib",
+        "@envoy//source/common/network:address_lib",
         "//boringssl_compat:bssl_compat_lib",
     ],
 )

--- a/source/extensions/transport_sockets/tls/context_config_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_config_impl.cc
@@ -80,24 +80,23 @@ Secret::CertificateValidationContextConfigProviderSharedPtr
 getCertificateValidationContextConfigProvider(
     const envoy::extensions::transport_sockets::tls::v3::CommonTlsContext& config,
     Server::Configuration::TransportSocketFactoryContext& factory_context,
-    std::unique_ptr<
-        envoy::extensions::transport_sockets::tls::v3::CertificateValidationContext>*
+    std::unique_ptr<envoy::extensions::transport_sockets::tls::v3::CertificateValidationContext>*
         default_cvc) {
   switch (config.validation_context_type_case()) {
-  case envoy::extensions::transport_sockets::tls::v3::CommonTlsContext::
-      ValidationContextTypeCase::kValidationContext: {
+  case envoy::extensions::transport_sockets::tls::v3::CommonTlsContext::ValidationContextTypeCase::
+      kValidationContext: {
     auto secret_provider =
         factory_context.secretManager().createInlineCertificateValidationContextProvider(
             config.validation_context());
     return secret_provider;
   }
-  case envoy::extensions::transport_sockets::tls::v3::CommonTlsContext::
-      ValidationContextTypeCase::kValidationContextSdsSecretConfig: {
+  case envoy::extensions::transport_sockets::tls::v3::CommonTlsContext::ValidationContextTypeCase::
+      kValidationContextSdsSecretConfig: {
     const auto& sds_secret_config = config.validation_context_sds_secret_config();
     return getProviderFromSds(factory_context, sds_secret_config);
   }
-  case envoy::extensions::transport_sockets::tls::v3::CommonTlsContext::
-      ValidationContextTypeCase::kCombinedValidationContext: {
+  case envoy::extensions::transport_sockets::tls::v3::CommonTlsContext::ValidationContextTypeCase::
+      kCombinedValidationContext: {
     *default_cvc = std::make_unique<
         envoy::extensions::transport_sockets::tls::v3::CertificateValidationContext>(
         config.combined_validation_context().default_validation_context());
@@ -167,34 +166,39 @@ ContextConfigImpl::ContextConfigImpl(
                                                 default_min_protocol_version)),
       max_protocol_version_(tlsVersionFromProto(config.tls_params().tls_maximum_protocol_version(),
                                                 default_max_protocol_version)) {
-  if (default_cvc_ && certificate_validation_context_provider_ != nullptr) {
-    // We need to validate combined certificate validation context.
-    // The default certificate validation context and dynamic certificate validation
-    // context could only contain partial fields, which is okay to fail the validation.
-    // But the combined certificate validation context should pass validation. If
-    // validation of combined certificate validation context fails,
-    // getCombinedValidationContextConfig() throws exception, validation_context_config_ will not
-    // get updated.
-    cvc_validation_callback_handle_ =
-        certificate_validation_context_provider_->addValidationCallback(
-            [this](const envoy::extensions::transport_sockets::tls::v3::
-                       CertificateValidationContext& dynamic_cvc) {
-              getCombinedValidationContextConfig(dynamic_cvc);
-            });
+  if (certificate_validation_context_provider_ != nullptr) {
+    if (default_cvc_) {
+      // We need to validate combined certificate validation context.
+      // The default certificate validation context and dynamic certificate validation
+      // context could only contain partial fields, which is okay to fail the validation.
+      // But the combined certificate validation context should pass validation. If
+      // validation of combined certificate validation context fails,
+      // getCombinedValidationContextConfig() throws exception, validation_context_config_ will not
+      // get updated.
+      cvc_validation_callback_handle_ =
+          certificate_validation_context_provider_->addValidationCallback(
+              [this](
+                  const envoy::extensions::transport_sockets::tls::v3::CertificateValidationContext&
+                      dynamic_cvc) { getCombinedValidationContextConfig(dynamic_cvc); });
+    }
+    // Load inlined, static or dynamic secret that's already available.
+    if (certificate_validation_context_provider_->secret() != nullptr) {
+      if (default_cvc_) {
+        validation_context_config_ =
+            getCombinedValidationContextConfig(*certificate_validation_context_provider_->secret());
+      } else {
+        validation_context_config_ = std::make_unique<Ssl::CertificateValidationContextConfigImpl>(
+            *certificate_validation_context_provider_->secret(), api_);
+      }
+    }
   }
-  // Load inline or static secret into tls_certificate_config_.
+  // Load inlined, static or dynamic secrets that are already available.
   if (!tls_certificate_providers_.empty()) {
     for (auto& provider : tls_certificate_providers_) {
       if (provider->secret() != nullptr) {
         tls_certificate_configs_.emplace_back(*provider->secret(), &factory_context, api_);
       }
     }
-  }
-  // Load inline or static secret into validation_context_config_.
-  if (certificate_validation_context_provider_ != nullptr &&
-      certificate_validation_context_provider_->secret() != nullptr) {
-    validation_context_config_ = std::make_unique<Ssl::CertificateValidationContextConfigImpl>(
-        *certificate_validation_context_provider_->secret(), api_);
   }
 }
 
@@ -360,16 +364,13 @@ ServerContextConfigImpl::ServerContextConfigImpl(
   if (session_ticket_keys_provider_ != nullptr) {
     // Validate tls session ticket keys early to reject bad sds updates.
     stk_validation_callback_handle_ = session_ticket_keys_provider_->addValidationCallback(
-        [this](
-            const envoy::extensions::transport_sockets::tls::v3::TlsSessionTicketKeys& keys) {
+        [this](const envoy::extensions::transport_sockets::tls::v3::TlsSessionTicketKeys& keys) {
           getSessionTicketKeys(keys);
         });
-  }
-
-  // Load inline or static secrets.
-  if (session_ticket_keys_provider_ != nullptr &&
-      session_ticket_keys_provider_->secret() != nullptr) {
-    session_ticket_keys_ = getSessionTicketKeys(*session_ticket_keys_provider_->secret());
+    // Load inlined, static or dynamic secret that's already available.
+    if (session_ticket_keys_provider_->secret() != nullptr) {
+      session_ticket_keys_ = getSessionTicketKeys(*session_ticket_keys_provider_->secret());
+    }
   }
 
   if ((config.common_tls_context().tls_certificates().size() +

--- a/source/extensions/transport_sockets/tls/context_config_impl.h
+++ b/source/extensions/transport_sockets/tls/context_config_impl.h
@@ -61,11 +61,11 @@ public:
           dynamic_cvc);
 
 protected:
-  ContextConfigImpl(
-      const envoy::extensions::transport_sockets::tls::v3::CommonTlsContext& config,
-      const unsigned default_min_protocol_version, const unsigned default_max_protocol_version,
-      const std::string& default_cipher_suites, const std::string& default_curves,
-      Server::Configuration::TransportSocketFactoryContext& factory_context);
+  ContextConfigImpl(const envoy::extensions::transport_sockets::tls::v3::CommonTlsContext& config,
+                    const unsigned default_min_protocol_version,
+                    const unsigned default_max_protocol_version,
+                    const std::string& default_cipher_suites, const std::string& default_curves,
+                    Server::Configuration::TransportSocketFactoryContext& factory_context);
   Api::Api& api_;
 
 private:
@@ -86,12 +86,12 @@ private:
       default_cvc_;
   std::vector<Secret::TlsCertificateConfigProviderSharedPtr> tls_certificate_providers_;
   // Handle for TLS certificate dynamic secret callback.
-  Common::CallbackHandle* tc_update_callback_handle_{};
+  Envoy::Common::CallbackHandle* tc_update_callback_handle_{};
   Secret::CertificateValidationContextConfigProviderSharedPtr
       certificate_validation_context_provider_;
   // Handle for certificate validation context dynamic secret callback.
-  Common::CallbackHandle* cvc_update_callback_handle_{};
-  Common::CallbackHandle* cvc_validation_callback_handle_{};
+  Envoy::Common::CallbackHandle* cvc_update_callback_handle_{};
+  Envoy::Common::CallbackHandle* cvc_validation_callback_handle_{};
   const unsigned min_protocol_version_;
   const unsigned max_protocol_version_;
 };
@@ -157,8 +157,8 @@ private:
   const bool require_client_certificate_;
   std::vector<SessionTicketKey> session_ticket_keys_;
   const Secret::TlsSessionTicketKeysConfigProviderSharedPtr session_ticket_keys_provider_;
-  Common::CallbackHandle* stk_update_callback_handle_{};
-  Common::CallbackHandle* stk_validation_callback_handle_{};
+  Envoy::Common::CallbackHandle* stk_update_callback_handle_{};
+  Envoy::Common::CallbackHandle* stk_validation_callback_handle_{};
 
   std::vector<ServerContextConfig::SessionTicketKey> getSessionTicketKeys(
       const envoy::extensions::transport_sockets::tls::v3::TlsSessionTicketKeys& keys);

--- a/source/extensions/transport_sockets/tls/context_impl.h
+++ b/source/extensions/transport_sockets/tls/context_impl.h
@@ -157,7 +157,6 @@ protected:
   std::string getCaFileName() const { return ca_file_path_; };
   void incCounter(const Stats::StatName name, absl::string_view value,
                   const Stats::StatName fallback) const;
-  static std::string generalNameAsString(const GENERAL_NAME* general_name);
 
   Envoy::Ssl::CertificateDetailsPtr certificateDetails(X509* cert, const std::string& path) const;
 

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -611,6 +611,14 @@ const std::string& SslSocketInfo::tlsVersion() const {
   return cached_tls_version_;
 }
 
+absl::optional<std::string> SslSocketInfo::x509Extension(absl::string_view extension_name) const {
+  bssl::UniquePtr<X509> cert(SSL_get_peer_certificate(ssl_.get()));
+  if (!cert) {
+    return absl::nullopt;
+  }
+  return Utility::getX509ExtensionValue(*cert, extension_name);
+}
+
 absl::string_view SslSocket::failureReason() const { return failure_reason_; }
 
 const std::string& SslSocketInfo::serialNumberPeerCertificate() const {

--- a/source/extensions/transport_sockets/tls/ssl_socket.h
+++ b/source/extensions/transport_sockets/tls/ssl_socket.h
@@ -17,6 +17,7 @@
 #include "extensions/transport_sockets/tls/context_impl.h"
 #include "extensions/transport_sockets/tls/utility.h"
 
+#include "absl/container/node_hash_map.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/types/optional.h"
 #include "boringssl_compat/bssl.h"
@@ -78,6 +79,7 @@ public:
   uint16_t ciphersuiteId() const override;
   std::string ciphersuiteString() const override;
   const std::string& tlsVersion() const override;
+  absl::optional<std::string> x509Extension(absl::string_view extension_name) const override;
 
   SSL* rawSslForTest() const { return ssl_.get(); }
 

--- a/source/extensions/transport_sockets/tls/utility.cc
+++ b/source/extensions/transport_sockets/tls/utility.cc
@@ -1,9 +1,9 @@
 #include "extensions/transport_sockets/tls/utility.h"
 
 #include "common/common/assert.h"
+#include "common/network/address_impl.h"
 
 #include "absl/strings/str_join.h"
-#include "openssl/x509v3.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -88,6 +88,41 @@ std::vector<std::string> Utility::getSubjectAltNames(X509& cert, int type) {
   return subject_alt_names;
 }
 
+std::string Utility::generalNameAsString(const GENERAL_NAME* general_name) {
+  std::string san;
+  switch (general_name->type) {
+  case GEN_DNS: {
+    ASN1_STRING* str = general_name->d.dNSName;
+    san.assign(reinterpret_cast<const char*>(ASN1_STRING_get0_data(str)), ASN1_STRING_length(str));
+    break;
+  }
+  case GEN_URI: {
+    ASN1_STRING* str = general_name->d.uniformResourceIdentifier;
+    san.assign(reinterpret_cast<const char*>(ASN1_STRING_get0_data(str)), ASN1_STRING_length(str));
+    break;
+  }
+  case GEN_IPADD: {
+    if (general_name->d.ip->length == 4) {
+      sockaddr_in sin;
+      sin.sin_port = 0;
+      sin.sin_family = AF_INET;
+      memcpy(&sin.sin_addr, general_name->d.ip->data, sizeof(sin.sin_addr));
+      Network::Address::Ipv4Instance addr(&sin);
+      san = addr.ip()->addressAsString();
+    } else if (general_name->d.ip->length == 16) {
+      sockaddr_in6 sin6;
+      sin6.sin6_port = 0;
+      sin6.sin6_family = AF_INET6;
+      memcpy(&sin6.sin6_addr, general_name->d.ip->data, sizeof(sin6.sin6_addr));
+      Network::Address::Ipv6Instance addr(sin6);
+      san = addr.ip()->addressAsString();
+    }
+    break;
+  }
+  }
+  return san;
+}
+
 std::string Utility::getIssuerFromCertificate(X509& cert) {
   return getRFC2253NameFromCertificate(cert, CertName::Issuer);
 }
@@ -122,18 +157,56 @@ int32_t Utility::getDaysUntilExpiration(const X509* cert, TimeSource& time_sourc
   return 0;
 }
 
+absl::optional<std::string> Utility::getX509ExtensionValue(const X509& cert,
+                                                           absl::string_view extension_name) {
+  const X509_EXTENSIONS* extensions(X509_get0_extensions(&cert));
+
+  if (extensions == nullptr) {
+    return absl::nullopt;
+  }
+
+  const size_t extension_count = sk_X509_EXTENSION_num(extensions);
+
+  for (size_t i = 0; i < extension_count; ++i) {
+    X509_EXTENSION* extension = sk_X509_EXTENSION_value(extensions, i);
+
+    ASN1_OBJECT* extension_object = X509_EXTENSION_get_object(extension);
+    const size_t size = OBJ_obj2txt(nullptr, 0, extension_object, 0);
+    std::vector<char> buffer;
+    // +1 to allow for NULL byte.
+    buffer.resize(size + 1);
+    OBJ_obj2txt(buffer.data(), buffer.size(), extension_object, 0);
+
+    if (absl::string_view(buffer.data(), size) == extension_name) {
+      ASN1_OCTET_STRING* octet_string = X509_EXTENSION_get_data(extension);
+      const unsigned char* octet_string_data = octet_string->data;
+      long xlen;
+      int tag, xclass;
+      ASN1_get_object(&octet_string_data, &xlen, &tag, &xclass, octet_string->length);
+
+      return std::string(reinterpret_cast<const char*>(octet_string_data), xlen);
+    }
+  }
+
+  return absl::nullopt;
+}
+
 SystemTime Utility::getValidFrom(const X509& cert) {
   int days, seconds;
   int rc = ASN1_TIME_diff(&days, &seconds, &epochASN1_Time(), X509_get0_notBefore(&cert));
   ASSERT(rc == 1);
-  return std::chrono::system_clock::from_time_t(days * 24 * 60 * 60 + seconds);
+  // Casting to <time_t (64bit)> to prevent multiplication overflow when certificate valid-from date
+  // beyond 2038-01-19T03:14:08Z.
+  return std::chrono::system_clock::from_time_t(static_cast<time_t>(days) * 24 * 60 * 60 + seconds);
 }
 
 SystemTime Utility::getExpirationTime(const X509& cert) {
   int days, seconds;
   int rc = ASN1_TIME_diff(&days, &seconds, &epochASN1_Time(), X509_get0_notAfter(&cert));
   ASSERT(rc == 1);
-  return std::chrono::system_clock::from_time_t(days * 24 * 60 * 60 + seconds);
+  // Casting to <time_t (64bit)> to prevent multiplication overflow when certificate not-after date
+  // beyond 2038-01-19T03:14:08Z.
+  return std::chrono::system_clock::from_time_t(static_cast<time_t>(days) * 24 * 60 * 60 + seconds);
 }
 
 } // namespace Tls

--- a/source/extensions/transport_sockets/tls/utility.h
+++ b/source/extensions/transport_sockets/tls/utility.h
@@ -9,6 +9,7 @@
 
 #include "boringssl_compat/bssl.h"
 #include "openssl/ssl.h"
+#include "openssl/x509v3.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -25,13 +26,19 @@ namespace Utility {
 std::string getSerialNumberFromCertificate(X509& cert);
 
 /**
- * Retrieves the subject alternate names of a certificate of type DNS.
+ * Retrieves the subject alternate names of a certificate.
  * @param cert the certificate
- * @param type type of subject alternate name either GEN_DNS or GEN_URI
+ * @param type type of subject alternate name
  * @return std::vector returns the list of subject alternate names.
  */
 std::vector<std::string> getSubjectAltNames(X509& cert, int type);
 
+/**
+ * Converts the Subject Alternate Name to string.
+ * @param general_name the subject alternate name
+ * @return std::string returns the string representation of subject alt names.
+ */
+std::string generalNameAsString(const GENERAL_NAME* general_name);
 
 /**
  * Retrieves the issuer from certificate.
@@ -46,6 +53,15 @@ std::string getIssuerFromCertificate(X509& cert);
  * @return std::string the subject field for the certificate.
  */
 std::string getSubjectFromCertificate(X509& cert);
+
+/**
+ * Retrieves the value of a specific X509 extension from the cert, if present.
+ * @param cert the certificate.
+ * @param extension_name the name of the extension to extract.
+ * @return absl::optional<std::string> the value of the extension field, if present.
+ */
+absl::optional<std::string> getX509ExtensionValue(const X509& cert,
+                                                  absl::string_view extension_name);
 
 /**
  * Returns the days until this certificate is valid.
@@ -68,6 +84,13 @@ SystemTime getValidFrom(const X509& cert);
  * @return time after which the certificate expires.
  */
 SystemTime getExpirationTime(const X509& cert);
+
+/**
+ * Returns the last crypto error from ERR_get_error(), or `absl::nullopt`
+ * if the error stack is empty.
+ * @return std::string error message
+ */
+absl::optional<std::string> getLastCryptoError();
 
 } // namespace Utility
 } // namespace Tls

--- a/test/common/crypto/utility_test.cc
+++ b/test/common/crypto/utility_test.cc
@@ -109,7 +109,7 @@ TEST(UtilityTest, TestVerifySignature) {
   EXPECT_EQ(false, result.result_);
   EXPECT_EQ("unknown is not supported.", result.error_message_);
 
-  PublicKeyObject* empty_crypto = new PublicKeyObject();
+  auto empty_crypto = std::make_unique<PublicKeyObject>();
   result = UtilitySingleton::get().verifySignature(hash_func, *empty_crypto, sig, text);
   EXPECT_EQ(false, result.result_);
   EXPECT_EQ("Failed to initialize digest verify.", result.error_message_);

--- a/test/common/grpc/grpc_client_integration_test_harness.h
+++ b/test/common/grpc/grpc_client_integration_test_harness.h
@@ -315,7 +315,8 @@ public:
     google_tls_ = std::make_unique<GoogleAsyncClientThreadLocal>(*api_);
     GoogleGenericStubFactory stub_factory;
     return std::make_unique<GoogleAsyncClientImpl>(*dispatcher_, *google_tls_, stub_factory,
-                                                   stats_scope_, createGoogleGrpcConfig(), *api_);
+                                                   stats_scope_, createGoogleGrpcConfig(), *api_,
+                                                   google_grpc_stat_names_);
 #else
     NOT_REACHED_GCOVR_EXCL_LINE;
 #endif
@@ -426,6 +427,7 @@ public:
   Event::DispatcherPtr dispatcher_;
   DispatcherHelper dispatcher_helper_{*dispatcher_};
   Stats::ScopeSharedPtr stats_scope_{stats_store_};
+  Grpc::StatNames google_grpc_stat_names_{stats_store_->symbolTable()};
   TestMetadata service_wide_initial_metadata_;
 #ifdef ENVOY_GOOGLE_GRPC
   std::unique_ptr<GoogleAsyncClientThreadLocal> google_tls_;

--- a/test/extensions/common/aws/aws_metadata_fetcher_integration_test.cc
+++ b/test/extensions/common/aws/aws_metadata_fetcher_integration_test.cc
@@ -20,12 +20,12 @@ public:
     return fmt::format(ConfigHelper::BASE_CONFIG + R"EOF(
     filter_chains:
       filters:
-        name: envoy.http_connection_manager
+        name: http
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           stat_prefix: metadata_test
           http_filters:
-            - name: envoy.fault
+            - name: fault
               typed_config:
                 "@type": type.googleapis.com/envoy.config.filter.http.fault.v2.HTTPFault
                 delay:
@@ -35,7 +35,7 @@ public:
                   percentage:
                     numerator: 100
                     denominator: HUNDRED
-            - name: envoy.router
+            - name: envoy.filters.http.router
           codec_type: HTTP1
           route_config:
             virtual_hosts:

--- a/test/extensions/common/aws/mocks.h
+++ b/test/extensions/common/aws/mocks.h
@@ -25,6 +25,7 @@ public:
 
   MOCK_METHOD(void, sign, (Http::RequestMessage&, bool));
   MOCK_METHOD(void, sign, (Http::RequestHeaderMap&));
+  MOCK_METHOD(void, sign, (Http::RequestHeaderMap&, const std::string&));
 };
 
 class MockMetadataFetcher {

--- a/test/extensions/common/aws/signer_impl_test.cc
+++ b/test/extensions/common/aws/signer_impl_test.cc
@@ -80,12 +80,12 @@ TEST_F(SignerImplTest, SignDateHeader) {
   addMethod("GET");
   addPath("/");
   signer_.sign(*message_);
-  EXPECT_EQ(nullptr, message_->headers().get(SignatureHeaders::get().ContentSha256));
+  EXPECT_NE(nullptr, message_->headers().get(SignatureHeaders::get().ContentSha256));
   EXPECT_EQ("20180102T030400Z",
             message_->headers().get(SignatureHeaders::get().Date)->value().getStringView());
   EXPECT_EQ("AWS4-HMAC-SHA256 Credential=akid/20180102/region/service/aws4_request, "
-            "SignedHeaders=x-amz-date, "
-            "Signature=1310784f67248cab70d98b9404d601f30d8fe20bd1820560cce224f4131dc1cc",
+            "SignedHeaders=x-amz-content-sha256;x-amz-date, "
+            "Signature=4ee6aa9355259c18133f150b139ea9aeb7969c9408ad361b2151f50a516afe42",
             message_->headers().Authorization()->value().getStringView());
 }
 
@@ -99,8 +99,8 @@ TEST_F(SignerImplTest, SignSecurityTokenHeader) {
       "token",
       message_->headers().get(SignatureHeaders::get().SecurityToken)->value().getStringView());
   EXPECT_EQ("AWS4-HMAC-SHA256 Credential=akid/20180102/region/service/aws4_request, "
-            "SignedHeaders=x-amz-date;x-amz-security-token, "
-            "Signature=ff1d9fa7e54a72677b5336df047bb1f1493f86b92099973bf62da3af852d1679",
+            "SignedHeaders=x-amz-content-sha256;x-amz-date;x-amz-security-token, "
+            "Signature=1d42526aabf7d8b6d7d33d9db43b03537300cc7e6bb2817e349749e0a08f5b5e",
             message_->headers().Authorization()->value().getStringView());
 }
 
@@ -145,8 +145,8 @@ TEST_F(SignerImplTest, SignExtraHeaders) {
   addHeader("c", "c_value");
   signer_.sign(*message_);
   EXPECT_EQ("AWS4-HMAC-SHA256 Credential=akid/20180102/region/service/aws4_request, "
-            "SignedHeaders=a;b;c;x-amz-date, "
-            "Signature=d5e025e1cf0d5af0d83110bc2ef1cafd2d9dca1dea9d7767f58308da64aa6558",
+            "SignedHeaders=a;b;c;x-amz-content-sha256;x-amz-date, "
+            "Signature=0940025fcecfef5d7ee30e0a26a0957e116560e374878cd86ef4316c53ae9e81",
             message_->headers().Authorization()->value().getStringView());
 }
 
@@ -158,9 +158,51 @@ TEST_F(SignerImplTest, SignHostHeader) {
   addHeader("host", "www.example.com");
   signer_.sign(*message_);
   EXPECT_EQ("AWS4-HMAC-SHA256 Credential=akid/20180102/region/service/aws4_request, "
-            "SignedHeaders=host;x-amz-date, "
-            "Signature=60216ee44dd651322ea10cc6747308dd30e582aaa773f6c1b1354e486385c021",
+            "SignedHeaders=host;x-amz-content-sha256;x-amz-date, "
+            "Signature=d9fd9be575a254c924d843964b063d770181d938ae818f5b603ef0575a5ce2cd",
             message_->headers().Authorization()->value().getStringView());
+}
+
+// Verify signing headers for S3
+TEST_F(SignerImplTest, SignHeadersS3) {
+  auto* credentials_provider = new NiceMock<MockCredentialsProvider>();
+  EXPECT_CALL(*credentials_provider, getCredentials()).WillOnce(Return(credentials_));
+  Http::TestRequestHeaderMapImpl headers{};
+  headers.setMethod("GET");
+  headers.setPath("/");
+  headers.addCopy(Http::LowerCaseString("host"), "www.example.com");
+
+  SignerImpl signer("s3", "region", CredentialsProviderSharedPtr{credentials_provider},
+                    time_system_);
+  signer.sign(headers);
+
+  EXPECT_EQ("AWS4-HMAC-SHA256 Credential=akid/20180102/region/s3/aws4_request, "
+            "SignedHeaders=host;x-amz-content-sha256;x-amz-date, "
+            "Signature=d97cae067345792b78d2bad746f25c729b9eb4701127e13a7c80398f8216a167",
+            headers.Authorization()->value().getStringView());
+  EXPECT_EQ(SignatureConstants::get().UnsignedPayload,
+            headers.get(SignatureHeaders::get().ContentSha256)->value().getStringView());
+}
+
+// Verify signing headers for non S3
+TEST_F(SignerImplTest, SignHeadersNonS3) {
+  auto* credentials_provider = new NiceMock<MockCredentialsProvider>();
+  EXPECT_CALL(*credentials_provider, getCredentials()).WillOnce(Return(credentials_));
+  Http::TestRequestHeaderMapImpl headers{};
+  headers.setMethod("GET");
+  headers.setPath("/");
+  headers.addCopy(Http::LowerCaseString("host"), "www.example.com");
+
+  SignerImpl signer("service", "region", CredentialsProviderSharedPtr{credentials_provider},
+                    time_system_);
+  signer.sign(headers);
+
+  EXPECT_EQ("AWS4-HMAC-SHA256 Credential=akid/20180102/region/service/aws4_request, "
+            "SignedHeaders=host;x-amz-content-sha256;x-amz-date, "
+            "Signature=d9fd9be575a254c924d843964b063d770181d938ae818f5b603ef0575a5ce2cd",
+            headers.Authorization()->value().getStringView());
+  EXPECT_EQ(SignatureConstants::get().HashedEmptyString,
+            headers.get(SignatureHeaders::get().ContentSha256)->value().getStringView());
 }
 
 } // namespace

--- a/test/extensions/filters/http/lua/BUILD
+++ b/test/extensions/filters/http/lua/BUILD
@@ -24,6 +24,7 @@ envoy_extension_cc_test(
         "@envoy//test/mocks/ssl:ssl_mocks",
         "@envoy//test/mocks/thread_local:thread_local_mocks",
         "@envoy//test/mocks/upstream:upstream_mocks",
+        "@envoy//test/test_common:logging_lib",
         "@envoy//test/test_common:utility_lib",
         "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
     ],

--- a/test/extensions/filters/http/lua/config_test.cc
+++ b/test/extensions/filters/http/lua/config_test.cc
@@ -41,6 +41,16 @@ TEST(LuaFilterConfigTest, LuaFilterInJson) {
   cb(filter_callback);
 }
 
+// Test that the deprecated extension name still functions.
+TEST(LuaFilterConfigTest, DEPRECATED_FEATURE_TEST(DeprecatedExtensionFilterName)) {
+  const std::string deprecated_name = "envoy.lua";
+
+  ASSERT_NE(
+      nullptr,
+      Registry::FactoryRegistry<Server::Configuration::NamedHttpFilterConfigFactory>::getFactory(
+          deprecated_name));
+}
+
 } // namespace
 } // namespace Lua
 } // namespace HttpFilters

--- a/test/extensions/filters/http/lua/lua_filter_test.cc
+++ b/test/extensions/filters/http/lua/lua_filter_test.cc
@@ -13,6 +13,7 @@
 #include "test/mocks/ssl/mocks.h"
 #include "test/mocks/thread_local/mocks.h"
 #include "test/mocks/upstream/mocks.h"
+#include "test/test_common/logging.h"
 #include "test/test_common/printers.h"
 #include "test/test_common/utility.h"
 
@@ -365,7 +366,7 @@ TEST_F(LuaHttpFilterTest, ScriptTrailersNoBodyRequestBodyTrailers) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
 }
 
-// Script asking for blocking body, request that is headers only.
+// Script asking for synchronous body, request that is headers only.
 TEST_F(LuaHttpFilterTest, ScriptBodyRequestHeadersOnly) {
   InSequence s;
   setup(BODY_SCRIPT);
@@ -376,7 +377,7 @@ TEST_F(LuaHttpFilterTest, ScriptBodyRequestHeadersOnly) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 }
 
-// Script asking for blocking body, request that has a body.
+// Script asking for synchronous body, request that has a body.
 TEST_F(LuaHttpFilterTest, ScriptBodyRequestBody) {
   InSequence s;
   setup(BODY_SCRIPT);
@@ -391,7 +392,7 @@ TEST_F(LuaHttpFilterTest, ScriptBodyRequestBody) {
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, true));
 }
 
-// Script asking for blocking body, request that has a body in multiple frames.
+// Script asking for synchronous body, request that has a body in multiple frames.
 TEST_F(LuaHttpFilterTest, ScriptBodyRequestBodyTwoFrames) {
   InSequence s;
   setup(BODY_SCRIPT);
@@ -410,7 +411,7 @@ TEST_F(LuaHttpFilterTest, ScriptBodyRequestBodyTwoFrames) {
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data2, true));
 }
 
-// Scripting asking for blocking body, request that has a body in multiple frames follows by
+// Scripting asking for synchronous body, request that has a body in multiple frames follows by
 // trailers.
 TEST_F(LuaHttpFilterTest, ScriptBodyRequestBodyTwoFramesTrailers) {
   InSequence s;
@@ -434,7 +435,7 @@ TEST_F(LuaHttpFilterTest, ScriptBodyRequestBodyTwoFramesTrailers) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
 }
 
-// Script asking for blocking body and trailers, request that is headers only.
+// Script asking for synchronous body and trailers, request that is headers only.
 TEST_F(LuaHttpFilterTest, ScriptBodyTrailersRequestHeadersOnly) {
   InSequence s;
   setup(BODY_TRAILERS_SCRIPT);
@@ -446,7 +447,7 @@ TEST_F(LuaHttpFilterTest, ScriptBodyTrailersRequestHeadersOnly) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
 }
 
-// Script asking for blocking body and trailers, request that has a body.
+// Script asking for synchronous body and trailers, request that has a body.
 TEST_F(LuaHttpFilterTest, ScriptBodyTrailersRequestBody) {
   InSequence s;
   setup(BODY_TRAILERS_SCRIPT);
@@ -462,7 +463,7 @@ TEST_F(LuaHttpFilterTest, ScriptBodyTrailersRequestBody) {
   EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, true));
 }
 
-// Script asking for blocking body and trailers, request that has a body and trailers.
+// Script asking for synchronous body and trailers, request that has a body and trailers.
 TEST_F(LuaHttpFilterTest, ScriptBodyTrailersRequestBodyTrailers) {
   InSequence s;
   setup(BODY_TRAILERS_SCRIPT);
@@ -708,8 +709,8 @@ TEST_F(LuaHttpFilterTest, RequestAndResponse) {
   EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->encodeTrailers(response_trailers));
 }
 
-// Response blocking body.
-TEST_F(LuaHttpFilterTest, ResponseBlockingBody) {
+// Response synchronous body.
+TEST_F(LuaHttpFilterTest, ResponseSynchronousBody) {
   const std::string SCRIPT{R"EOF(
     function envoy_on_response(response_handle)
       response_handle:logTrace(response_handle:headers():get(":status"))
@@ -797,6 +798,119 @@ TEST_F(LuaHttpFilterTest, HttpCall) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("response")));
   EXPECT_CALL(decoder_callbacks_, continueDecoding());
   callbacks->onSuccess(std::move(response_message));
+}
+
+// Basic HTTP request flow. Asynchronous flag set to false.
+TEST_F(LuaHttpFilterTest, HttpCallAsyncFalse) {
+  const std::string SCRIPT{R"EOF(
+    function envoy_on_request(request_handle)
+      local headers, body = request_handle:httpCall(
+        "cluster",
+        {
+          [":method"] = "POST",
+          [":path"] = "/",
+          [":authority"] = "foo",
+          ["set-cookie"] = { "flavor=chocolate; Path=/", "variant=chewy; Path=/" }
+        },
+        "hello world",
+        5000,
+        false)
+      for key, value in pairs(headers) do
+        request_handle:logTrace(key .. " " .. value)
+      end
+      request_handle:logTrace(body)
+    end
+  )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::MockAsyncClientRequest request(&cluster_manager_.async_client_);
+  Http::AsyncClient::Callbacks* callbacks;
+  EXPECT_CALL(cluster_manager_, get(Eq("cluster")));
+  EXPECT_CALL(cluster_manager_, httpAsyncClientForCluster("cluster"));
+  EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
+      .WillOnce(
+          Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
+            EXPECT_EQ((Http::TestHeaderMapImpl{{":path", "/"},
+                                               {":method", "POST"},
+                                               {":authority", "foo"},
+                                               {"set-cookie", "flavor=chocolate; Path=/"},
+                                               {"set-cookie", "variant=chewy; Path=/"},
+                                               {"content-length", "11"}}),
+                      message->headers());
+            callbacks = &cb;
+            return &request;
+          }));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::StopIteration,
+            filter_->decodeHeaders(request_headers, false));
+
+  Buffer::OwnedImpl data("hello");
+  EXPECT_EQ(Http::FilterDataStatus::StopIterationAndBuffer, filter_->decodeData(data, false));
+
+  Http::TestRequestTrailerMapImpl request_trailers{{"foo", "bar"}};
+  EXPECT_EQ(Http::FilterTrailersStatus::StopIteration, filter_->decodeTrailers(request_trailers));
+
+  Http::ResponseMessagePtr response_message(new Http::ResponseMessageImpl(
+      Http::ResponseHeaderMapPtr{new Http::TestResponseHeaderMapImpl{{":status", "200"}}}));
+  response_message->body() = std::make_unique<Buffer::OwnedImpl>("response");
+  EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq(":status 200")));
+  EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("response")));
+  EXPECT_CALL(decoder_callbacks_, continueDecoding());
+  callbacks->onSuccess(std::move(response_message));
+}
+
+// Basic asynchronous, fire-and-forget HTTP request flow.
+TEST_F(LuaHttpFilterTest, HttpCallAsynchronous) {
+  const std::string SCRIPT{R"EOF(
+        function envoy_on_request(request_handle)
+          local headers, body = request_handle:httpCall(
+            "cluster",
+            {
+              [":method"] = "POST",
+              [":path"] = "/",
+              [":authority"] = "foo",
+              ["set-cookie"] = { "flavor=chocolate; Path=/", "variant=chewy; Path=/" }
+            },
+            "hello world",
+            5000,
+            true)
+        end
+      )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
+  Http::MockAsyncClientRequest request(&cluster_manager_.async_client_);
+  Http::AsyncClient::Callbacks* callbacks;
+  EXPECT_CALL(cluster_manager_, get(Eq("cluster")));
+  EXPECT_CALL(cluster_manager_, httpAsyncClientForCluster("cluster"));
+  EXPECT_CALL(cluster_manager_.async_client_, send_(_, _, _))
+      .WillOnce(
+          Invoke([&](Http::RequestMessagePtr& message, Http::AsyncClient::Callbacks& cb,
+                     const Http::AsyncClient::RequestOptions&) -> Http::AsyncClient::Request* {
+            EXPECT_EQ((Http::TestHeaderMapImpl{{":path", "/"},
+                                               {":method", "POST"},
+                                               {":authority", "foo"},
+                                               {"set-cookie", "flavor=chocolate; Path=/"},
+                                               {"set-cookie", "variant=chewy; Path=/"},
+                                               {"content-length", "11"}}),
+                      message->headers());
+            callbacks = &cb;
+            return &request;
+          }));
+
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
+
+  Buffer::OwnedImpl data("hello");
+  EXPECT_EQ(Http::FilterDataStatus::Continue, filter_->decodeData(data, false));
+
+  Http::TestRequestTrailerMapImpl request_trailers{{"foo", "bar"}};
+  EXPECT_EQ(Http::FilterTrailersStatus::Continue, filter_->decodeTrailers(request_trailers));
 }
 
 // Double HTTP call. Responses before request body.
@@ -1246,6 +1360,34 @@ TEST_F(LuaHttpFilterTest, HttpCallInvalidHeaders) {
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
 }
 
+// Invalid HTTP call asynchronous flag value.
+TEST_F(LuaHttpFilterTest, HttpCallAsyncInvalidAsynchronousFlag) {
+  const std::string SCRIPT{R"EOF(
+    function envoy_on_request(request_handle)
+      request_handle:httpCall(
+        "cluster",
+        {
+          [":method"] = "POST",
+          [":path"] = "/",
+          [":authority"] = "foo",
+          ["set-cookie"] = { "flavor=chocolate; Path=/", "variant=chewy; Path=/" }
+        },
+        "hello world",
+        5000,
+        potato)
+    end
+  )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
+  EXPECT_CALL(*filter_,
+              scriptLog(spdlog::level::err, StrEq("[string \"...\"]:3: http call asynchronous flag "
+                                                  "must be 'true', 'false', or empty")));
+  EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, false));
+}
+
 // Respond right away.
 // This is also a regression test for https://github.com/envoyproxy/envoy/issues/3570 which runs
 // the request flow 2000 times and does a GC at the end to make sure we don't leak memory.
@@ -1457,7 +1599,7 @@ TEST_F(LuaHttpFilterTest, GetMetadataFromHandle) {
 
   const std::string METADATA{R"EOF(
     filter_metadata:
-      envoy.lua:
+      envoy.filters.http.lua:
         foo.bar:
           name: foo
           prop: bar
@@ -1476,6 +1618,46 @@ TEST_F(LuaHttpFilterTest, GetMetadataFromHandle) {
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("baz")));
   EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("bat")));
   EXPECT_EQ(Http::FilterHeadersStatus::Continue, filter_->decodeHeaders(request_headers, true));
+}
+
+// Test that the deprecated filter name works for metadata.
+TEST_F(LuaHttpFilterTest, DEPRECATED_FEATURE_TEST(GetMetadataFromHandleUsingDeprecatedName)) {
+  const std::string SCRIPT{R"EOF(
+    function envoy_on_request(request_handle)
+      request_handle:logTrace(request_handle:metadata():get("foo.bar")["name"])
+      request_handle:logTrace(request_handle:metadata():get("foo.bar")["prop"])
+    end
+  )EOF"};
+
+  const std::string METADATA{R"EOF(
+    filter_metadata:
+      envoy.lua:
+        foo.bar:
+          name: foo
+          prop: bar
+  )EOF"};
+
+  InSequence s;
+  setup(SCRIPT);
+  setupMetadata(METADATA);
+
+  // Logs deprecation warning the first time.
+  Http::TestRequestHeaderMapImpl request_headers{{":path", "/"}};
+  EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("foo")));
+  EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("bar")));
+  EXPECT_LOG_CONTAINS(
+      "warn",
+      "Using deprecated http filter extension name 'envoy.lua' for 'envoy.filters.http.lua'",
+      filter_->decodeHeaders(request_headers, true));
+
+  // Doesn't log deprecation warning the second time.
+  setupMetadata(METADATA);
+  EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("foo")));
+  EXPECT_CALL(*filter_, scriptLog(spdlog::level::trace, StrEq("bar")));
+  EXPECT_LOG_NOT_CONTAINS(
+      "warn",
+      "Using deprecated http filter extension name 'envoy.lua' for 'envoy.filters.http.lua'",
+      filter_->decodeHeaders(request_headers, true));
 }
 
 // No available metadata on route.

--- a/test/extensions/filters/http/lua/lua_integration_test.cc
+++ b/test/extensions/filters/http/lua/lua_integration_test.cc
@@ -8,6 +8,8 @@
 
 #include "gtest/gtest.h"
 
+using Envoy::Http::HeaderValueOf;
+
 namespace Envoy {
 namespace {
 
@@ -106,7 +108,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, LuaIntegrationTest,
 TEST_P(LuaIntegrationTest, CallMetadataDuringLocalReply) {
   const std::string FILTER_AND_CODE =
       R"EOF(
-name: envoy.lua
+name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.config.filter.http.lua.v2.Lua
   inline_code: |
@@ -131,7 +133,7 @@ typed_config:
 TEST_P(LuaIntegrationTest, RequestAndResponse) {
   const std::string FILTER_AND_CODE =
       R"EOF(
-name: envoy.lua
+name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.config.filter.http.lua.v2.Lua
   inline_code: |
@@ -251,7 +253,7 @@ typed_config:
 TEST_P(LuaIntegrationTest, UpstreamHttpCall) {
   const std::string FILTER_AND_CODE =
       R"EOF(
-name: envoy.lua
+name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.config.filter.http.lua.v2.Lua
   inline_code: |
@@ -309,7 +311,7 @@ typed_config:
 TEST_P(LuaIntegrationTest, UpstreamCallAndRespond) {
   const std::string FILTER_AND_CODE =
       R"EOF(
-name: envoy.lua
+name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.config.filter.http.lua.v2.Lua
   inline_code: |
@@ -355,11 +357,61 @@ typed_config:
   EXPECT_EQ("nope", response->body());
 }
 
+// Upstream fire and forget asynchronous call.
+TEST_P(LuaIntegrationTest, UpstreamAsyncHttpCall) {
+  const std::string FILTER_AND_CODE =
+      R"EOF(
+name: envoy.filters.http.lua
+typed_config:
+  "@type": type.googleapis.com/envoy.config.filter.http.lua.v2.Lua
+  inline_code: |
+    function envoy_on_request(request_handle)
+      local headers, body = request_handle:httpCall(
+      "lua_cluster",
+      {
+        [":method"] = "POST",
+        [":path"] = "/",
+        [":authority"] = "lua_cluster"
+      },
+      "hello world",
+      5000,
+      true)
+    end
+)EOF";
+
+  initializeFilter(FILTER_AND_CODE);
+
+  codec_client_ = makeHttpConnection(makeClientConnection(lookupPort("http")));
+  Http::TestRequestHeaderMapImpl request_headers{{":method", "GET"},
+                                                 {":path", "/test/long/url"},
+                                                 {":scheme", "http"},
+                                                 {":authority", "host"},
+                                                 {"x-forwarded-for", "10.0.0.1"}};
+  auto response = codec_client_->makeHeaderOnlyRequest(request_headers);
+
+  ASSERT_TRUE(fake_upstreams_[1]->waitForHttpConnection(*dispatcher_, fake_lua_connection_));
+  ASSERT_TRUE(fake_lua_connection_->waitForNewStream(*dispatcher_, lua_request_));
+  ASSERT_TRUE(lua_request_->waitForEndStream(*dispatcher_));
+  // Sanity checking that we sent the expected data.
+  EXPECT_THAT(lua_request_->headers(), HeaderValueOf(Http::Headers::get().Method, "POST"));
+  EXPECT_THAT(lua_request_->headers(), HeaderValueOf(Http::Headers::get().Path, "/"));
+
+  waitForNextUpstreamRequest();
+
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+  response->waitForEndStream();
+
+  cleanup();
+
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+}
+
 // Filter alters headers and changes route.
 TEST_P(LuaIntegrationTest, ChangeRoute) {
   const std::string FILTER_AND_CODE =
       R"EOF(
-name: envoy.lua
+name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.config.filter.http.lua.v2.Lua
   inline_code: |
@@ -393,7 +445,7 @@ typed_config:
 TEST_P(LuaIntegrationTest, SurviveMultipleCalls) {
   const std::string FILTER_AND_CODE =
       R"EOF(
-name: envoy.lua
+name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.config.filter.http.lua.v2.Lua
   inline_code: |
@@ -429,7 +481,7 @@ typed_config:
 TEST_P(LuaIntegrationTest, SignatureVerification) {
   const std::string FILTER_AND_CODE =
       R"EOF(
-name: envoy.lua
+name: lua
 typed_config:
   "@type": type.googleapis.com/envoy.config.filter.http.lua.v2.Lua
   inline_code: |
@@ -473,7 +525,7 @@ typed_config:
       local sig = request_handle:headers():get("signature")
       local rawsig = sig:fromhex()
       local data = request_handle:headers():get("message")
-      local ok, error = request_handle:verifySignature(hash, pubkey, rawsig, string.len(rawsig), data, string.len(data)) 
+      local ok, error = request_handle:verifySignature(hash, pubkey, rawsig, string.len(rawsig), data, string.len(data))
 
       if ok then
         request_handle:headers():add("signature_verification", "approved")

--- a/test/extensions/filters/listener/tls_inspector/BUILD
+++ b/test/extensions/filters/listener/tls_inspector/BUILD
@@ -5,6 +5,7 @@ load(
     "envoy_cc_binary",
     "envoy_cc_library",
     "envoy_cc_test",
+    "envoy_cc_test_binary",
     "envoy_package",
 )
 
@@ -16,6 +17,7 @@ envoy_cc_test(
     srcs = ["tls_inspector_test.cc"],
     deps = [
         ":tls_utility_lib",
+        "//source/extensions/filters/listener/tls_inspector:config",
         "//source/extensions/filters/listener/tls_inspector:tls_inspector_lib",
         "@envoy//test/mocks/api:api_mocks",
         "@envoy//test/mocks/network:network_mocks",
@@ -24,10 +26,9 @@ envoy_cc_test(
     ],
 )
 
-envoy_cc_binary(
+envoy_cc_test_binary(
     name = "tls_inspector_benchmark",
     repository = "@envoy",
-    testonly = 1,
     srcs = ["tls_inspector_benchmark.cc"],
     external_deps = [
         "benchmark",

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
@@ -1,5 +1,6 @@
 #include <vector>
 
+#include "common/api/os_sys_calls_impl.h"
 #include "common/network/io_socket_handle_impl.h"
 #include "common/network/listen_socket_impl.h"
 
@@ -43,7 +44,7 @@ class FastMockFileEvent : public Event::FileEvent {
 
 class FastMockDispatcher : public Event::MockDispatcher {
 public:
-  Event::FileEventPtr createFileEvent(int, Event::FileReadyCb cb, Event::FileTriggerType,
+  Event::FileEventPtr createFileEvent(os_fd_t, Event::FileReadyCb cb, Event::FileTriggerType,
                                       uint32_t) override {
     file_event_callback_ = cb;
     return std::make_unique<FastMockFileEvent>();
@@ -56,7 +57,7 @@ class FastMockOsSysCalls : public Api::MockOsSysCalls {
 public:
   FastMockOsSysCalls(const std::vector<uint8_t>& client_hello) : client_hello_(client_hello) {}
 
-  Api::SysCallSizeResult recv(int, void* buffer, size_t length, int) override {
+  Api::SysCallSizeResult recv(os_fd_t, void* buffer, size_t length, int) override {
     RELEASE_ASSERT(length >= client_hello_.size(), "");
     memcpy(buffer, client_hello_.data(), client_hello_.size());
     return Api::SysCallSizeResult{ssize_t(client_hello_.size()), 0};

--- a/test/extensions/grpc_credentials/aws_iam/BUILD
+++ b/test/extensions/grpc_credentials/aws_iam/BUILD
@@ -13,6 +13,7 @@ envoy_cc_test(
     name = "aws_iam_grpc_credentials_test",
     repository = "@envoy",
     srcs = envoy_select_google_grpc(["aws_iam_grpc_credentials_test.cc"], "@envoy"),
+    data = ["@envoy//test/config/integration/certs"],
     deps = [
         "@envoy//source/extensions/grpc_credentials:well_known_names",
         "//source/extensions/grpc_credentials/aws_iam:config",

--- a/test/extensions/grpc_credentials/aws_iam/aws_iam_grpc_credentials_test.cc
+++ b/test/extensions/grpc_credentials/aws_iam/aws_iam_grpc_credentials_test.cc
@@ -44,7 +44,7 @@ public:
     EXPECT_TRUE(absl::StartsWith(auth_parts[1], "Credential=test_akid/"));
     EXPECT_TRUE(absl::EndsWith(auth_parts[1],
                                fmt::format("{}/{}/aws4_request", region_name_, service_name_)));
-    EXPECT_EQ("SignedHeaders=host;x-amz-date", auth_parts[2]);
+    EXPECT_EQ("SignedHeaders=host;x-amz-content-sha256;x-amz-date", auth_parts[2]);
     // We don't verify correctness off the signature here, as this is part of the signer unit tests.
     EXPECT_TRUE(absl::StartsWith(auth_parts[3], "Signature="));
   }
@@ -61,13 +61,13 @@ public:
     if (region_in_env_) {
       TestEnvironment::setEnvVar("AWS_REGION", region_name_, 1);
       config_yaml = fmt::format(R"EOF(
-"@type": type.googleapis.com/envoy.config.grpc_credential.v2alpha.AwsIamConfig
+"@type": type.googleapis.com/envoy.config.grpc_credential.v2alpha.AwsIamConfig        
 service_name: {}
 )EOF",
                                 service_name_);
     } else {
       config_yaml = fmt::format(R"EOF(
-"@type": type.googleapis.com/envoy.config.grpc_credential.v2alpha.AwsIamConfig
+"@type": type.googleapis.com/envoy.config.grpc_credential.v2alpha.AwsIamConfig        
 service_name: {}
 region: {}
 )EOF",

--- a/test/integration/ads_integration.cc
+++ b/test/integration/ads_integration.cc
@@ -88,7 +88,7 @@ AdsIntegrationTest::buildListener(const std::string& name, const std::string& ro
           port_value: 0
       filter_chains:
         filters:
-        - name: envoy.filters.network.http_connection_manager
+        - name: http
           typed_config:
             "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
             stat_prefix: {}
@@ -96,7 +96,7 @@ AdsIntegrationTest::buildListener(const std::string& name, const std::string& ro
             rds:
               route_config_name: {}
               config_source: {{ ads: {{}} }}
-            http_filters: [{{ name: envoy.router }}]
+            http_filters: [{{ name: envoy.filters.http.router }}]
     )EOF",
       name, Network::Test::getLoopbackAddressString(ipVersion()), stat_prefix, route_config));
 }
@@ -112,7 +112,7 @@ AdsIntegrationTest::buildRedisListener(const std::string& name, const std::strin
           port_value: 0
       filter_chains:
         filters:
-        - name: envoy.filters.network.redis_proxy
+        - name: redis
           typed_config:
             "@type": type.googleapis.com/envoy.config.filter.network.redis_proxy.v2.RedisProxy
             settings: 

--- a/test/integration/api_listener_integration_test.cc
+++ b/test/integration/api_listener_integration_test.cc
@@ -67,7 +67,7 @@ api_listener:
         domains: "*"
       name: route_config_0
     http_filters:
-      - name: envoy.router
+      - name: router
         typed_config:
           "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
       )EOF";

--- a/test/integration/autonomous_upstream.cc
+++ b/test/integration/autonomous_upstream.cc
@@ -101,16 +101,16 @@ void AutonomousUpstream::createUdpListenerFilterChain(Network::UdpListenerFilter
 
 void AutonomousUpstream::setLastRequestHeaders(const Http::HeaderMap& headers) {
   Thread::LockGuard lock(headers_lock_);
-  last_request_headers_ = std::make_unique<Http::TestHeaderMapImpl>(headers);
+  last_request_headers_ = std::make_unique<Http::TestRequestHeaderMapImpl>(headers);
 }
 
-std::unique_ptr<Http::TestHeaderMapImpl> AutonomousUpstream::lastRequestHeaders() {
+std::unique_ptr<Http::TestRequestHeaderMapImpl> AutonomousUpstream::lastRequestHeaders() {
   Thread::LockGuard lock(headers_lock_);
   return std::move(last_request_headers_);
 }
 
 void AutonomousUpstream::setResponseHeaders(
-    std::unique_ptr<Http::TestHeaderMapImpl>&& response_headers) {
+    std::unique_ptr<Http::TestResponseHeaderMapImpl>&& response_headers) {
   Thread::LockGuard lock(headers_lock_);
   response_headers_ = std::move(response_headers);
 }

--- a/test/integration/autonomous_upstream.h
+++ b/test/integration/autonomous_upstream.h
@@ -55,7 +55,7 @@ public:
                      bool allow_incomplete_streams)
       : FakeUpstream(address, type, time_system),
         allow_incomplete_streams_(allow_incomplete_streams),
-        response_headers_(std::make_unique<Http::TestHeaderMapImpl>(
+        response_headers_(std::make_unique<Http::TestResponseHeaderMapImpl>(
             Http::TestHeaderMapImpl({{":status", "200"}}))) {}
 
   AutonomousUpstream(Network::TransportSocketFactoryPtr&& transport_socket_factory, uint32_t port,
@@ -63,7 +63,7 @@ public:
                      Event::TestTimeSystem& time_system, bool allow_incomplete_streams)
       : FakeUpstream(std::move(transport_socket_factory), port, type, version, time_system),
         allow_incomplete_streams_(allow_incomplete_streams),
-        response_headers_(std::make_unique<Http::TestHeaderMapImpl>(
+        response_headers_(std::make_unique<Http::TestResponseHeaderMapImpl>(
             Http::TestHeaderMapImpl({{":status", "200"}}))) {}
 
   ~AutonomousUpstream() override;
@@ -75,15 +75,15 @@ public:
                                     Network::UdpReadFilterCallbacks& callbacks) override;
 
   void setLastRequestHeaders(const Http::HeaderMap& headers);
-  std::unique_ptr<Http::TestHeaderMapImpl> lastRequestHeaders();
-  void setResponseHeaders(std::unique_ptr<Http::TestHeaderMapImpl>&& response_headers);
+  std::unique_ptr<Http::TestRequestHeaderMapImpl> lastRequestHeaders();
+  void setResponseHeaders(std::unique_ptr<Http::TestResponseHeaderMapImpl>&& response_headers);
   Http::TestHeaderMapImpl responseHeaders();
   const bool allow_incomplete_streams_{false};
 
 private:
   Thread::MutexBasicLockable headers_lock_;
-  std::unique_ptr<Http::TestHeaderMapImpl> last_request_headers_;
-  std::unique_ptr<Http::TestHeaderMapImpl> response_headers_;
+  std::unique_ptr<Http::TestRequestHeaderMapImpl> last_request_headers_;
+  std::unique_ptr<Http::TestResponseHeaderMapImpl> response_headers_;
   std::vector<AutonomousHttpConnectionPtr> http_connections_;
   std::vector<SharedConnectionWrapperPtr> shared_connections_;
 };

--- a/test/integration/echo_integration_test.cc
+++ b/test/integration/echo_integration_test.cc
@@ -17,14 +17,14 @@ public:
     echo_config = ConfigHelper::BASE_CONFIG + R"EOF(
     filter_chains:
       filters:
-        name: envoy.filters.network.ratelimit
-        config:
+        name: ratelimit
+        typed_config:
+          "@type": type.googleapis.com/envoy.config.filter.network.rate_limit.v2.RateLimit
           domain: foo
           stats_prefix: name
           descriptors: [{"key": "foo", "value": "bar"}]
       filters:
         name: envoy.filters.network.echo
-        config:
       )EOF";
   }
 

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -64,9 +64,9 @@ public:
   void encodeTrailers(const Http::HeaderMap& trailers);
   void encodeResetStream();
   void encodeMetadata(const Http::MetadataMapVector& metadata_map_vector);
-  const Http::HeaderMap& headers() { return *headers_; }
+  const Http::RequestHeaderMap& headers() { return *headers_; }
   void setAddServedByHeader(bool add_header) { add_served_by_header_ = add_header; }
-  const Http::HeaderMapPtr& trailers() { return trailers_; }
+  const Http::RequestTrailerMapPtr& trailers() { return trailers_; }
   bool receivedData() { return received_data_; }
 
   ABSL_MUST_USE_RESULT
@@ -175,14 +175,14 @@ public:
   }
 
 protected:
-  Http::HeaderMapPtr headers_;
+  Http::RequestHeaderMapPtr headers_;
 
 private:
   FakeHttpConnection& parent_;
   Http::ResponseEncoder& encoder_;
   Thread::MutexBasicLockable lock_;
   Thread::CondVar decoder_event_;
-  Http::HeaderMapPtr trailers_;
+  Http::RequestTrailerMapPtr trailers_;
   bool end_stream_{};
   Buffer::OwnedImpl body_;
   bool saw_reset_{};

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -64,6 +64,7 @@ public:
   void encodeTrailers(const Http::HeaderMap& trailers);
   void encodeResetStream();
   void encodeMetadata(const Http::MetadataMapVector& metadata_map_vector);
+  void readDisable(bool disable);
   const Http::RequestHeaderMap& headers() { return *headers_; }
   void setAddServedByHeader(bool add_header) { add_served_by_header_ = add_header; }
   const Http::RequestTrailerMapPtr& trailers() { return trailers_; }

--- a/test/integration/filters/add_trailers_filter.cc
+++ b/test/integration/filters/add_trailers_filter.cc
@@ -15,7 +15,8 @@ class AddTrailersStreamFilter : public Http::PassThroughFilter {
 public:
   Http::FilterDataStatus decodeData(Buffer::Instance&, bool end_stream) override {
     if (end_stream) {
-      decoder_callbacks_->addDecodedTrailers().setGrpcMessage("decode");
+      decoder_callbacks_->addDecodedTrailers().addCopy(Http::LowerCaseString("grpc-message"),
+                                                       "decode");
     }
 
     return Http::FilterDataStatus::Continue;

--- a/test/integration/h1_capture_direct_response_fuzz_test.cc
+++ b/test/integration/h1_capture_direct_response_fuzz_test.cc
@@ -31,8 +31,8 @@ void H1FuzzIntegrationTest::initialize() {
 DEFINE_PROTO_FUZZER(const test::integration::CaptureFuzzTestCase& input) {
   RELEASE_ASSERT(!TestEnvironment::getIpVersionsForTest().empty(), "");
   const auto ip_version = TestEnvironment::getIpVersionsForTest()[0];
-  H1FuzzIntegrationTest h1_fuzz_integration_test(ip_version);
-  h1_fuzz_integration_test.replay(input);
+  PERSISTENT_FUZZ_VAR H1FuzzIntegrationTest h1_fuzz_integration_test(ip_version);
+  h1_fuzz_integration_test.replay(input, true);
 }
 
 } // namespace Envoy

--- a/test/integration/h1_capture_fuzz_test.cc
+++ b/test/integration/h1_capture_fuzz_test.cc
@@ -7,8 +7,8 @@ DEFINE_PROTO_FUZZER(const test::integration::CaptureFuzzTestCase& input) {
   // Pick an IP version to use for loopback, it doesn't matter which.
   RELEASE_ASSERT(!TestEnvironment::getIpVersionsForTest().empty(), "");
   const auto ip_version = TestEnvironment::getIpVersionsForTest()[0];
-  H1FuzzIntegrationTest h1_fuzz_integration_test(ip_version);
-  h1_fuzz_integration_test.replay(input);
+  PERSISTENT_FUZZ_VAR H1FuzzIntegrationTest h1_fuzz_integration_test(ip_version);
+  h1_fuzz_integration_test.replay(input, false);
 }
 
 } // namespace Envoy

--- a/test/integration/h1_fuzz.h
+++ b/test/integration/h1_fuzz.h
@@ -15,7 +15,8 @@ public:
       : HttpIntegrationTest(Http::CodecClient::Type::HTTP1, version) {}
 
   void initialize() override;
-  void replay(const test::integration::CaptureFuzzTestCase&);
+  void replay(const test::integration::CaptureFuzzTestCase&, bool ignore_response);
   const std::chrono::milliseconds max_wait_ms_{10};
 };
+
 } // namespace Envoy

--- a/test/integration/header_integration_test.cc
+++ b/test/integration/header_integration_test.cc
@@ -39,7 +39,7 @@ void disableHeaderValueOptionAppend(
 
 const std::string http_connection_mgr_config = R"EOF(
 http_filters:
-  - name: envoy.router
+  - name: envoy.filters.http.router
 codec_type: HTTP1
 use_remote_address: false
 xff_num_trusted_hops: 1

--- a/test/integration/hotrestart_test.sh
+++ b/test/integration/hotrestart_test.sh
@@ -74,12 +74,14 @@ fi
 echo "Hot restart test using --base-id ${BASE_ID}"
 
 TEST_INDEX=0
-for HOT_RESTART_JSON in "${JSON_TEST_ARRAY[@]}"
-do
+function run_testsuite() {
+  local HOT_RESTART_JSON="$1"
+  local FAKE_SYMBOL_TABLE="$2"
+
   # TODO(jun03): instead of setting the base-id, the validate server should use the nop hot restart
   start_test validation
   check "${ENVOY_BIN}" -c "${HOT_RESTART_JSON}" --mode validate --service-cluster cluster \
-      --max-obj-name-len 500 --service-node node --base-id "${BASE_ID}"
+      --use-fake-symbol-table "$FAKE_SYMBOL_TABLE" --service-node node --base-id "${BASE_ID}"
 
   # Now start the real server, hot restart it twice, and shut it all down as a basic hot restart
   # sanity test.
@@ -87,12 +89,13 @@ do
   ADMIN_ADDRESS_PATH_0="${TEST_TMPDIR}"/admin.0."${TEST_INDEX}".address
   run_in_background_saving_pid "${ENVOY_BIN}" -c "${HOT_RESTART_JSON}" \
       --restart-epoch 0 --base-id "${BASE_ID}" --service-cluster cluster --service-node node \
-      --max-obj-name-len 500 --admin-address-path "${ADMIN_ADDRESS_PATH_0}"
+      --use-fake-symbol-table "$FAKE_SYMBOL_TABLE" --admin-address-path "${ADMIN_ADDRESS_PATH_0}"
 
   FIRST_SERVER_PID=$BACKGROUND_PID
 
   start_test Updating original config listener addresses
   sleep 3
+
   UPDATED_HOT_RESTART_JSON="${TEST_TMPDIR}"/hot_restart_updated."${TEST_INDEX}".yaml
   "${TEST_SRCDIR}/envoy"/tools/socket_passing "-o" "${HOT_RESTART_JSON}" "-a" "${ADMIN_ADDRESS_PATH_0}" \
     "-u" "${UPDATED_HOT_RESTART_JSON}"
@@ -115,10 +118,9 @@ do
   echo "Now checking that the above version is what we expected."
   check [ "${CLI_HOT_RESTART_VERSION}" = "${EXPECTED_CLI_HOT_RESTART_VERSION}" ]
 
-  # TODO(fredlas) max-obj-name-len is a deprecated no-op; can probably remove this test soon.
-  start_test Checking for consistency of /hot_restart_version with --max-obj-name-len 500
+  start_test Checking for consistency of /hot_restart_version with --use-fake-symbol-table "$FAKE_SYMBOL_TABLE"
   CLI_HOT_RESTART_VERSION=$("${ENVOY_BIN}" --hot-restart-version --base-id "${BASE_ID}" \
-    --max-obj-name-len 500 2>&1)
+    --use-fake-symbol-table "$FAKE_SYMBOL_TABLE" 2>&1)
   EXPECTED_CLI_HOT_RESTART_VERSION="11.104"
   check [ "${CLI_HOT_RESTART_VERSION}" = "${EXPECTED_CLI_HOT_RESTART_VERSION}" ]
 
@@ -128,8 +130,12 @@ do
   ADMIN_HOT_RESTART_VERSION=$(curl -sg http://${ADMIN_ADDRESS_0}/hot_restart_version)
   echo "Fetched ADMIN_HOT_RESTART_VERSION is ${ADMIN_HOT_RESTART_VERSION}"
   CLI_HOT_RESTART_VERSION=$("${ENVOY_BIN}" --hot-restart-version --base-id "${BASE_ID}" \
-    --max-obj-name-len 500 2>&1)
+    --use-fake-symbol-table "$FAKE_SYMBOL_TABLE" 2>&1)
   check [ "${ADMIN_HOT_RESTART_VERSION}" = "${CLI_HOT_RESTART_VERSION}" ]
+
+  start_test Checking server.hot_restart_generation 1
+  GENERATION_0=$(curl -sg http://${ADMIN_ADDRESS_0}/stats | grep server.hot_restart_generation)
+  check [ "$GENERATION_0" = "server.hot_restart_generation: 1" ];
 
   # Verify we can see server.live in the admin port.
   SERVER_LIVE_0=$(curl -sg http://${ADMIN_ADDRESS_0}/stats | grep server.live)
@@ -141,7 +147,7 @@ do
   ADMIN_ADDRESS_PATH_1="${TEST_TMPDIR}"/admin.1."${TEST_INDEX}".address
   run_in_background_saving_pid "${ENVOY_BIN}" -c "${UPDATED_HOT_RESTART_JSON}" \
       --restart-epoch 1 --base-id "${BASE_ID}" --service-cluster cluster --service-node node \
-      --max-obj-name-len 500 --admin-address-path "${ADMIN_ADDRESS_PATH_1}"
+      --use-fake-symbol-table "$FAKE_SYMBOL_TABLE" --admin-address-path "${ADMIN_ADDRESS_PATH_1}"
 
   SECOND_SERVER_PID=$BACKGROUND_PID
 
@@ -159,11 +165,15 @@ do
   CONFIG_DIFF=$(diff "${UPDATED_HOT_RESTART_JSON}" "${HOT_RESTART_JSON_1}")
   [[ -z "${CONFIG_DIFF}" ]]
 
+  start_test Checking server.hot_restart_generation 2
+  GENERATION_1=$(curl -sg http://${ADMIN_ADDRESS_1}/stats | grep server.hot_restart_generation)
+  check [ "$GENERATION_1" = "server.hot_restart_generation: 2" ];
+
   ADMIN_ADDRESS_PATH_2="${TEST_TMPDIR}"/admin.2."${TEST_INDEX}".address
   start_test Starting epoch 2
   run_in_background_saving_pid "${ENVOY_BIN}" -c "${UPDATED_HOT_RESTART_JSON}" \
       --restart-epoch 2  --base-id "${BASE_ID}" --service-cluster cluster --service-node node \
-      --max-obj-name-len 500 --admin-address-path "${ADMIN_ADDRESS_PATH_2}"
+      --use-fake-symbol-table "$FAKE_SYMBOL_TABLE" --admin-address-path "${ADMIN_ADDRESS_PATH_2}"
 
   THIRD_SERVER_PID=$BACKGROUND_PID
   sleep 3
@@ -194,7 +204,16 @@ do
   start_test Waiting for epoch 1
   wait ${SECOND_SERVER_PID}
   [[ $? == 0 ]]
-  TEST_INDEX=$((TEST_INDEX+1))
+}
+
+for HOT_RESTART_JSON in "${JSON_TEST_ARRAY[@]}"
+do
+  # Run one of the tests with real symbol tables. No need to do all of them.
+  if [ "$TEST_INDEX" = "0" ]; then
+    run_testsuite "$HOT_RESTART_JSON" "0" || exit 1
+  fi
+
+  run_testsuite "$HOT_RESTART_JSON" "1" || exit 1
 done
 
 start_test disabling hot_restart by command line.

--- a/test/integration/http2_upstream_integration_test.cc
+++ b/test/integration/http2_upstream_integration_test.cc
@@ -328,7 +328,7 @@ TEST_P(Http2UpstreamIntegrationTest, HittingEncoderFilterLimitForGrpc) {
             TestEnvironment::temporaryPath(TestUtility::uniqueFilename());
         // Configure just enough of an upstream access log to reference the upstream headers.
         const std::string yaml_string = R"EOF(
-name: envoy.router
+name: router
 typed_config:
   "@type": type.googleapis.com/envoy.config.filter.http.router.v2.Router
   upstream_log:
@@ -345,7 +345,7 @@ typed_config:
   // As with ProtocolIntegrationTest.HittingEncoderFilterLimit use a filter
   // which buffers response data but in this case, make sure the sendLocalReply
   // is gRPC.
-  config_helper_.addFilter("{ name: envoy.http_dynamo_filter, typed_config: { \"@type\": "
+  config_helper_.addFilter("{ name: envoy.filters.http.dynamo, typed_config: { \"@type\": "
                            "type.googleapis.com/google.protobuf.Empty } }");
   config_helper_.setBufferLimits(1024, 1024);
   initialize();
@@ -453,7 +453,7 @@ TEST_P(Http2UpstreamIntegrationTest, ConfigureHttpOverGrpcLogs) {
             TestEnvironment::temporaryPath(TestUtility::uniqueFilename());
         // Configure just enough of an upstream access log to reference the upstream headers.
         const std::string yaml_string = R"EOF(
-name: envoy.router
+name: router
 typed_config:
   "@type": type.googleapis.com/envoy.config.filter.http.router.v2.Router
   upstream_log:

--- a/test/integration/http_integration.cc
+++ b/test/integration/http_integration.cc
@@ -331,8 +331,8 @@ void HttpIntegrationTest::cleanupUpstreamAndDownstream() {
 }
 
 void HttpIntegrationTest::sendRequestAndVerifyResponse(
-    const Http::TestHeaderMapImpl& request_headers, const int request_size,
-    const Http::TestHeaderMapImpl& response_headers, const int response_size,
+    const Http::TestRequestHeaderMapImpl& request_headers, const int request_size,
+    const Http::TestResponseHeaderMapImpl& response_headers, const int response_size,
     const int backend_idx) {
   codec_client_ = makeHttpConnection(lookupPort("http"));
   auto response = sendRequestAndWaitForResponse(request_headers, request_size, response_headers,
@@ -346,13 +346,13 @@ void HttpIntegrationTest::sendRequestAndVerifyResponse(
 
 void HttpIntegrationTest::verifyResponse(IntegrationStreamDecoderPtr response,
                                          const std::string& response_code,
-                                         const Http::TestHeaderMapImpl& expected_headers,
+                                         const Http::TestResponseHeaderMapImpl& expected_headers,
                                          const std::string& expected_body) {
   EXPECT_TRUE(response->complete());
   EXPECT_EQ(response_code, response->headers().Status()->value().getStringView());
   expected_headers.iterate(
       [](const Http::HeaderEntry& header, void* context) -> Http::HeaderMap::Iterate {
-        auto response_headers = static_cast<Http::HeaderMap*>(context);
+        auto response_headers = static_cast<Http::ResponseHeaderMap*>(context);
         const Http::HeaderEntry* entry =
             response_headers->get(Http::LowerCaseString{std::string(header.key().getStringView())});
         EXPECT_NE(entry, nullptr);
@@ -811,7 +811,7 @@ void HttpIntegrationTest::testEnvoyProxying100Continue(bool continue_before_upst
                                                        bool with_encoder_filter) {
   if (with_encoder_filter) {
     // Because 100-continue only affects encoder filters, make sure it plays well with one.
-    config_helper_.addFilter("name: envoy.cors");
+    config_helper_.addFilter("name: envoy.filters.http.cors");
     config_helper_.addConfigModifier(
         [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
                 hcm) -> void {
@@ -1022,18 +1022,21 @@ void HttpIntegrationTest::testManyRequestHeaders(std::chrono::milliseconds time)
             max_request_headers_count_);
       });
 
-  Http::TestRequestHeaderMapImpl big_headers{
-      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}, {":authority", "host"}};
+  auto big_headers = Http::createHeaderMap<Http::RequestHeaderMapImpl>(
+      {{Http::Headers::get().Method, "GET"},
+       {Http::Headers::get().Path, "/test/long/url"},
+       {Http::Headers::get().Scheme, "http"},
+       {Http::Headers::get().Host, "host"}});
 
   for (int i = 0; i < 20000; i++) {
-    big_headers.addCopy(Http::LowerCaseString(std::to_string(i)), std::string(0, 'a'));
+    big_headers->addCopy(Http::LowerCaseString(std::to_string(i)), std::string(0, 'a'));
   }
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   auto response =
-      sendRequestAndWaitForResponse(big_headers, 0, default_response_headers_, 0, 0, time);
+      sendRequestAndWaitForResponse(*big_headers, 0, default_response_headers_, 0, 0, time);
 
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("200", response->headers().Status()->value().getStringView());

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -150,15 +150,15 @@ protected:
   // Verifies the response_headers contains the expected_headers, and response body matches given
   // body string.
   void verifyResponse(IntegrationStreamDecoderPtr response, const std::string& response_code,
-                      const Http::TestHeaderMapImpl& expected_headers,
+                      const Http::TestResponseHeaderMapImpl& expected_headers,
                       const std::string& expected_body);
 
   // Helper that sends a request to Envoy, and verifies if Envoy response headers and body size is
   // the same as the expected headers map.
   // Requires the "http" port has been registered.
-  void sendRequestAndVerifyResponse(const Http::TestHeaderMapImpl& request_headers,
+  void sendRequestAndVerifyResponse(const Http::TestRequestHeaderMapImpl& request_headers,
                                     const int request_size,
-                                    const Http::TestHeaderMapImpl& response_headers,
+                                    const Http::TestResponseHeaderMapImpl& response_headers,
                                     const int response_size, const int backend_idx);
 
   // Check for completion of upstream_request_, and a simple "200" response.

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -41,9 +41,9 @@ public:
   bool complete() { return saw_end_stream_; }
   bool reset() { return saw_reset_; }
   Http::StreamResetReason reset_reason() { return reset_reason_; }
-  const Http::HeaderMap* continue_headers() { return continue_headers_.get(); }
-  const Http::HeaderMap& headers() { return *headers_; }
-  const Http::HeaderMapPtr& trailers() { return trailers_; }
+  const Http::ResponseHeaderMap* continue_headers() { return continue_headers_.get(); }
+  const Http::ResponseHeaderMap& headers() { return *headers_; }
+  const Http::ResponseTrailerMapPtr& trailers() { return trailers_; }
   const Http::MetadataMap& metadata_map() { return *metadata_map_; }
   uint64_t keyCount(std::string key) { return duplicated_metadata_key_count_[key]; }
   void waitForContinueHeaders();
@@ -73,9 +73,9 @@ public:
 
 private:
   Event::Dispatcher& dispatcher_;
-  Http::HeaderMapPtr continue_headers_;
-  Http::HeaderMapPtr headers_;
-  Http::HeaderMapPtr trailers_;
+  Http::ResponseHeaderMapPtr continue_headers_;
+  Http::ResponseHeaderMapPtr headers_;
+  Http::ResponseTrailerMapPtr trailers_;
   Http::MetadataMapPtr metadata_map_{new Http::MetadataMap()};
   std::unordered_map<std::string, uint64_t> duplicated_metadata_key_count_;
   bool waiting_for_end_stream_{};

--- a/test/integration/integration_admin_test.cc
+++ b/test/integration/integration_admin_test.cc
@@ -117,7 +117,8 @@ std::string ContentType(const BufferingStreamDecoderPtr& response) {
 } // namespace
 
 TEST_P(IntegrationAdminTest, Admin) {
-  Stats::TestUtil::SymbolTableCreatorTestPeer::setUseFakeSymbolTables(false);
+  Stats::TestUtil::SymbolTableCreatorTestPeer symbol_table_creator_test_peer;
+  symbol_table_creator_test_peer.setUseFakeSymbolTables(false);
   initialize();
 
   BufferingStreamDecoderPtr response;
@@ -267,8 +268,9 @@ TEST_P(IntegrationAdminTest, Admin) {
   case Http::CodecClient::Type::HTTP1:
     EXPECT_EQ("   Count Lookup\n"
               "       1 http1.metadata_not_supported_error\n"
+              "       1 http1.response_flood\n"
               "\n"
-              "total: 1\n",
+              "total: 2\n",
               response->body());
     break;
   case Http::CodecClient::Type::HTTP2:

--- a/test/integration/integration_test.cc
+++ b/test/integration/integration_test.cc
@@ -329,8 +329,9 @@ TEST_P(IntegrationTest, UpstreamDisconnectWithTwoRequests) {
 // Test hitting the bridge filter with too many response bytes to buffer. Given
 // the headers are not proxied, the connection manager will send a local error reply.
 TEST_P(IntegrationTest, HittingGrpcFilterLimitBufferingHeaders) {
-  config_helper_.addFilter("{ name: envoy.grpc_http1_bridge, typed_config: { \"@type\": "
-                           "type.googleapis.com/google.protobuf.Empty } }");
+  config_helper_.addFilter(
+      "{ name: grpc_http1_bridge, typed_config: { \"@type\": "
+      "type.googleapis.com/envoy.config.filter.http.grpc_http1_bridge.v2.Config } }");
   config_helper_.setBufferLimits(1024, 1024);
 
   initialize();
@@ -489,7 +490,7 @@ TEST_P(IntegrationTest, Http09Enabled) {
   EXPECT_THAT(response, HasSubstr("connection: close"));
   EXPECT_THAT(response, Not(HasSubstr("transfer-encoding: chunked\r\n")));
 
-  std::unique_ptr<Http::TestHeaderMapImpl> upstream_headers =
+  std::unique_ptr<Http::TestRequestHeaderMapImpl> upstream_headers =
       reinterpret_cast<AutonomousUpstream*>(fake_upstreams_.front().get())->lastRequestHeaders();
   ASSERT_TRUE(upstream_headers != nullptr);
   EXPECT_EQ(upstream_headers->Host()->value(), "default.com");
@@ -508,7 +509,7 @@ TEST_P(IntegrationTest, Http10Enabled) {
   EXPECT_THAT(response, HasSubstr("connection: close"));
   EXPECT_THAT(response, Not(HasSubstr("transfer-encoding: chunked\r\n")));
 
-  std::unique_ptr<Http::TestHeaderMapImpl> upstream_headers =
+  std::unique_ptr<Http::TestRequestHeaderMapImpl> upstream_headers =
       reinterpret_cast<AutonomousUpstream*>(fake_upstreams_.front().get())->lastRequestHeaders();
   ASSERT_TRUE(upstream_headers != nullptr);
   EXPECT_EQ(upstream_headers->Host()->value(), "default.com");
@@ -534,7 +535,7 @@ TEST_P(IntegrationTest, TestInlineHeaders) {
                                 &response, true);
   EXPECT_THAT(response, HasSubstr("HTTP/1.1 200 OK\r\n"));
 
-  std::unique_ptr<Http::TestHeaderMapImpl> upstream_headers =
+  std::unique_ptr<Http::TestRequestHeaderMapImpl> upstream_headers =
       reinterpret_cast<AutonomousUpstream*>(fake_upstreams_.front().get())->lastRequestHeaders();
   ASSERT_TRUE(upstream_headers != nullptr);
   EXPECT_EQ(upstream_headers->Host()->value(), "foo.com");
@@ -565,7 +566,7 @@ TEST_P(IntegrationTest, Http10WithHostandKeepAliveAndLwsNoContentLength) {
   EXPECT_THAT(response, Not(HasSubstr("content-length:")));
   EXPECT_THAT(response, Not(HasSubstr("transfer-encoding: chunked\r\n")));
 
-  std::unique_ptr<Http::TestHeaderMapImpl> upstream_headers =
+  std::unique_ptr<Http::TestRequestHeaderMapImpl> upstream_headers =
       reinterpret_cast<AutonomousUpstream*>(fake_upstreams_.front().get())->lastRequestHeaders();
   ASSERT_TRUE(upstream_headers != nullptr);
   EXPECT_EQ(upstream_headers->Host()->value(), "foo.com");
@@ -576,7 +577,7 @@ TEST_P(IntegrationTest, Http10WithHostandKeepAliveAndContentLengthAndLws) {
   config_helper_.addConfigModifier(&setAllowHttp10WithDefaultHost);
   initialize();
   reinterpret_cast<AutonomousUpstream*>(fake_upstreams_.front().get())
-      ->setResponseHeaders(std::make_unique<Http::TestHeaderMapImpl>(
+      ->setResponseHeaders(std::make_unique<Http::TestResponseHeaderMapImpl>(
           Http::TestHeaderMapImpl({{":status", "200"}, {"content-length", "10"}})));
   std::string response;
   sendRawHttpAndWaitForResponse(lookupPort("http"),
@@ -968,8 +969,8 @@ TEST_P(IntegrationTest, ViaAppendWith100Continue) {
 TEST_P(IntegrationTest, TestDelayedConnectionTeardownOnGracefulClose) {
   // This test will trigger an early 413 Payload Too Large response due to buffer limits being
   // exceeded. The following filter is needed since the router filter will never trigger a 413.
-  config_helper_.addFilter("{ name: envoy.http_dynamo_filter, typed_config: { \"@type\": "
-                           "type.googleapis.com/google.protobuf.Empty } }");
+  config_helper_.addFilter("{ name: http_dynamo_filter, typed_config: { \"@type\": "
+                           "type.googleapis.com/envoy.config.filter.http.dynamo.v2.Dynamo } }");
   config_helper_.setBufferLimits(1024, 1024);
   initialize();
 
@@ -1003,8 +1004,8 @@ TEST_P(IntegrationTest, TestDelayedConnectionTeardownOnGracefulClose) {
 // Test configuration of the delayed close timeout on downstream HTTP/1.1 connections. A value of 0
 // disables delayed close processing.
 TEST_P(IntegrationTest, TestDelayedConnectionTeardownConfig) {
-  config_helper_.addFilter("{ name: envoy.http_dynamo_filter, typed_config: { \"@type\": "
-                           "type.googleapis.com/google.protobuf.Empty } }");
+  config_helper_.addFilter("{ name: http_dynamo_filter, typed_config: { \"@type\": "
+                           "type.googleapis.com/envoy.config.filter.http.dynamo.v2.Dynamo } }");
   config_helper_.setBufferLimits(1024, 1024);
   config_helper_.addConfigModifier(
       [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
@@ -1039,8 +1040,8 @@ TEST_P(IntegrationTest, TestDelayedConnectionTeardownConfig) {
 
 // Test that delay closed connections are eventually force closed when the timeout triggers.
 TEST_P(IntegrationTest, TestDelayedConnectionTeardownTimeoutTrigger) {
-  config_helper_.addFilter("{ name: envoy.http_dynamo_filter, typed_config: { \"@type\": "
-                           "type.googleapis.com/google.protobuf.Empty } }");
+  config_helper_.addFilter("{ name: http_dynamo_filter, typed_config: { \"@type\": "
+                           "type.googleapis.com/envoy.config.filter.http.dynamo.v2.Dynamo } }");
   config_helper_.setBufferLimits(1024, 1024);
   config_helper_.addConfigModifier(
       [](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
@@ -1174,6 +1175,55 @@ TEST_P(UpstreamEndpointIntegrationTest, TestUpstreamEndpointAddress) {
   initialize();
   EXPECT_STREQ(fake_upstreams_[0]->localAddress()->ip()->addressAsString().c_str(),
                Network::Test::getLoopbackAddressString(GetParam()).c_str());
+}
+
+// Send continuous pipelined requests while not reading responses, to check
+// HTTP/1.1 response flood protection.
+TEST_P(IntegrationTest, TestFlood) {
+  initialize();
+
+  // Set up a raw connection to easily send requests without reading responses.
+  Network::ClientConnectionPtr raw_connection = makeClientConnection(lookupPort("http"));
+  raw_connection->connect();
+
+  // Read disable so responses will queue up.
+  uint32_t bytes_to_send = 0;
+  raw_connection->readDisable(true);
+  // Track locally queued bytes, to make sure the outbound client queue doesn't back up.
+  raw_connection->addBytesSentCallback([&](uint64_t bytes) { bytes_to_send -= bytes; });
+
+  // Keep sending requests until flood protection kicks in and kills the connection.
+  while (raw_connection->state() == Network::Connection::State::Open) {
+    // These requests are missing the host header, so will provoke an internally generated error
+    // response from Envoy.
+    Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\n\r\nGET / HTTP/1.1\r\n\r\nGET / HTTP/1.1\r\n\r\n");
+    bytes_to_send += buffer.length();
+    raw_connection->write(buffer, false);
+    // Loop until all bytes are sent.
+    while (bytes_to_send > 0 && raw_connection->state() == Network::Connection::State::Open) {
+      raw_connection->dispatcher().run(Event::Dispatcher::RunType::NonBlock);
+    }
+  }
+
+  // Verify the connection was closed due to flood protection.
+  EXPECT_EQ(1, test_server_->counter("http1.response_flood")->value());
+}
+
+// Make sure flood protection doesn't kick in with many requests sent serially.
+TEST_P(IntegrationTest, TestManyBadRequests) {
+  initialize();
+
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  Http::TestRequestHeaderMapImpl bad_request{
+      {":method", "GET"}, {":path", "/test/long/url"}, {":scheme", "http"}};
+
+  for (int i = 0; i < 1; ++i) {
+    IntegrationStreamDecoderPtr response = codec_client_->makeHeaderOnlyRequest(bad_request);
+    response->waitForEndStream();
+    ASSERT_TRUE(response->complete());
+    EXPECT_THAT(response->headers(), HttpStatusIs("400"));
+  }
+  EXPECT_EQ(0, test_server_->counter("http1.response_flood")->value());
 }
 
 } // namespace Envoy

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -156,7 +156,7 @@ TEST_P(ProtocolIntegrationTest, RouterRedirect) {
 // Add a health check filter and verify correct computation of health based on upstream status.
 TEST_P(ProtocolIntegrationTest, ComputedHealthCheck) {
   config_helper_.addFilter(R"EOF(
-name: envoy.health_check
+name: health_check
 typed_config:
     "@type": type.googleapis.com/envoy.config.filter.http.health_check.v2.HealthCheck
     pass_through_mode: false
@@ -177,7 +177,7 @@ typed_config:
 // Add a health check filter and verify correct computation of health based on upstream status.
 TEST_P(ProtocolIntegrationTest, ModifyBuffer) {
   config_helper_.addFilter(R"EOF(
-name: envoy.health_check
+name: health_check
 typed_config:
     "@type": type.googleapis.com/envoy.config.filter.http.health_check.v2.HealthCheck
     pass_through_mode: false
@@ -211,7 +211,10 @@ typed_config:
   response->waitForEndStream();
 
   if (upstreamProtocol() == FakeHttpConnection::Type::HTTP2) {
-    EXPECT_EQ("decode", upstream_request_->trailers()->GrpcMessage()->value().getStringView());
+    EXPECT_EQ("decode", upstream_request_->trailers()
+                            ->get(Http::LowerCaseString("grpc-message"))
+                            ->value()
+                            .getStringView());
   }
   EXPECT_TRUE(response->complete());
   EXPECT_EQ("503", response->headers().Status()->value().getStringView());
@@ -531,7 +534,7 @@ TEST_P(ProtocolIntegrationTest, RetryHittingRouteLimits) {
 // Test hitting the dynamo filter with too many request bytes to buffer. Ensure the connection
 // manager sends a 413.
 TEST_P(DownstreamProtocolIntegrationTest, HittingDecoderFilterLimit) {
-  config_helper_.addFilter("{ name: envoy.http_dynamo_filter, typed_config: { \"@type\": "
+  config_helper_.addFilter("{ name: envoy.filters.http.dynamo, typed_config: { \"@type\": "
                            "type.googleapis.com/google.protobuf.Empty } }");
   config_helper_.setBufferLimits(1024, 1024);
   initialize();
@@ -567,7 +570,7 @@ TEST_P(DownstreamProtocolIntegrationTest, HittingDecoderFilterLimit) {
 // are sent on early, the stream/connection will be reset.
 TEST_P(ProtocolIntegrationTest, HittingEncoderFilterLimit) {
   useAccessLog();
-  config_helper_.addFilter("{ name: envoy.http_dynamo_filter, typed_config: { \"@type\": "
+  config_helper_.addFilter("{ name: envoy.filters.http.dynamo, typed_config: { \"@type\": "
                            "type.googleapis.com/google.protobuf.Empty } }");
   config_helper_.setBufferLimits(1024, 1024);
   initialize();
@@ -1142,7 +1145,7 @@ TEST_P(ProtocolIntegrationTest, LargeRequestMethod) {
 
 // Tests StopAllIterationAndBuffer. Verifies decode-headers-return-stop-all-filter calls decodeData
 // once after iteration is resumed.
-TEST_P(DownstreamProtocolIntegrationTest, testDecodeHeadersReturnsStopAll) {
+TEST_P(DownstreamProtocolIntegrationTest, TestDecodeHeadersReturnsStopAll) {
   config_helper_.addFilter(R"EOF(
 name: call-decodedata-once-filter
 )EOF");
@@ -1193,7 +1196,7 @@ name: passthrough-filter
 
 // Tests StopAllIterationAndWatermark. decode-headers-return-stop-all-watermark-filter sets buffer
 // limit to 100. Verifies data pause when limit is reached, and resume after iteration continues.
-TEST_P(DownstreamProtocolIntegrationTest, testDecodeHeadersReturnsStopAllWatermark) {
+TEST_P(DownstreamProtocolIntegrationTest, TestDecodeHeadersReturnsStopAllWatermark) {
   config_helper_.addFilter(R"EOF(
 name: decode-headers-return-stop-all-filter
 )EOF");
@@ -1251,7 +1254,7 @@ name: passthrough-filter
 }
 
 // Test two filters that return StopAllIterationAndBuffer back-to-back.
-TEST_P(DownstreamProtocolIntegrationTest, testTwoFiltersDecodeHeadersReturnsStopAll) {
+TEST_P(DownstreamProtocolIntegrationTest, TestTwoFiltersDecodeHeadersReturnsStopAll) {
   config_helper_.addFilter(R"EOF(
 name: decode-headers-return-stop-all-filter
 )EOF");
@@ -1299,7 +1302,7 @@ name: passthrough-filter
 }
 
 // Tests encodeHeaders() returns StopAllIterationAndBuffer.
-TEST_P(DownstreamProtocolIntegrationTest, testEncodeHeadersReturnsStopAll) {
+TEST_P(DownstreamProtocolIntegrationTest, TestEncodeHeadersReturnsStopAll) {
   config_helper_.addFilter(R"EOF(
 name: encode-headers-return-stop-all-filter
 )EOF");
@@ -1331,7 +1334,7 @@ name: encode-headers-return-stop-all-filter
 }
 
 // Tests encodeHeaders() returns StopAllIterationAndWatermark.
-TEST_P(DownstreamProtocolIntegrationTest, testEncodeHeadersReturnsStopAllWatermark) {
+TEST_P(DownstreamProtocolIntegrationTest, TestEncodeHeadersReturnsStopAllWatermark) {
   config_helper_.addFilter(R"EOF(
 name: encode-headers-return-stop-all-filter
 )EOF");

--- a/test/integration/proxy_proto_integration_test.cc
+++ b/test/integration/proxy_proto_integration_test.cc
@@ -18,7 +18,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, ProxyProtoIntegrationTest,
                          testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
                          TestUtility::ipTestParamsToString);
 
-TEST_P(ProxyProtoIntegrationTest, v1RouterRequestAndResponseWithBodyNoBuffer) {
+TEST_P(ProxyProtoIntegrationTest, V1RouterRequestAndResponseWithBodyNoBuffer) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     Network::ClientConnectionPtr conn = makeClientConnection(lookupPort("http"));
     Buffer::OwnedImpl buf("PROXY TCP4 1.2.3.4 254.254.254.254 65535 1234\r\n");
@@ -29,7 +29,7 @@ TEST_P(ProxyProtoIntegrationTest, v1RouterRequestAndResponseWithBodyNoBuffer) {
   testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
 }
 
-TEST_P(ProxyProtoIntegrationTest, v2RouterRequestAndResponseWithBodyNoBuffer) {
+TEST_P(ProxyProtoIntegrationTest, V2RouterRequestAndResponseWithBodyNoBuffer) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     Network::ClientConnectionPtr conn = makeClientConnection(lookupPort("http"));
     constexpr uint8_t buffer[] = {0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51, 0x55, 0x49,
@@ -43,7 +43,7 @@ TEST_P(ProxyProtoIntegrationTest, v2RouterRequestAndResponseWithBodyNoBuffer) {
   testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
 }
 
-TEST_P(ProxyProtoIntegrationTest, v1RouterRequestAndResponseWithBodyNoBufferV6) {
+TEST_P(ProxyProtoIntegrationTest, V1RouterRequestAndResponseWithBodyNoBufferV6) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     auto conn = makeClientConnection(lookupPort("http"));
     Buffer::OwnedImpl buf("PROXY TCP6 1:2:3::4 FE00:: 65535 1234\r\n");
@@ -54,7 +54,7 @@ TEST_P(ProxyProtoIntegrationTest, v1RouterRequestAndResponseWithBodyNoBufferV6) 
   testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
 }
 
-TEST_P(ProxyProtoIntegrationTest, v2RouterRequestAndResponseWithBodyNoBufferV6) {
+TEST_P(ProxyProtoIntegrationTest, V2RouterRequestAndResponseWithBodyNoBufferV6) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     constexpr uint8_t buffer[] = {0x0d, 0x0a, 0x0d, 0x0a, 0x00, 0x0d, 0x0a, 0x51, 0x55, 0x49, 0x54,
                                   0x0a, 0x21, 0x22, 0x00, 0x24, 0x00, 0x01, 0x00, 0x02, 0x00, 0x03,

--- a/test/integration/ratelimit_integration_test.cc
+++ b/test/integration/ratelimit_integration_test.cc
@@ -48,7 +48,7 @@ public:
                      "ratelimit", fake_upstreams_.back()->localAddress());
 
       envoy::config::listener::v3::Filter ratelimit_filter;
-      ratelimit_filter.set_name("envoy.rate_limit");
+      ratelimit_filter.set_name("envoy.filters.http.ratelimit");
       ratelimit_filter.mutable_typed_config()->PackFrom(proto_config_);
       config_helper_.addFilter(MessageUtil::getJsonStringFromMessage(ratelimit_filter));
     });
@@ -128,8 +128,8 @@ public:
   }
 
   void sendRateLimitResponse(envoy::service::ratelimit::v3::RateLimitResponse::Code code,
-                             const Http::HeaderMap& response_headers_to_add,
-                             const Http::HeaderMap& request_headers_to_add) {
+                             const Http::ResponseHeaderMap& response_headers_to_add,
+                             const Http::RequestHeaderMap& request_headers_to_add) {
     ratelimit_request_->startGrpcStream();
     envoy::service::ratelimit::v3::RateLimitResponse response_msg;
     response_msg.set_overall_code(code);
@@ -175,7 +175,7 @@ public:
     initiateClientConnection();
     waitForRatelimitRequest();
     sendRateLimitResponse(envoy::service::ratelimit::v3::RateLimitResponse::OK,
-                          Http::HeaderMapImpl{}, Http::HeaderMapImpl{});
+                          Http::ResponseHeaderMapImpl{}, Http::RequestHeaderMapImpl{});
     waitForSuccessfulUpstreamResponse();
     cleanup();
 
@@ -214,8 +214,8 @@ TEST_P(RatelimitIntegrationTest, Ok) { basicFlow(); }
 TEST_P(RatelimitIntegrationTest, OkWithHeaders) {
   initiateClientConnection();
   waitForRatelimitRequest();
-  Http::TestHeaderMapImpl ratelimit_response_headers{{"x-ratelimit-limit", "1000"},
-                                                     {"x-ratelimit-remaining", "500"}};
+  Http::TestResponseHeaderMapImpl ratelimit_response_headers{{"x-ratelimit-limit", "1000"},
+                                                             {"x-ratelimit-remaining", "500"}};
   Http::TestRequestHeaderMapImpl request_headers_to_add{{"x-ratelimit-done", "true"}};
 
   sendRateLimitResponse(envoy::service::ratelimit::v3::RateLimitResponse::OK,
@@ -251,7 +251,7 @@ TEST_P(RatelimitIntegrationTest, OverLimit) {
   initiateClientConnection();
   waitForRatelimitRequest();
   sendRateLimitResponse(envoy::service::ratelimit::v3::RateLimitResponse::OVER_LIMIT,
-                        Http::HeaderMapImpl{}, Http::HeaderMapImpl{});
+                        Http::ResponseHeaderMapImpl{}, Http::RequestHeaderMapImpl{});
   waitForFailedUpstreamResponse(429);
   cleanup();
 
@@ -263,10 +263,10 @@ TEST_P(RatelimitIntegrationTest, OverLimit) {
 TEST_P(RatelimitIntegrationTest, OverLimitWithHeaders) {
   initiateClientConnection();
   waitForRatelimitRequest();
-  Http::TestHeaderMapImpl ratelimit_response_headers{
+  Http::TestResponseHeaderMapImpl ratelimit_response_headers{
       {"x-ratelimit-limit", "1000"}, {"x-ratelimit-remaining", "0"}, {"retry-after", "33"}};
   sendRateLimitResponse(envoy::service::ratelimit::v3::RateLimitResponse::OVER_LIMIT,
-                        ratelimit_response_headers, Http::HeaderMapImpl{});
+                        ratelimit_response_headers, Http::RequestHeaderMapImpl{});
   waitForFailedUpstreamResponse(429);
 
   ratelimit_response_headers.iterate(

--- a/test/integration/redirect_integration_test.cc
+++ b/test/integration/redirect_integration_test.cc
@@ -75,7 +75,7 @@ protected:
     return new_stream;
   }
 
-  Http::TestHeaderMapImpl redirect_response_{
+  Http::TestResponseHeaderMapImpl redirect_response_{
       {":status", "302"}, {"content-length", "0"}, {"location", "http://authority2/new/url"}};
 
   std::vector<FakeHttpConnectionPtr> upstream_connections_;

--- a/test/integration/sds_dynamic_integration_test.cc
+++ b/test/integration/sds_dynamic_integration_test.cc
@@ -15,6 +15,7 @@
 
 #include "extensions/transport_sockets/tls/context_config_impl.h"
 #include "extensions/transport_sockets/tls/context_manager_impl.h"
+#include "extensions/transport_sockets/tls/ssl_socket.h"
 
 #include "test/common/grpc/grpc_client_integration.h"
 #include "test/config/integration/certs/clientcert_hash.h"
@@ -263,21 +264,7 @@ public:
           TestEnvironment::runfilesPath("test/config/integration/certs/servercert.pem"));
       tls_certificate->mutable_private_key()->set_filename(
           TestEnvironment::runfilesPath("test/config/integration/certs/serverkey.pem"));
-
-      if (use_combined_validation_context_) {
-        // Modify the listener context validation type to use combined certificate validation
-        // context.
-        auto* combined_config = common_tls_context->mutable_combined_validation_context();
-        auto* default_validation_context = combined_config->mutable_default_validation_context();
-        default_validation_context->add_verify_certificate_hash(TEST_CLIENT_CERT_HASH);
-        auto* secret_config = combined_config->mutable_validation_context_sds_secret_config();
-        setUpSdsConfig(secret_config, validation_secret_);
-      } else {
-        // Modify the listener context validation type to use dynamic certificate validation
-        // context.
-        auto* secret_config = common_tls_context->mutable_validation_context_sds_secret_config();
-        setUpSdsConfig(secret_config, validation_secret_);
-      }
+      setUpSdsValidationContext(common_tls_context);
       transport_socket->set_name("envoy.transport_sockets.tls");
       transport_socket->mutable_typed_config()->PackFrom(tls_context);
 
@@ -286,16 +273,90 @@ public:
       sds_cluster->MergeFrom(bootstrap.static_resources().clusters()[0]);
       sds_cluster->set_name("sds_cluster");
       sds_cluster->mutable_http2_protocol_options();
+
+      envoy::extensions::transport_sockets::tls::v3::UpstreamTlsContext upstream_tls_context;
+      if (share_validation_secret_) {
+        // Configure static cluster with SDS config referencing "validation_secret",
+        // which is going to be processed before LDS resources.
+        ASSERT(use_lds_);
+        setUpSdsValidationContext(upstream_tls_context.mutable_common_tls_context());
+      }
+      // Enable SSL/TLS with a client certificate in the first cluster.
+      auto* upstream_tls_certificate =
+          upstream_tls_context.mutable_common_tls_context()->add_tls_certificates();
+      upstream_tls_certificate->mutable_certificate_chain()->set_filename(
+          TestEnvironment::runfilesPath("test/config/integration/certs/clientcert.pem"));
+      upstream_tls_certificate->mutable_private_key()->set_filename(
+          TestEnvironment::runfilesPath("test/config/integration/certs/clientkey.pem"));
+      auto* upstream_transport_socket =
+          bootstrap.mutable_static_resources()->mutable_clusters(0)->mutable_transport_socket();
+      upstream_transport_socket->set_name("envoy.transport_sockets.tls");
+      upstream_transport_socket->mutable_typed_config()->PackFrom(upstream_tls_context);
     });
 
     HttpIntegrationTest::initialize();
+    registerTestServerPorts({"http"});
     client_ssl_ctx_ = createClientSslTransportSocketFactory({}, context_manager_, *api_);
   }
 
+  void setUpSdsValidationContext(
+      envoy::extensions::transport_sockets::tls::v3::CommonTlsContext* common_tls_context) {
+    if (use_combined_validation_context_) {
+      // Modify the listener context validation type to use combined certificate validation
+      // context.
+      auto* combined_config = common_tls_context->mutable_combined_validation_context();
+      auto* default_validation_context = combined_config->mutable_default_validation_context();
+      default_validation_context->add_verify_certificate_hash(TEST_CLIENT_CERT_HASH);
+      auto* secret_config = combined_config->mutable_validation_context_sds_secret_config();
+      setUpSdsConfig(secret_config, validation_secret_);
+    } else {
+      // Modify the listener context validation type to use dynamic certificate validation
+      // context.
+      auto* secret_config = common_tls_context->mutable_validation_context_sds_secret_config();
+      setUpSdsConfig(secret_config, validation_secret_);
+    }
+  }
+
+  void createUpstreams() override {
+    // Fake upstream with SSL/TLS for the first cluster.
+    fake_upstreams_.emplace_back(new FakeUpstream(
+        createUpstreamSslContext(), 0, FakeHttpConnection::Type::HTTP1, version_, timeSystem()));
+    create_xds_upstream_ = true;
+  }
+
+  Network::TransportSocketFactoryPtr createUpstreamSslContext() {
+    envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
+    auto* common_tls_context = tls_context.mutable_common_tls_context();
+    auto* tls_certificate = common_tls_context->add_tls_certificates();
+    tls_certificate->mutable_certificate_chain()->set_filename(
+        TestEnvironment::runfilesPath("test/config/integration/certs/clientcert.pem"));
+    tls_certificate->mutable_private_key()->set_filename(
+        TestEnvironment::runfilesPath("test/config/integration/certs/clientkey.pem"));
+
+    auto cfg = std::make_unique<Extensions::TransportSockets::Tls::ServerContextConfigImpl>(
+        tls_context, factory_context_);
+    static Stats::Scope* upstream_stats_store = new Stats::TestIsolatedStoreImpl();
+    return std::make_unique<Extensions::TransportSockets::Tls::ServerSslSocketFactory>(
+        std::move(cfg), context_manager_, *upstream_stats_store, std::vector<std::string>{});
+  }
+
+  void TearDown() override {
+    cleanUpXdsConnection();
+
+    client_ssl_ctx_.reset();
+    cleanupUpstreamAndDownstream();
+    codec_client_.reset();
+
+    test_server_.reset();
+    fake_upstreams_.clear();
+  }
+
   void enableCombinedValidationContext(bool enable) { use_combined_validation_context_ = enable; }
+  void shareValidationSecret(bool share) { share_validation_secret_ = share; }
 
 private:
   bool use_combined_validation_context_{false};
+  bool share_validation_secret_{false};
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersionsClientType, SdsDynamicDownstreamCertValidationContextTest,
@@ -326,6 +387,53 @@ TEST_P(SdsDynamicDownstreamCertValidationContextTest, CombinedCertValidationCont
     sendSdsResponse(getCvcSecretWithOnlyTrustedCa());
   };
   initialize();
+
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection();
+  };
+  testRouterHeaderOnlyRequestAndResponse(&creator);
+}
+
+// A test that verifies that both: static cluster and LDS listener are updated when using
+// the same verification secret (standalone validation context) from the SDS server.
+TEST_P(SdsDynamicDownstreamCertValidationContextTest, BasicWithSharedSecret) {
+  shareValidationSecret(true);
+  on_server_init_function_ = [this]() {
+    createSdsStream(*(fake_upstreams_[1]));
+    sendSdsResponse(getCvcSecret());
+  };
+  initialize();
+
+  // Wait for "ssl_context_updated_by_sds" counters to indicate that both resources
+  // depending on the verification_secret were updated.
+  test_server_->waitForCounterGe(
+      "cluster.cluster_0.client_ssl_socket_factory.ssl_context_update_by_sds", 1);
+  test_server_->waitForCounterGe(
+      listenerStatPrefix("server_ssl_socket_factory.ssl_context_update_by_sds"), 1);
+
+  ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
+    return makeSslClientConnection();
+  };
+  testRouterHeaderOnlyRequestAndResponse(&creator);
+}
+
+// A test that verifies that both: static cluster and LDS listener are updated when using
+// the same verification secret (combined validation context) from the SDS server.
+TEST_P(SdsDynamicDownstreamCertValidationContextTest, CombinedValidationContextWithSharedSecret) {
+  enableCombinedValidationContext(true);
+  shareValidationSecret(true);
+  on_server_init_function_ = [this]() {
+    createSdsStream(*(fake_upstreams_[1]));
+    sendSdsResponse(getCvcSecretWithOnlyTrustedCa());
+  };
+  initialize();
+
+  // Wait for "ssl_context_updated_by_sds" counters to indicate that both resources
+  // depending on the verification_secret were updated.
+  test_server_->waitForCounterGe(
+      "cluster.cluster_0.client_ssl_socket_factory.ssl_context_update_by_sds", 1);
+  test_server_->waitForCounterGe(
+      listenerStatPrefix("server_ssl_socket_factory.ssl_context_update_by_sds"), 1);
 
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection();

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -81,19 +81,22 @@ public:
     wrapped_scope_->deliverHistogramToSinks(histogram, value);
   }
 
-  Counter& counterFromStatName(StatName name) override {
+  Counter& counterFromStatNameWithTags(const StatName& name,
+                                       StatNameTagVectorOptConstRef tags) override {
     Thread::LockGuard lock(lock_);
-    return wrapped_scope_->counterFromStatName(name);
+    return wrapped_scope_->counterFromStatNameWithTags(name, tags);
   }
 
-  Gauge& gaugeFromStatName(StatName name, Gauge::ImportMode import_mode) override {
+  Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
+                                   Gauge::ImportMode import_mode) override {
     Thread::LockGuard lock(lock_);
-    return wrapped_scope_->gaugeFromStatName(name, import_mode);
+    return wrapped_scope_->gaugeFromStatNameWithTags(name, tags, import_mode);
   }
 
-  Histogram& histogramFromStatName(StatName name, Histogram::Unit unit) override {
+  Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
+                                           Histogram::Unit unit) override {
     Thread::LockGuard lock(lock_);
-    return wrapped_scope_->histogramFromStatName(name, unit);
+    return wrapped_scope_->histogramFromStatNameWithTags(name, tags, unit);
   }
   NullGaugeImpl& nullGauge(const std::string& str) override {
     return wrapped_scope_->nullGauge(str);
@@ -142,9 +145,10 @@ private:
 class TestIsolatedStoreImpl : public StoreRoot {
 public:
   // Stats::Scope
-  Counter& counterFromStatName(StatName name) override {
+  Counter& counterFromStatNameWithTags(const StatName& name,
+                                       StatNameTagVectorOptConstRef tags) override {
     Thread::LockGuard lock(lock_);
-    return store_.counterFromStatName(name);
+    return store_.counterFromStatNameWithTags(name, tags);
   }
   Counter& counter(const std::string& name) override {
     Thread::LockGuard lock(lock_);
@@ -155,17 +159,19 @@ public:
     return ScopePtr{new TestScopeWrapper(lock_, store_.createScope(name))};
   }
   void deliverHistogramToSinks(const Histogram&, uint64_t) override {}
-  Gauge& gaugeFromStatName(StatName name, Gauge::ImportMode import_mode) override {
+  Gauge& gaugeFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
+                                   Gauge::ImportMode import_mode) override {
     Thread::LockGuard lock(lock_);
-    return store_.gaugeFromStatName(name, import_mode);
+    return store_.gaugeFromStatNameWithTags(name, tags, import_mode);
   }
   Gauge& gauge(const std::string& name, Gauge::ImportMode import_mode) override {
     Thread::LockGuard lock(lock_);
     return store_.gauge(name, import_mode);
   }
-  Histogram& histogramFromStatName(StatName name, Histogram::Unit unit) override {
+  Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
+                                           Histogram::Unit unit) override {
     Thread::LockGuard lock(lock_);
-    return store_.histogramFromStatName(name, unit);
+    return store_.histogramFromStatNameWithTags(name, tags, unit);
   }
   NullGaugeImpl& nullGauge(const std::string& name) override { return store_.nullGauge(name); }
   Histogram& histogram(const std::string& name, Histogram::Unit unit) override {

--- a/test/integration/stats_integration_test.cc
+++ b/test/integration/stats_integration_test.cc
@@ -206,13 +206,7 @@ private:
 };
 class ClusterMemoryTestRunner : public testing::TestWithParam<Network::Address::IpVersion> {
 protected:
-  ClusterMemoryTestRunner() : save_use_fakes_(Stats::SymbolTableCreator::useFakeSymbolTables()) {}
-  ~ClusterMemoryTestRunner() override {
-    Stats::TestUtil::SymbolTableCreatorTestPeer::setUseFakeSymbolTables(save_use_fakes_);
-  }
-
-private:
-  const bool save_use_fakes_;
+  Stats::TestUtil::SymbolTableCreatorTestPeer symbol_table_creator_test_peer_;
 };
 
 INSTANTIATE_TEST_SUITE_P(IpVersions, ClusterMemoryTestRunner,
@@ -220,7 +214,7 @@ INSTANTIATE_TEST_SUITE_P(IpVersions, ClusterMemoryTestRunner,
                          TestUtility::ipTestParamsToString);
 
 TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithFakeSymbolTable) {
-  Stats::TestUtil::SymbolTableCreatorTestPeer::setUseFakeSymbolTables(true);
+  symbol_table_creator_test_peer_.setUseFakeSymbolTables(true);
 
   // A unique instance of ClusterMemoryTest allows for multiple runs of Envoy with
   // differing configuration. This is necessary for measuring the memory consumption
@@ -271,6 +265,8 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithFakeSymbolTable) {
   // 2020/01/09  9227     43637       44000   router: per-cluster histograms w/ timeout budget
   // 2020/01/12  9633     43797       44104   config: support recovery of original message when
   //                                          upgrading.
+  // 2020/02/13  10042    43797       44136   Metadata: Metadata are shared across different
+  //                                          clusters and hosts.
 
   // Note: when adjusting this value: EXPECT_MEMORY_EQ is active only in CI
   // 'release' builds, where we control the platform and tool-chain. So you
@@ -285,11 +281,11 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithFakeSymbolTable) {
   // https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#stats-memory-tests
   // for details on how to fix.
   EXPECT_MEMORY_EQ(m_per_cluster, 43797); // 104 bytes higher than a debug build.
-  EXPECT_MEMORY_LE(m_per_cluster, 44104);
+  EXPECT_MEMORY_LE(m_per_cluster, 44136);
 }
 
 TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithRealSymbolTable) {
-  Stats::TestUtil::SymbolTableCreatorTestPeer::setUseFakeSymbolTables(false);
+  symbol_table_creator_test_peer_.setUseFakeSymbolTables(false);
 
   // A unique instance of ClusterMemoryTest allows for multiple runs of Envoy with
   // differing configuration. This is necessary for measuring the memory consumption
@@ -343,7 +339,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeClusterSizeWithRealSymbolTable) {
 }
 
 TEST_P(ClusterMemoryTestRunner, MemoryLargeHostSizeWithStats) {
-  Stats::TestUtil::SymbolTableCreatorTestPeer::setUseFakeSymbolTables(false);
+  symbol_table_creator_test_peer_.setUseFakeSymbolTables(false);
 
   // A unique instance of ClusterMemoryTest allows for multiple runs of Envoy with
   // differing configuration. This is necessary for measuring the memory consumption
@@ -368,6 +364,8 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeHostSizeWithStats) {
   // 2019/11/12  8998     1299         1350   test: adjust memory limit for macOS
   // 2019/11/15  9040     1283         1350   build: update protobuf to 3.10.1
   // 2020/01/13  9663     1619         1655   api: deprecate hosts in Cluster.
+  // 2020/02/13  10042    1363         1655   Metadata object are shared across different clusters
+  //                                          and hosts.
 
   // Note: when adjusting this value: EXPECT_MEMORY_EQ is active only in CI
   // 'release' builds, where we control the platform and tool-chain. So you
@@ -377,7 +375,7 @@ TEST_P(ClusterMemoryTestRunner, MemoryLargeHostSizeWithStats) {
   // If you encounter a failure here, please see
   // https://github.com/envoyproxy/envoy/blob/master/source/docs/stats.md#stats-memory-tests
   // for details on how to fix.
-  EXPECT_MEMORY_EQ(m_per_host, 1619);
+  EXPECT_MEMORY_EQ(m_per_host, 1363);
   EXPECT_MEMORY_LE(m_per_host, 1655);
 }
 

--- a/test/integration/transport_socket_match_integration_test.cc
+++ b/test/integration/transport_socket_match_integration_test.cc
@@ -38,7 +38,7 @@ name: "tls_socket"
 match:
   mtlsReady: "true"
 transport_socket:
-  name: envoy.transport_sockets.tls
+  name: tls
   typed_config:
     "@type": type.googleapis.com/envoy.api.v2.auth.UpstreamTlsContext
     common_tls_context:

--- a/test/integration/utility.h
+++ b/test/integration/utility.h
@@ -27,7 +27,7 @@ public:
   BufferingStreamDecoder(std::function<void()> on_complete_cb) : on_complete_cb_(on_complete_cb) {}
 
   bool complete() { return complete_; }
-  const Http::HeaderMap& headers() { return *headers_; }
+  const Http::ResponseHeaderMap& headers() { return *headers_; }
   const std::string& body() { return body_; }
 
   // Http::StreamDecoder
@@ -48,7 +48,7 @@ public:
 private:
   void onComplete();
 
-  Http::HeaderMapPtr headers_;
+  Http::ResponseHeaderMapPtr headers_;
   std::string body_;
   bool complete_{};
   std::function<void()> on_complete_cb_;

--- a/test/integration/version_integration_test.cc
+++ b/test/integration/version_integration_test.cc
@@ -24,20 +24,20 @@ const char ExampleIpTaggingConfig[] = R"EOF(
           - {address_prefix: 1.2.3.4, prefix_len: 32}
 )EOF";
 
-// envoy.ip_tagging from v2 Struct config.
+// envoy.filters.http.ip_tagging from v2 Struct config.
 TEST_P(VersionIntegrationTest, DEPRECATED_FEATURE_TEST(IpTaggingV2StaticStructConfig)) {
   config_helper_.addFilter(absl::StrCat(R"EOF(
-  name: envoy.ip_tagging
+  name: envoy.filters.http.ip_tagging
   config:
   )EOF",
                                         ExampleIpTaggingConfig));
   initialize();
 }
 
-// envoy.ip_tagging from v2 TypedStruct config.
+// envoy.filters.http.ip_tagging from v2 TypedStruct config.
 TEST_P(VersionIntegrationTest, IpTaggingV2StaticTypedStructConfig) {
   config_helper_.addFilter(absl::StrCat(R"EOF(
-name: envoy.ip_tagging
+name: ip_tagging
 typed_config:
   "@type": type.googleapis.com/udpa.type.v1.TypedStruct
   type_url: type.googleapis.com/envoy.config.filter.http.ip_tagging.v2.IPTagging
@@ -47,10 +47,10 @@ typed_config:
   initialize();
 }
 
-// envoy.ip_tagging from v3 TypedStruct config.
+// envoy.filters.http.ip_tagging from v3 TypedStruct config.
 TEST_P(VersionIntegrationTest, IpTaggingV3StaticTypedStructConfig) {
   config_helper_.addFilter(absl::StrCat(R"EOF(
-name: envoy.ip_tagging
+name: ip_tagging
 typed_config:
   "@type": type.googleapis.com/udpa.type.v1.TypedStruct
   type_url: type.googleapis.com/envoy.extensions.filters.http.ip_tagging.v3.IPTagging
@@ -60,10 +60,10 @@ typed_config:
   initialize();
 }
 
-// envoy.ip_tagging from v2 typed Any config.
+// envoy.filters.http.ip_tagging from v2 typed Any config.
 TEST_P(VersionIntegrationTest, IpTaggingV2StaticTypedConfig) {
   config_helper_.addFilter(absl::StrCat(R"EOF(
-  name: envoy.ip_tagging
+  name: ip_tagging
   typed_config:
     "@type": type.googleapis.com/envoy.config.filter.http.ip_tagging.v2.IPTagging
   )EOF",
@@ -71,10 +71,10 @@ TEST_P(VersionIntegrationTest, IpTaggingV2StaticTypedConfig) {
   initialize();
 }
 
-// envoy.ip_tagging from v3 typed Any config.
+// envoy.filters.http.ip_tagging from v3 typed Any config.
 TEST_P(VersionIntegrationTest, IpTaggingV3StaticTypedConfig) {
   config_helper_.addFilter(absl::StrCat(R"EOF(
-  name: envoy.ip_tagging
+  name: ip_tagging
   typed_config:
     "@type": type.googleapis.com/envoy.extensions.filters.http.ip_tagging.v3.IPTagging
   )EOF",

--- a/test/integration/vhds_integration_test.cc
+++ b/test/integration/vhds_integration_test.cc
@@ -65,13 +65,13 @@ static_resources:
         port_value: 0
     filter_chains:
     - filters:
-      - name: envoy.filters.network.http_connection_manager
+      - name: http
         typed_config:
           "@type": type.googleapis.com/envoy.config.filter.network.http_connection_manager.v2.HttpConnectionManager
           stat_prefix: config_test
           http_filters:
           - name: envoy.filters.http.on_demand
-          - name: envoy.router
+          - name: envoy.filters.http.router
           codec_type: HTTP2
           rds:
             route_config_name: my_route

--- a/test/integration/websocket_integration_test.cc
+++ b/test/integration/websocket_integration_test.cc
@@ -21,13 +21,13 @@ namespace {
 
 Http::TestRequestHeaderMapImpl upgradeRequestHeaders(const char* upgrade_type = "websocket",
                                                      uint32_t content_length = 0) {
-  return Http::TestHeaderMapImpl{{":authority", "host"},
-                                 {"content-length", fmt::format("{}", content_length)},
-                                 {":path", "/websocket/test"},
-                                 {":method", "GET"},
-                                 {":scheme", "http"},
-                                 {"upgrade", upgrade_type},
-                                 {"connection", "keep-alive, upgrade"}};
+  return Http::TestRequestHeaderMapImpl{{":authority", "host"},
+                                        {"content-length", fmt::format("{}", content_length)},
+                                        {":path", "/websocket/test"},
+                                        {":method", "GET"},
+                                        {":scheme", "http"},
+                                        {"upgrade", upgrade_type},
+                                        {"connection", "keep-alive, upgrade"}};
 }
 
 Http::TestResponseHeaderMapImpl upgradeResponseHeaders(const char* upgrade_type = "websocket") {
@@ -37,12 +37,35 @@ Http::TestResponseHeaderMapImpl upgradeResponseHeaders(const char* upgrade_type 
                                          {"content-length", "0"}};
 }
 
+template <class ProxiedHeaders, class OriginalHeaders>
+void commonValidate(ProxiedHeaders& proxied_headers, const OriginalHeaders& original_headers) {
+  // 0 byte content lengths may be stripped on the H2 path - ignore that as a difference by adding
+  // it back to the proxied headers.
+  if (original_headers.ContentLength() && proxied_headers.ContentLength() == nullptr) {
+    proxied_headers.setContentLength(size_t(0));
+  }
+  // If no content length is specified, the HTTP1 codec will add a chunked encoding header.
+  if (original_headers.ContentLength() == nullptr &&
+      proxied_headers.TransferEncoding() != nullptr) {
+    ASSERT_EQ(proxied_headers.TransferEncoding()->value().getStringView(), "chunked");
+    proxied_headers.removeTransferEncoding();
+  }
+  if (proxied_headers.Connection() != nullptr &&
+      proxied_headers.Connection()->value() == "upgrade" &&
+      original_headers.Connection() != nullptr &&
+      original_headers.Connection()->value() == "keep-alive, upgrade") {
+    // The keep-alive is implicit for HTTP/1.1, so Envoy only sets the upgrade
+    // header when converting from HTTP/1.1 to H2
+    proxied_headers.setConnection("keep-alive, upgrade");
+  }
+}
+
 } // namespace
 
 void WebsocketIntegrationTest::validateUpgradeRequestHeaders(
-    const Http::HeaderMap& original_proxied_request_headers,
-    const Http::HeaderMap& original_request_headers) {
-  Http::TestHeaderMapImpl proxied_request_headers(original_proxied_request_headers);
+    const Http::RequestHeaderMap& original_proxied_request_headers,
+    const Http::RequestHeaderMap& original_request_headers) {
+  Http::TestRequestHeaderMapImpl proxied_request_headers(original_proxied_request_headers);
   if (proxied_request_headers.ForwardedProto()) {
     ASSERT_EQ(proxied_request_headers.ForwardedProto()->value().getStringView(), "http");
     proxied_request_headers.removeForwardedProto();
@@ -66,9 +89,9 @@ void WebsocketIntegrationTest::validateUpgradeRequestHeaders(
 }
 
 void WebsocketIntegrationTest::validateUpgradeResponseHeaders(
-    const Http::HeaderMap& original_proxied_response_headers,
-    const Http::HeaderMap& original_response_headers) {
-  Http::TestHeaderMapImpl proxied_response_headers(original_proxied_response_headers);
+    const Http::ResponseHeaderMap& original_proxied_response_headers,
+    const Http::ResponseHeaderMap& original_response_headers) {
+  Http::TestResponseHeaderMapImpl proxied_response_headers(original_proxied_response_headers);
 
   // Check for and remove headers added by default for HTTP responses.
   ASSERT_TRUE(proxied_response_headers.Date() != nullptr);
@@ -80,29 +103,6 @@ void WebsocketIntegrationTest::validateUpgradeResponseHeaders(
   commonValidate(proxied_response_headers, original_response_headers);
 
   EXPECT_THAT(&proxied_response_headers, HeaderMapEqualIgnoreOrder(&original_response_headers));
-}
-
-void WebsocketIntegrationTest::commonValidate(Http::HeaderMap& proxied_headers,
-                                              const Http::HeaderMap& original_headers) {
-  // 0 byte content lengths may be stripped on the H2 path - ignore that as a difference by adding
-  // it back to the proxied headers.
-  if (original_headers.ContentLength() && proxied_headers.ContentLength() == nullptr) {
-    proxied_headers.setContentLength(size_t(0));
-  }
-  // If no content length is specified, the HTTP1 codec will add a chunked encoding header.
-  if (original_headers.ContentLength() == nullptr &&
-      proxied_headers.TransferEncoding() != nullptr) {
-    ASSERT_EQ(proxied_headers.TransferEncoding()->value().getStringView(), "chunked");
-    proxied_headers.removeTransferEncoding();
-  }
-  if (proxied_headers.Connection() != nullptr &&
-      proxied_headers.Connection()->value() == "upgrade" &&
-      original_headers.Connection() != nullptr &&
-      original_headers.Connection()->value() == "keep-alive, upgrade") {
-    // The keep-alive is implicit for HTTP/1.1, so Envoy only sets the upgrade
-    // header when converting from HTTP/1.1 to H2
-    proxied_headers.setConnection("keep-alive, upgrade");
-  }
 }
 
 INSTANTIATE_TEST_SUITE_P(Protocols, WebsocketIntegrationTest,
@@ -352,7 +352,7 @@ TEST_P(WebsocketIntegrationTest, WebsocketCustomFilterChain) {
         auto* foo_upgrade = hcm.add_upgrade_configs();
         foo_upgrade->set_upgrade_type("foo");
         auto* filter_list_back = foo_upgrade->add_filters();
-        TestUtility::loadFromYaml("name: envoy.router", *filter_list_back);
+        TestUtility::loadFromYaml("name: envoy.filters.http.router", *filter_list_back);
       });
   initialize();
 

--- a/test/integration/websocket_integration_test.h
+++ b/test/integration/websocket_integration_test.h
@@ -21,11 +21,10 @@ protected:
                       const Http::TestResponseHeaderMapImpl& upgrade_response_headers);
   void sendBidirectionalData();
 
-  void validateUpgradeRequestHeaders(const Http::HeaderMap& proxied_request_headers,
-                                     const Http::HeaderMap& original_request_headers);
-  void validateUpgradeResponseHeaders(const Http::HeaderMap& proxied_response_headers,
-                                      const Http::HeaderMap& original_response_headers);
-  void commonValidate(Http::HeaderMap& proxied_headers, const Http::HeaderMap& original_headers);
+  void validateUpgradeRequestHeaders(const Http::RequestHeaderMap& proxied_request_headers,
+                                     const Http::RequestHeaderMap& original_request_headers);
+  void validateUpgradeResponseHeaders(const Http::ResponseHeaderMap& proxied_response_headers,
+                                      const Http::ResponseHeaderMap& original_response_headers);
 
   ABSL_MUST_USE_RESULT
   testing::AssertionResult waitForUpstreamDisconnectOrReset() {

--- a/test/integration/xfcc_integration_test.cc
+++ b/test/integration/xfcc_integration_test.cc
@@ -737,6 +737,7 @@ TEST_P(XfccIntegrationTest, TagExtractedNameGenerationTest) {
       {"server.memory_allocated", "server.memory_allocated"},
       {"http.admin.downstream_cx_http2_active", "http.downstream_cx_http2_active"},
       {"server.memory_heap_size", "server.memory_heap_size"},
+      {"server.memory_physical_size", "server.memory_physical_size"},
       {"listener_manager.total_listeners_draining", "listener_manager.total_listeners_draining"},
       {"filesystem.write_total_buffered", "filesystem.write_total_buffered"},
       {"http.admin.downstream_cx_ssl_active", "http.downstream_cx_ssl_active"},

--- a/test/mocks/server/BUILD
+++ b/test/mocks/server/BUILD
@@ -24,6 +24,7 @@ envoy_cc_mock(
         "@envoy//include/envoy/server:instance_interface",
         "@envoy//include/envoy/server:options_interface",
         "@envoy//include/envoy/server:overload_manager_interface",
+        "@envoy//include/envoy/server:tracer_config_interface",
         "@envoy//include/envoy/server:worker_interface",
         "@envoy//include/envoy/ssl:context_manager_interface",
         "@envoy//include/envoy/upstream:health_checker_interface",

--- a/test/mocks/server/mocks.cc
+++ b/test/mocks/server/mocks.cc
@@ -195,7 +195,8 @@ MockMain::MockMain(int wd_miss, int wd_megamiss, int wd_kill, int wd_multikill)
 MockMain::~MockMain() = default;
 
 MockServerFactoryContext::MockServerFactoryContext()
-    : singleton_manager_(new Singleton::ManagerImpl(Thread::threadFactoryForTest())) {
+    : singleton_manager_(new Singleton::ManagerImpl(Thread::threadFactoryForTest())),
+      grpc_context_(scope_.symbolTable()) {
   ON_CALL(*this, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
   ON_CALL(*this, dispatcher()).WillByDefault(ReturnRef(dispatcher_));
   ON_CALL(*this, drainDecision()).WillByDefault(ReturnRef(drain_manager_));
@@ -208,6 +209,7 @@ MockServerFactoryContext::MockServerFactoryContext()
   ON_CALL(*this, admin()).WillByDefault(ReturnRef(admin_));
   ON_CALL(*this, api()).WillByDefault(ReturnRef(api_));
   ON_CALL(*this, timeSource()).WillByDefault(ReturnRef(time_system_));
+  ON_CALL(*this, messageValidationContext()).WillByDefault(ReturnRef(validation_context_));
   ON_CALL(*this, messageValidationVisitor())
       .WillByDefault(ReturnRef(ProtobufMessage::getStrictValidationVisitor()));
   ON_CALL(*this, api()).WillByDefault(ReturnRef(api_));
@@ -217,6 +219,7 @@ MockServerFactoryContext::~MockServerFactoryContext() = default;
 MockFactoryContext::MockFactoryContext()
     : singleton_manager_(new Singleton::ManagerImpl(Thread::threadFactoryForTest())),
       grpc_context_(scope_.symbolTable()), http_context_(scope_.symbolTable()) {
+  ON_CALL(*this, getServerFactoryContext()).WillByDefault(ReturnRef(server_factory_context_));
   ON_CALL(*this, accessLogManager()).WillByDefault(ReturnRef(access_log_manager_));
   ON_CALL(*this, clusterManager()).WillByDefault(ReturnRef(cluster_manager_));
   ON_CALL(*this, dispatcher()).WillByDefault(ReturnRef(dispatcher_));
@@ -234,6 +237,7 @@ MockFactoryContext::MockFactoryContext()
   ON_CALL(*this, api()).WillByDefault(ReturnRef(api_));
   ON_CALL(*this, timeSource()).WillByDefault(ReturnRef(time_system_));
   ON_CALL(*this, overloadManager()).WillByDefault(ReturnRef(overload_manager_));
+  ON_CALL(*this, messageValidationContext()).WillByDefault(ReturnRef(validation_context_));
   ON_CALL(*this, messageValidationVisitor())
       .WillByDefault(ReturnRef(ProtobufMessage::getStrictValidationVisitor()));
   ON_CALL(*this, api()).WillByDefault(ReturnRef(api_));
@@ -270,6 +274,14 @@ MockHealthCheckerFactoryContext::~MockHealthCheckerFactoryContext() = default;
 
 MockFilterChainFactoryContext::MockFilterChainFactoryContext() = default;
 MockFilterChainFactoryContext::~MockFilterChainFactoryContext() = default;
+
+MockTracerFactoryContext::MockTracerFactoryContext() {
+  ON_CALL(*this, serverFactoryContext()).WillByDefault(ReturnRef(server_factory_context_));
+  ON_CALL(*this, messageValidationVisitor())
+      .WillByDefault(ReturnRef(ProtobufMessage::getStrictValidationVisitor()));
+}
+
+MockTracerFactoryContext::~MockTracerFactoryContext() = default;
 } // namespace Configuration
 } // namespace Server
 } // namespace Envoy

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -20,6 +20,7 @@
 #include "envoy/server/instance.h"
 #include "envoy/server/options.h"
 #include "envoy/server/overload_manager.h"
+#include "envoy/server/tracer_config.h"
 #include "envoy/server/transport_socket_config.h"
 #include "envoy/server/worker.h"
 #include "envoy/ssl/context_manager.h"
@@ -156,7 +157,7 @@ public:
                Stats::ScopePtr&& listener_scope));
   MOCK_METHOD(Http::Code, request,
               (absl::string_view path_and_query, absl::string_view method,
-               Http::HeaderMap& response_headers, std::string& body));
+               Http::ResponseHeaderMap& response_headers, std::string& body));
   MOCK_METHOD(void, addListenerToHandler, (Network::ConnectionHandler * handler));
 
   NiceMock<MockConfigTracker> config_tracker_;
@@ -170,7 +171,7 @@ public:
   MOCK_METHOD(void, setEndStreamOnComplete, (bool));
   MOCK_METHOD(void, addOnDestroyCallback, (std::function<void()>));
   MOCK_METHOD(const Buffer::Instance*, getRequestBody, (), (const));
-  MOCK_METHOD(Http::HeaderMap&, getRequestHeaders, (), (const));
+  MOCK_METHOD(Http::RequestHeaderMap&, getRequestHeaders, (), (const));
   MOCK_METHOD(NiceMock<Http::MockStreamDecoderFilterCallbacks>&, getDecoderFilterCallbacks, (),
               (const));
 };
@@ -406,9 +407,14 @@ public:
   MOCK_METHOD(ThreadLocal::Instance&, threadLocal, ());
   MOCK_METHOD(const LocalInfo::LocalInfo&, localInfo, (), (const));
   MOCK_METHOD(std::chrono::milliseconds, statsFlushInterval, (), (const));
+  MOCK_METHOD(void, flushStats, ());
   MOCK_METHOD(ProtobufMessage::ValidationContext&, messageValidationContext, ());
   MOCK_METHOD(Configuration::ServerFactoryContext&, serverFactoryContext, ());
   MOCK_METHOD(Configuration::TransportSocketFactoryContext&, transportSocketFactoryContext, ());
+
+  void setDefaultTracingConfig(const envoy::config::trace::v3::Tracing& tracing_config) override {
+    http_context_.setDefaultTracingConfig(tracing_config);
+  }
 
   TimeSource& timeSource() override { return time_system_; }
 
@@ -454,7 +460,6 @@ public:
   ~MockMain() override;
 
   MOCK_METHOD(Upstream::ClusterManager*, clusterManager, ());
-  MOCK_METHOD(Tracing::HttpTracer&, httpTracer, ());
   MOCK_METHOD(std::list<Stats::SinkPtr>&, statsSinks, ());
   MOCK_METHOD(std::chrono::milliseconds, statsFlushInterval, (), (const));
   MOCK_METHOD(std::chrono::milliseconds, wdMissTimeout, (), (const));
@@ -485,8 +490,10 @@ public:
   MOCK_METHOD(Server::Admin&, admin, ());
   MOCK_METHOD(TimeSource&, timeSource, ());
   Event::TestTimeSystem& timeSystem() { return time_system_; }
+  MOCK_METHOD(ProtobufMessage::ValidationContext&, messageValidationContext, ());
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
   MOCK_METHOD(Api::Api&, api, ());
+  Grpc::Context& grpcContext() override { return grpc_context_; }
 
   testing::NiceMock<Upstream::MockClusterManager> cluster_manager_;
   testing::NiceMock<Event::MockDispatcher> dispatcher_;
@@ -496,10 +503,12 @@ public:
   testing::NiceMock<Envoy::Runtime::MockLoader> runtime_loader_;
   testing::NiceMock<Stats::MockIsolatedStatsStore> scope_;
   testing::NiceMock<ThreadLocal::MockInstance> thread_local_;
+  testing::NiceMock<ProtobufMessage::MockValidationContext> validation_context_;
   Singleton::ManagerPtr singleton_manager_;
   testing::NiceMock<MockAdmin> admin_;
   Event::GlobalTimeSystem time_system_;
   testing::NiceMock<Api::MockApi> api_;
+  Grpc::ContextImpl grpc_context_;
 };
 
 class MockFactoryContext : public virtual FactoryContext {
@@ -514,7 +523,6 @@ public:
   MOCK_METHOD(Event::Dispatcher&, dispatcher, ());
   MOCK_METHOD(const Network::DrainDecision&, drainDecision, ());
   MOCK_METHOD(bool, healthCheckFailed, ());
-  MOCK_METHOD(Tracing::HttpTracer&, httpTracer, ());
   MOCK_METHOD(Init::Manager&, initManager, ());
   MOCK_METHOD(ServerLifecycleNotifier&, lifecycleNotifier, ());
   MOCK_METHOD(Envoy::Runtime::RandomGenerator&, random, ());
@@ -533,14 +541,15 @@ public:
   Grpc::Context& grpcContext() override { return grpc_context_; }
   Http::Context& httpContext() override { return http_context_; }
   MOCK_METHOD(ProcessContextOptRef, processContext, ());
+  MOCK_METHOD(ProtobufMessage::ValidationContext&, messageValidationContext, ());
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
   MOCK_METHOD(Api::Api&, api, ());
 
+  testing::NiceMock<MockServerFactoryContext> server_factory_context_;
   testing::NiceMock<AccessLog::MockAccessLogManager> access_log_manager_;
   testing::NiceMock<Upstream::MockClusterManager> cluster_manager_;
   testing::NiceMock<Event::MockDispatcher> dispatcher_;
   testing::NiceMock<MockDrainManager> drain_manager_;
-  testing::NiceMock<Tracing::MockHttpTracer> http_tracer_;
   testing::NiceMock<Init::MockManager> init_manager_;
   testing::NiceMock<MockServerLifecycleNotifier> lifecycle_notifier_;
   testing::NiceMock<LocalInfo::MockLocalInfo> local_info_;
@@ -552,6 +561,7 @@ public:
   testing::NiceMock<MockAdmin> admin_;
   Stats::IsolatedStoreImpl listener_scope_;
   Event::GlobalTimeSystem time_system_;
+  testing::NiceMock<ProtobufMessage::MockValidationContext> validation_context_;
   testing::NiceMock<MockOverloadManager> overload_manager_;
   Grpc::ContextImpl grpc_context_;
   Http::ContextImpl http_context_;
@@ -624,6 +634,17 @@ class MockFilterChainFactoryContext : public MockFactoryContext, public FilterCh
 public:
   MockFilterChainFactoryContext();
   ~MockFilterChainFactoryContext() override;
+};
+
+class MockTracerFactoryContext : public TracerFactoryContext {
+public:
+  MockTracerFactoryContext();
+  ~MockTracerFactoryContext() override;
+
+  MOCK_METHOD(ServerFactoryContext&, serverFactoryContext, ());
+  MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
+
+  testing::NiceMock<Configuration::MockServerFactoryContext> server_factory_context_;
 };
 
 } // namespace Configuration


### PR DESCRIPTION
NB: The following change is not backported (because the updated tests
started failing):
  > tls_inspector: enable TLSv1.3. (#118)

* envoy 10d40f5...1db15db (108):
  > router: add x-envoy-attempt-count on downstream responses (#10325)
  > direct_response: use data source (#10342)
  > stats: Don't use real symbol's decodeTokens function to extract fake-symbol dynamics (#10388)
  > router: add missing unit tests for x-envoy-attempt-count on upstream requests (#10368)
  > tcp: proxying TCP over HTTP/2 to upstreams (#10162)
  > [config] Add basic config validators for path rewrite, host rewrite and redirect actions (#10367)
  > [fuzz] split out the uber filter test class (#10249)
  > protobuf: refactor proto visitor pattern. (#10354)
  > router: trace mirrored requests (#10327)
  > Enable Windows CI //source/exe:envoy-static build (#10293)
  > [build] fix fuzz build mode macro and test runs (#10322)
  > build: allow building envoy on s390x (#10251)
  > lua: allow using moonjit (#10265)
  > ci: force install/link bazelisk package in macos dependency setup (#10357)
  > stats: Predefine symbols needed for user agent stats (#10302)
  > strip whitespace for retryon (#10298)
  > readme: update public meeting schedule (#10371)
  > build: use host gn and ninja on non-mainstream architectures (#10248)
  > Lrs example (#9920)
  > docs: fixed typo (#10350)
  > Python virtualvenv --no-site-packages arg is deprecated (#10338)
  > [api] Fix header validations #10335
  > test: Add bazel build extensions for benchmark targets (#10334)
  > Fix typo in docs (#10352)
  > tracing: Fix issue on aarch64 (#10344)
  > quiche: update tar (#10341)
  > coverage: disambiguate HCM UtilityTest from other UtilityTests. (#10339)
  > tracing: update LightStep tracer (#10152)
  > Expose fault.http.abort.http_status setting via HTTTP header (#10294)
  > api: embed tracing provider config into `http_connection_manager` (#10324)
  > check_format: process non-BUILD files before BUILD files. (#10330)
  > server: remove references to v1/2 from loadBootstrapConfig (#10320)
  > tracing: introduce `HttpTracerManager` abstraction and make `envoy.http_connection_manager` filter responsible for instantiating `HttpTracer` instances (#10240)
  > config: adding update time statistic. (#10220)
  > gzip: make use of generalized compression filter (#10306)
  > build: bump gperftools version (#10317)
  > filter: AWS Lambda filter (initial version) (#10260)
  > headers: Return number of header removals (#10295)
  > router: refactor for upcoming TCP upstream (#10305)
  > http: split header methods (#10252)
  > http: h2 codec refactor required for header split (#10283)
  > listener: fix tls inspector injection on deprecated name (#10309)
  > More fuzz tests for common http utility (#10276)
  > Add more fuzz tests for base64 functions (#10271)
  > aws_request_signing: a few fixes (#10280)
  > stats: Remove remaining calls to Stats::Scope::counter() et al in source/..., found by adding more patterns to the check-format script (#10189)
  > Request hash on filterstate (#10263)
  > network: add direct response network filter (#10210)
  > docs: Update proto format tool path (#10297)
  > fuzz: H1 capture fuzz test performance improvements. (#10281)
  > datasource: retry policy for remote data source (#9463)
  > http filters: fix filter_metadata when used with router and lua filters (#10285)
  > ssl: add utility to extract arbitrary X.509 extensions from TLS connection (#10203)
  > docs: Add example circuit breaker configuration (#10290)
  > test: remove descriptor file during test shutdown for transcoder test (#10288)
  > maintainers: add Greg back! (#10284)
  > admin: add ip address SAN in certs endpoint (#10246)
  > Fix conditional expression (#10278)
  > http: fix HCM crash when drain timeout races with protocol error (#10238)
  > Fix MetadataEncoderDecoderDeathTest.PackTooManyFrames in coverage build. (#10279)
  > stats: pass tags by const ref (#10267)
  > quiche: fix SpdyStringUtilsTest ASAN failure and disable quic_mem_slice_storage_test (#10268)
  > router: moving upstream to a new file (#10253)
  > lua: add fire-and-forget functionality to http call (#10145)
  > filters: add generic compressor filter (#7057)
  > stats: cleanup APIs and avoid extra conversions between StatName and string. (#10165)
  > http2: Fix extra frames and memory underflow in MetadataEncoder. (#9996)
  > test: use semantic names for all extensions (#10130)
  > deps: update cel-cpp and abseil (#10243)
  > runtime: Fix undefined behavior in the Snapshot::get method (#10151)
  > stats: clear the stats storage before asserting the symbol table is empty. (#10245)
  > http: http/1 codec refactor (#10199)
  > Fix doc build sed err 'extra char at the end of g cmd' (#10244)
  > common: add big-endian support to Ip6ntohl and Ip6htonl (#10250)
  > router: clarify max grpc timeout docs (#10247)
  > tracing: introduce `TracerFactoryContext` abstraction (#10234)
  > listener, srds, rds, vhds: replace FactoryContext with ServerFactoryContext in router/...  (#9779)
  > test: use semantic network filter names (#10122)
  > [fuzz] fix filter fuzz bugs (#10144)
  > stats: initialize store_ parameter on mock histograms (#10232)
  > Update jwt_verify_lib to 2020-02-11 (#10228)
  > test: fix test case capitalization (#10117)
  > runtime: Parse integers as booleans when necessary (#10133)
  > doc: Event RunType (#10185)
  > buffer: force copy when appending small slices to OwnedImpl buffer to avoid fragmentation
  > tls_inspector: enable TLSv1.3. (#118)
  > buffer: release empty slices after commit (#116)
  > sds: fix combined validation context validation bypassing (#114)
  > http: adding response flood protection
  > doc: fix SNI FAQ link (#10227)
  > listener filters: use new style names (#10193)
  > spelling: somewhat less pedantic spell checking (#10188)
  > stream_info: add response_flags mocks (#10215)
  > docker: fix typo in docker push script (#10219)
  > quiche: update tar (#10213)
  > dns cache: add missing logs (#10216)
  > docker: push SHA tag for release branch too (#10214)
  > jwt_authn: update base64 flavour in payload forward docs (#10204)
  > dns cache: add dns failure refresh rate (#10200)
  > [fuzz] fix fuzz tests that didn't validate configs (#10205)
  > Update Mongo Filter max time stat to be compatible with Mongo v3.2+ (#10206)
  > docs: fix config example in flow control faq (#10208)
  > Use os_sys_calls in all code paths to replace raw syscalls (#10107)
  > stats: allow specifying tags when creating metric objects (#9743)
  > dns: introduce ResolutionStatus for ResolveCb and fix #9927 (#10137)
  > http: more header map refactor (#10194)
  > route checker tool: differentiate between request and response headers (#10168)
  > http filters: use new style names (#10103)

Signed-off-by: Mikko Ylinen <mikko.ylinen@intel.com>