### PR TITLE
envoy: Update to 1.14.1

### DIFF
--- a/boringssl_compat/cbs.h
+++ b/boringssl_compat/cbs.h
@@ -12,10 +12,10 @@ namespace Extensions {
 namespace Common {
 namespace Cbs {
 
-struct CBS {
+typedef struct CBS {
   const uint8_t* data;
   size_t len;
-};
+} CBS;
 
 void CBS_init(CBS* cbs, const uint8_t* data, size_t len);
 

--- a/source/extensions/common/crypto/utility_impl.cc
+++ b/source/extensions/common/crypto/utility_impl.cc
@@ -17,10 +17,7 @@ std::vector<uint8_t> UtilityImpl::getSha256Digest(const Buffer::Instance& buffer
   EVP_MD_CTX* ctx(EVP_MD_CTX_new());
   auto rc = EVP_DigestInit(ctx, EVP_sha256());
   RELEASE_ASSERT(rc == 1, "Failed to init digest context");
-  const auto num_slices = buffer.getRawSlices(nullptr, 0);
-  absl::FixedArray<Buffer::RawSlice> slices(num_slices);
-  buffer.getRawSlices(slices.begin(), num_slices);
-  for (const auto& slice : slices) {
+  for (const auto& slice : buffer.getRawSlices()) {
     rc = EVP_DigestUpdate(ctx, slice.mem_, slice.len_);
     RELEASE_ASSERT(rc == 1, "Failed to update digest");
   }

--- a/source/extensions/filters/http/lua/lua_filter.cc
+++ b/source/extensions/filters/http/lua/lua_filter.cc
@@ -295,7 +295,8 @@ int StreamHandleWrapper::luaHttpCallAsynchronous(lua_State* state) {
   return 0;
 }
 
-void StreamHandleWrapper::onSuccess(Http::ResponseMessagePtr&& response) {
+void StreamHandleWrapper::onSuccess(const Http::AsyncClient::Request&,
+                                    Http::ResponseMessagePtr&& response) {
   ASSERT(state_ == State::HttpCall || state_ == State::Running);
   ENVOY_LOG(debug, "async HTTP response complete");
   http_request_ = nullptr;
@@ -341,7 +342,8 @@ void StreamHandleWrapper::onSuccess(Http::ResponseMessagePtr&& response) {
   }
 }
 
-void StreamHandleWrapper::onFailure(Http::AsyncClient::FailureReason) {
+void StreamHandleWrapper::onFailure(const Http::AsyncClient::Request& request,
+                                    Http::AsyncClient::FailureReason) {
   ASSERT(state_ == State::HttpCall || state_ == State::Running);
   ENVOY_LOG(debug, "async HTTP failure");
 
@@ -351,7 +353,7 @@ void StreamHandleWrapper::onFailure(Http::AsyncClient::FailureReason) {
           {{Http::Headers::get().Status,
             std::to_string(enumToInt(Http::Code::ServiceUnavailable))}})));
   response_message->body() = std::make_unique<Buffer::OwnedImpl>("upstream failure");
-  onSuccess(std::move(response_message));
+  onSuccess(request, std::move(response_message));
 }
 
 int StreamHandleWrapper::luaHeaders(lua_State* state) {

--- a/source/extensions/filters/http/lua/lua_filter.h
+++ b/source/extensions/filters/http/lua/lua_filter.h
@@ -253,8 +253,8 @@ private:
   }
 
   // Http::AsyncClient::Callbacks
-  void onSuccess(Http::ResponseMessagePtr&&) override;
-  void onFailure(Http::AsyncClient::FailureReason) override;
+  void onSuccess(const Http::AsyncClient::Request&, Http::ResponseMessagePtr&&) override;
+  void onFailure(const Http::AsyncClient::Request&, Http::AsyncClient::FailureReason) override;
 
   Filters::Common::Lua::Coroutine& coroutine_;
   Http::HeaderMap& headers_;
@@ -283,8 +283,8 @@ private:
 class NoopCallbacks : public Http::AsyncClient::Callbacks {
 public:
   // Http::AsyncClient::Callbacks
-  void onSuccess(Http::ResponseMessagePtr&&) override {}
-  void onFailure(Http::AsyncClient::FailureReason) override {}
+  void onSuccess(const Http::AsyncClient::Request&, Http::ResponseMessagePtr&&) override {}
+  void onFailure(const Http::AsyncClient::Request&, Http::AsyncClient::FailureReason) override {}
 };
 
 /**

--- a/source/extensions/filters/listener/tls_inspector/config.cc
+++ b/source/extensions/filters/listener/tls_inspector/config.cc
@@ -19,13 +19,15 @@ namespace TlsInspector {
 class TlsInspectorConfigFactory : public Server::Configuration::NamedListenerFilterConfigFactory {
 public:
   // NamedListenerFilterConfigFactory
-  Network::ListenerFilterFactoryCb
-  createFilterFactoryFromProto(const Protobuf::Message&,
-                               Server::Configuration::ListenerFactoryContext& context) override {
+  Network::ListenerFilterFactoryCb createListenerFilterFactoryFromProto(
+      const Protobuf::Message&,
+      const Network::ListenerFilterMatcherSharedPtr& listener_filter_matcher,
+      Server::Configuration::ListenerFactoryContext& context) override {
     ConfigSharedPtr config(new Config(context.scope()));
-    return [config](Network::ListenerFilterManager& filter_manager) -> void {
-      filter_manager.addAcceptFilter(std::make_unique<Filter>(config));
-    };
+    return
+        [listener_filter_matcher, config](Network::ListenerFilterManager& filter_manager) -> void {
+          filter_manager.addAcceptFilter(listener_filter_matcher, std::make_unique<Filter>(config));
+        };
   }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {

--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.h
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.h
@@ -9,6 +9,7 @@
 #include "common/common/logger.h"
 
 #include "boringssl_compat/bssl.h"
+#include "boringssl_compat/cbs.h"
 #include "openssl/ssl.h"
 
 namespace Envoy {
@@ -57,6 +58,8 @@ public:
   uint32_t maxClientHelloSize() const { return max_client_hello_size_; }
 
   static constexpr size_t TLS_MAX_CLIENT_HELLO = 64 * 1024;
+  static const unsigned TLS_MIN_SUPPORTED_VERSION;
+  static const unsigned TLS_MAX_SUPPORTED_VERSION;
 
 private:
   TlsInspectorStats stats_;
@@ -75,25 +78,21 @@ public:
 
   // Network::ListenerFilter
   Network::FilterStatus onAccept(Network::ListenerFilterCallbacks& cb) override;
-  void onALPN(const unsigned char* data, unsigned int len);
-  void onCert();
 
 private:
   ParseState parseClientHello(const void* data, size_t len);
   ParseState onRead();
   void done(bool success);
+  void onALPN(const unsigned char* data, unsigned int len);
   void onServername(absl::string_view name);
-  void setIstioApplicationProtocol();
 
   ConfigSharedPtr config_;
   Network::ListenerFilterCallbacks* cb_;
   Event::FileEventPtr file_event_;
-  Event::TimerPtr timer_;
 
   bssl::UniquePtr<SSL> ssl_;
   uint64_t read_{0};
   bool alpn_found_{false};
-  bool istio_protocol_required_{false};
   bool clienthello_success_{false};
 
   static thread_local uint8_t buf_[Config::TLS_MAX_CLIENT_HELLO];

--- a/source/extensions/transport_sockets/tls/context_config_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_config_impl.cc
@@ -138,11 +138,24 @@ Secret::TlsSessionTicketKeysConfigProviderSharedPtr getTlsSessionTicketKeysConfi
     }
   }
   case envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext::
+      SessionTicketKeysTypeCase::kDisableStatelessSessionResumption:
+  case envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext::
       SessionTicketKeysTypeCase::SESSION_TICKET_KEYS_TYPE_NOT_SET:
     return nullptr;
   default:
     throw EnvoyException(fmt::format("Unexpected case for oneof session_ticket_keys: {}",
                                      config.session_ticket_keys_type_case()));
+  }
+}
+
+bool getStatelessSessionResumptionDisabled(
+    const envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext& config) {
+  if (config.session_ticket_keys_type_case() ==
+      envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext::
+          SessionTicketKeysTypeCase::kDisableStatelessSessionResumption) {
+    return config.disable_stateless_session_resumption();
+  } else {
+    return false;
   }
 }
 
@@ -359,8 +372,9 @@ ServerContextConfigImpl::ServerContextConfigImpl(
                         DEFAULT_CIPHER_SUITES, DEFAULT_CURVES, factory_context),
       require_client_certificate_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, require_client_certificate, false)),
-      session_ticket_keys_provider_(
-          getTlsSessionTicketKeysConfigProvider(factory_context, config)) {
+      session_ticket_keys_provider_(getTlsSessionTicketKeysConfigProvider(factory_context, config)),
+      disable_stateless_session_resumption_(getStatelessSessionResumptionDisabled(config)) {
+
   if (session_ticket_keys_provider_ != nullptr) {
     // Validate tls session ticket keys early to reject bad sds updates.
     stk_validation_callback_handle_ = session_ticket_keys_provider_->addValidationCallback(

--- a/source/extensions/transport_sockets/tls/context_config_impl.h
+++ b/source/extensions/transport_sockets/tls/context_config_impl.h
@@ -147,6 +147,9 @@ public:
   }
 
   void setSecretUpdateCallback(std::function<void()> callback) override;
+  bool disableStatelessSessionResumption() const override {
+    return disable_stateless_session_resumption_;
+  }
 
 private:
   static const unsigned DEFAULT_MIN_VERSION;
@@ -165,6 +168,7 @@ private:
   ServerContextConfig::SessionTicketKey getSessionTicketKey(const std::string& key_data);
 
   absl::optional<std::chrono::seconds> session_timeout_;
+  const bool disable_stateless_session_resumption_;
 };
 
 } // namespace Tls

--- a/source/extensions/transport_sockets/tls/context_impl.cc
+++ b/source/extensions/transport_sockets/tls/context_impl.cc
@@ -975,7 +975,9 @@ ServerContextImpl::ServerContextImpl(Stats::Scope& scope,
           this);
     }
 
-    if (!session_ticket_keys_.empty()) {
+    if (config.disableStatelessSessionResumption()) {
+      SSL_CTX_set_options(ctx.ssl_ctx_.get(), SSL_OP_NO_TICKET);
+    } else if (!session_ticket_keys_.empty()) {
       SSL_CTX_set_tlsext_ticket_key_cb(
           ctx.ssl_ctx_.get(),
           +[](SSL* ssl, unsigned char key_name[16], unsigned char* iv, EVP_CIPHER_CTX* ctx, HMAC_CTX* hmac_ctx,

--- a/source/extensions/transport_sockets/tls/ssl_socket.cc
+++ b/source/extensions/transport_sockets/tls/ssl_socket.cc
@@ -157,8 +157,7 @@ Network::IoResult SslSocket::doRead(Buffer::Instance& read_buffer) {
     }
   }
 
-  ENVOY_CONN_LOG(trace, "ssl read {} bytes into {} slices", callbacks_->connection(), bytes_read,
-                 read_buffer.getRawSlices(nullptr, 0));
+  ENVOY_CONN_LOG(trace, "ssl read {} bytes", callbacks_->connection(), bytes_read);
 
   return {action, bytes_read, end_stream};
 }

--- a/test/extensions/common/aws/aws_metadata_fetcher_integration_test.cc
+++ b/test/extensions/common/aws/aws_metadata_fetcher_integration_test.cc
@@ -17,7 +17,8 @@ public:
       : BaseIntegrationTest(Network::Address::IpVersion::v4, renderConfig(status_code, delay_s)) {}
 
   static std::string renderConfig(int status_code, int delay_s) {
-    return fmt::format(ConfigHelper::BASE_CONFIG + R"EOF(
+    return absl::StrCat(ConfigHelper::baseConfig(),
+                        fmt::format(R"EOF(
     filter_chains:
       filters:
         name: http
@@ -66,7 +67,7 @@ public:
               domains: "*"
             name: route_config_0
       )EOF",
-                       delay_s, delay_s > 0 ? 0 : 1000, status_code, status_code);
+                                    delay_s, delay_s > 0 ? 0 : 1000, status_code, status_code));
   }
 
   void SetUp() override { BaseIntegrationTest::initialize(); }

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_benchmark.cc
@@ -67,7 +67,9 @@ public:
 };
 
 static void BM_TlsInspector(benchmark::State& state) {
-  NiceMock<FastMockOsSysCalls> os_sys_calls(Envoy::Extensions::ListenerFilters::TlsInspector::Test::generateClientHello("example.com", "\x02h2\x08http/1.1"));
+  NiceMock<FastMockOsSysCalls> os_sys_calls(Tls::Test::generateClientHello(
+      Config::TLS_MIN_SUPPORTED_VERSION, Config::TLS_MAX_SUPPORTED_VERSION, "example.com",
+      "\x02h2\x08http/1.1"));
   TestThreadsafeSingletonInjector<Api::OsSysCallsImpl> os_calls{&os_sys_calls};
   NiceMock<Stats::MockStore> store;
   ConfigSharedPtr cfg(std::make_shared<Config>(store));
@@ -79,7 +81,7 @@ static void BM_TlsInspector(benchmark::State& state) {
   for (auto _ : state) {
     Filter filter(cfg);
     filter.onAccept(cb);
-    dispatcher.file_event_callback_(Event::FileReadyType::Read);
+    RELEASE_ASSERT(dispatcher.file_event_callback_ == nullptr, "");
     RELEASE_ASSERT(socket.detectedTransportProtocol() == "tls", "");
     RELEASE_ASSERT(socket.requestedServerName() == "example.com", "");
     RELEASE_ASSERT(socket.requestedApplicationProtocols().size() == 2 &&
@@ -97,16 +99,3 @@ BENCHMARK(BM_TlsInspector)->Unit(benchmark::kMicrosecond);
 } // namespace ListenerFilters
 } // namespace Extensions
 } // namespace Envoy
-
-// Boilerplate main(), which discovers benchmarks in the same file and runs them.
-int main(int argc, char** argv) {
-  Envoy::Thread::MutexBasicLockable lock;
-  Envoy::Logger::Context logging_context(spdlog::level::warn,
-                                         Envoy::Logger::Logger::DEFAULT_LOG_FORMAT, lock, false);
-
-  benchmark::Initialize(&argc, argv);
-  if (benchmark::ReportUnrecognizedArguments(argc, argv)) {
-    return 1;
-  }
-  benchmark::RunSpecifiedBenchmarks();
-}

--- a/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_inspector_test.cc
@@ -27,7 +27,7 @@ namespace ListenerFilters {
 namespace TlsInspector {
 namespace {
 
-class TlsInspectorTest : public testing::Test {
+class TlsInspectorTest : public testing::TestWithParam<std::tuple<uint16_t, uint16_t>> {
 public:
   TlsInspectorTest()
       : cfg_(std::make_shared<Config>(store_)),
@@ -41,6 +41,13 @@ public:
     EXPECT_CALL(cb_, dispatcher()).WillRepeatedly(ReturnRef(dispatcher_));
     EXPECT_CALL(socket_, ioHandle()).WillRepeatedly(ReturnRef(*io_handle_));
 
+    // Prepare the first recv attempt during
+    EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
+        .WillOnce(
+            Invoke([](os_fd_t fd, void* buffer, size_t length, int flag) -> Api::SysCallSizeResult {
+              ENVOY_LOG_MISC(error, "In mock syscall recv {} {} {} {}", fd, buffer, length, flag);
+              return Api::SysCallSizeResult{static_cast<ssize_t>(0), 0};
+            }));
     EXPECT_CALL(dispatcher_,
                 createFileEvent_(_, _, Event::FileTriggerType::Edge,
                                  Event::FileReadyType::Read | Event::FileReadyType::Closed))
@@ -61,14 +68,22 @@ public:
   Network::IoHandlePtr io_handle_;
 };
 
+INSTANTIATE_TEST_SUITE_P(TlsProtocolVersions, TlsInspectorTest,
+                         testing::Values(std::make_tuple(Config::TLS_MIN_SUPPORTED_VERSION,
+                                                         Config::TLS_MAX_SUPPORTED_VERSION),
+                                         std::make_tuple(TLS1_VERSION, TLS1_VERSION),
+                                         std::make_tuple(TLS1_1_VERSION, TLS1_1_VERSION),
+                                         std::make_tuple(TLS1_2_VERSION, TLS1_2_VERSION),
+                                         std::make_tuple(TLS1_3_VERSION, TLS1_3_VERSION)));
+
 // Test that an exception is thrown for an invalid value for max_client_hello_size
-TEST_F(TlsInspectorTest, MaxClientHelloSize) {
+TEST_P(TlsInspectorTest, MaxClientHelloSize) {
   EXPECT_THROW_WITH_MESSAGE(Config(store_, Config::TLS_MAX_CLIENT_HELLO + 1), EnvoyException,
                             "max_client_hello_size of 65537 is greater than maximum of 65536.");
 }
 
 // Test that the filter detects Closed events and terminates.
-TEST_F(TlsInspectorTest, ConnectionClosed) {
+TEST_P(TlsInspectorTest, ConnectionClosed) {
   init();
   EXPECT_CALL(cb_, continueFilterChain(false));
   file_event_callback_(Event::FileReadyType::Closed);
@@ -76,7 +91,7 @@ TEST_F(TlsInspectorTest, ConnectionClosed) {
 }
 
 // Test that the filter detects detects read errors.
-TEST_F(TlsInspectorTest, ReadError) {
+TEST_P(TlsInspectorTest, ReadError) {
   init();
   EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK)).WillOnce(InvokeWithoutArgs([]() {
     return Api::SysCallSizeResult{ssize_t(-1), ENOTSUP};
@@ -87,11 +102,11 @@ TEST_F(TlsInspectorTest, ReadError) {
 }
 
 // Test that a ClientHello with an SNI value causes the correct name notification.
-TEST_F(TlsInspectorTest, SniRegistered) {
+TEST_P(TlsInspectorTest, SniRegistered) {
   init();
   const std::string servername("example.com");
-  std::vector<uint8_t> client_hello =
-      Envoy::Extensions::ListenerFilters::TlsInspector::Test::generateClientHello(servername, "");
+  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello(
+      std::get<0>(GetParam()), std::get<1>(GetParam()), servername, "");
   EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
       .WillOnce(Invoke(
           [&client_hello](os_fd_t, void* buffer, size_t length, int) -> Api::SysCallSizeResult {
@@ -100,8 +115,7 @@ TEST_F(TlsInspectorTest, SniRegistered) {
             return Api::SysCallSizeResult{ssize_t(client_hello.size()), 0};
           }));
   EXPECT_CALL(socket_, setRequestedServerName(Eq(servername)));
-  // Not valid for ALPN "istio" application protocol hack for openssl
-  EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(1);
+  EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
   EXPECT_CALL(socket_, setDetectedTransportProtocol(absl::string_view("tls")));
   EXPECT_CALL(cb_, continueFilterChain(true));
   file_event_callback_(Event::FileReadyType::Read);
@@ -111,13 +125,12 @@ TEST_F(TlsInspectorTest, SniRegistered) {
 }
 
 // Test that a ClientHello with an ALPN value causes the correct name notification.
-TEST_F(TlsInspectorTest, AlpnRegistered) {
+TEST_P(TlsInspectorTest, AlpnRegistered) {
   init();
   const std::vector<absl::string_view> alpn_protos = {absl::string_view("h2"),
                                                       absl::string_view("http/1.1")};
-  std::vector<uint8_t> client_hello =
-      Envoy::Extensions::ListenerFilters::TlsInspector::Test::generateClientHello("",
-                                                                            "\x02h2\x08http/1.1");
+  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello(
+      std::get<0>(GetParam()), std::get<1>(GetParam()), "", "\x02h2\x08http/1.1");
   EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
       .WillOnce(Invoke(
           [&client_hello](os_fd_t, void* buffer, size_t length, int) -> Api::SysCallSizeResult {
@@ -136,12 +149,12 @@ TEST_F(TlsInspectorTest, AlpnRegistered) {
 }
 
 // Test with the ClientHello spread over multiple socket reads.
-TEST_F(TlsInspectorTest, MultipleReads) {
+TEST_P(TlsInspectorTest, MultipleReads) {
   init();
   const std::vector<absl::string_view> alpn_protos = {absl::string_view("h2")};
   const std::string servername("example.com");
-  std::vector<uint8_t> client_hello =
-      Envoy::Extensions::ListenerFilters::TlsInspector::Test::generateClientHello(servername, "\x02h2");
+  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello(
+      std::get<0>(GetParam()), std::get<1>(GetParam()), servername, "\x02h2");
   {
     InSequence s;
     EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
@@ -175,10 +188,10 @@ TEST_F(TlsInspectorTest, MultipleReads) {
 }
 
 // Test that the filter correctly handles a ClientHello with no extensions present.
-TEST_F(TlsInspectorTest, NoExtensions) {
+TEST_P(TlsInspectorTest, NoExtensions) {
   init();
   std::vector<uint8_t> client_hello =
-      Envoy::Extensions::ListenerFilters::TlsInspector::Test::generateClientHello("", "");
+      Tls::Test::generateClientHello(std::get<0>(GetParam()), std::get<1>(GetParam()), "", "");
   EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
       .WillOnce(Invoke(
           [&client_hello](os_fd_t, void* buffer, size_t length, int) -> Api::SysCallSizeResult {
@@ -187,8 +200,7 @@ TEST_F(TlsInspectorTest, NoExtensions) {
             return Api::SysCallSizeResult{ssize_t(client_hello.size()), 0};
           }));
   EXPECT_CALL(socket_, setRequestedServerName(_)).Times(0);
-// 0 times not valid for ALPN "istio" application protocol hack for openssl
-  EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(1);
+  EXPECT_CALL(socket_, setRequestedApplicationProtocols(_)).Times(0);
   EXPECT_CALL(socket_, setDetectedTransportProtocol(absl::string_view("tls")));
   EXPECT_CALL(cb_, continueFilterChain(true));
   file_event_callback_(Event::FileReadyType::Read);
@@ -199,11 +211,11 @@ TEST_F(TlsInspectorTest, NoExtensions) {
 
 // Test that the filter fails if the ClientHello is larger than the
 // maximum allowed size.
-TEST_F(TlsInspectorTest, ClientHelloTooBig) {
+TEST_P(TlsInspectorTest, ClientHelloTooBig) {
   const size_t max_size = 50;
   cfg_ = std::make_shared<Config>(store_, static_cast<uint32_t>(max_size));
-  std::vector<uint8_t> client_hello =
-      Envoy::Extensions::ListenerFilters::TlsInspector::Test::generateClientHello("example.com", "");
+  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello(
+      std::get<0>(GetParam()), std::get<1>(GetParam()), "example.com", "");
   ASSERT(client_hello.size() > max_size);
   init();
   EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
@@ -219,7 +231,7 @@ TEST_F(TlsInspectorTest, ClientHelloTooBig) {
 }
 
 // Test that the filter fails on non-SSL data
-TEST_F(TlsInspectorTest, NotSsl) {
+TEST_P(TlsInspectorTest, NotSsl) {
   init();
   std::vector<uint8_t> data;
 
@@ -238,7 +250,7 @@ TEST_F(TlsInspectorTest, NotSsl) {
   EXPECT_EQ(1, cfg_->stats().tls_not_found_.value());
 }
 
-TEST_F(TlsInspectorTest, InlineReadSucceed) {
+TEST_P(TlsInspectorTest, InlineReadSucceed) {
   filter_ = std::make_unique<Filter>(cfg_);
 
   EXPECT_CALL(cb_, socket()).WillRepeatedly(ReturnRef(socket_));
@@ -246,17 +258,17 @@ TEST_F(TlsInspectorTest, InlineReadSucceed) {
   EXPECT_CALL(socket_, ioHandle()).WillRepeatedly(ReturnRef(*io_handle_));
   const std::vector<absl::string_view> alpn_protos = {absl::string_view("h2")};
   const std::string servername("example.com");
-  std::vector<uint8_t> client_hello =
-      Envoy::Extensions::ListenerFilters::TlsInspector::Test::generateClientHello(servername, "\x02h2");
+  std::vector<uint8_t> client_hello = Tls::Test::generateClientHello(
+      std::get<0>(GetParam()), std::get<1>(GetParam()), servername, "\x02h2");
 
   EXPECT_CALL(os_sys_calls_, recv(42, _, _, MSG_PEEK))
-      .WillOnce(Invoke(
-          [&client_hello](int fd, void* buffer, size_t length, int flag) -> Api::SysCallSizeResult {
-            ENVOY_LOG_MISC(trace, "In mock syscall recv {} {} {} {}", fd, buffer, length, flag);
-            ASSERT(length >= client_hello.size());
-            memcpy(buffer, client_hello.data(), client_hello.size());
-            return Api::SysCallSizeResult{ssize_t(client_hello.size()), 0};
-          }));
+      .WillOnce(Invoke([&client_hello](os_fd_t fd, void* buffer, size_t length,
+                                       int flag) -> Api::SysCallSizeResult {
+        ENVOY_LOG_MISC(trace, "In mock syscall recv {} {} {} {}", fd, buffer, length, flag);
+        ASSERT(length >= client_hello.size());
+        memcpy(buffer, client_hello.data(), client_hello.size());
+        return Api::SysCallSizeResult{ssize_t(client_hello.size()), 0};
+      }));
 
   // No event is created if the inline recv parse the hello.
   EXPECT_CALL(dispatcher_,

--- a/test/extensions/filters/listener/tls_inspector/tls_utility.cc
+++ b/test/extensions/filters/listener/tls_inspector/tls_utility.cc
@@ -8,17 +8,15 @@
 #include "openssl/ssl.h"
 
 namespace Envoy {
-namespace Extensions {
-namespace ListenerFilters {
-namespace TlsInspector {
+namespace Tls {
 namespace Test {
 
-std::vector<uint8_t> generateClientHello(const std::string& sni_name, const std::string& alpn) {
-  bssl::UniquePtr<SSL_CTX> ctx(
-      SSL_CTX_new(Envoy::Extensions::ListenerFilters::TlsInspector::TLS_with_buffers_method()));
+std::vector<uint8_t> generateClientHello(uint16_t tls_min_version, uint16_t tls_max_version,
+                                         const std::string& sni_name, const std::string& alpn) {
+  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_with_buffers_method()));
 
-  const long flags = SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION;
-  SSL_CTX_set_options(ctx.get(), flags);
+  SSL_CTX_set_min_proto_version(ctx.get(), tls_min_version);
+  SSL_CTX_set_max_proto_version(ctx.get(), tls_max_version);
 
   bssl::UniquePtr<SSL> ssl(SSL_new(ctx.get()));
 
@@ -37,7 +35,7 @@ std::vector<uint8_t> generateClientHello(const std::string& sni_name, const std:
     SSL_set_alpn_protos(ssl.get(), reinterpret_cast<const uint8_t*>(alpn.data()), alpn.size());
   }
   SSL_do_handshake(ssl.get());
-  const uint8_t* data = NULL;
+  const uint8_t* data = nullptr;
   size_t data_len = 0;
   BIO_mem_contents(out, &data, &data_len);
   ASSERT(data_len > 0);
@@ -46,7 +44,5 @@ std::vector<uint8_t> generateClientHello(const std::string& sni_name, const std:
 }
 
 } // namespace Test
-} // namespace TlsInspector
-} // namespace ListenerFilters
-} // namespace Extensions
+} // namespace Tls
 } // namespace Envoy

--- a/test/extensions/filters/listener/tls_inspector/tls_utility.h
+++ b/test/extensions/filters/listener/tls_inspector/tls_utility.h
@@ -4,22 +4,21 @@
 #include <vector>
 
 namespace Envoy {
-namespace Extensions {
-namespace ListenerFilters {
-namespace TlsInspector {
+namespace Tls {
 namespace Test {
 
 /**
  * Generate a TLS ClientHello in wire-format.
+ * @param tls_min_version Minimum supported TLS version to advertise.
+ * @param tls_max_version Maximum supported TLS version to advertise.
  * @param sni_name The name to include as a Server Name Indication.
  *                 No SNI extension is added if sni_name is empty.
  * @param alpn Protocol(s) list in the wire-format (i.e. 8-bit length-prefixed string) to advertise
  *             in Application-Layer Protocol Negotiation. No ALPN is advertised if alpn is empty.
  */
-std::vector<uint8_t> generateClientHello(const std::string& sni_name, const std::string& alpn);
+std::vector<uint8_t> generateClientHello(uint16_t tls_min_version, uint16_t tls_max_version,
+                                         const std::string& sni_name, const std::string& alpn);
 
 } // namespace Test
-} // namespace TlsInspector
-} // namespace ListenerFilters
-} // namespace Extensions
+} // namespace Tls
 } // namespace Envoy

--- a/test/extensions/transport_sockets/tls/BUILD
+++ b/test/extensions/transport_sockets/tls/BUILD
@@ -26,6 +26,7 @@ envoy_cc_test(
     external_deps = ["ssl"],
     shard_count = 4,
     deps = [
+        ":test_private_key_method_provider_test_lib",
         "@envoy//include/envoy/network:transport_socket_interface",
         "@envoy//source/common/buffer:buffer_lib",
         "@envoy//source/common/common:empty_string",
@@ -41,6 +42,7 @@ envoy_cc_test(
 	"//source/extensions/transport_sockets/tls:context_lib",
 	"//source/extensions/transport_sockets/tls:ssl_socket_lib",
 	"//source/extensions/transport_sockets/tls:utility_lib",
+        "//source/extensions/transport_sockets/tls/private_key:private_key_manager_lib",
         "@envoy//test/extensions/transport_sockets/tls/test_data:cert_infos",
         "@envoy//test/mocks/buffer:buffer_mocks",
         "@envoy//test/mocks/network:network_mocks",
@@ -121,5 +123,28 @@ envoy_cc_test_library(
         "//boringssl_compat:bssl_compat_lib",
 	"//source/extensions/transport_sockets/tls:utility_lib",
         "@envoy//test/test_common:environment_lib",
+    ],
+)
+
+envoy_cc_test_library(
+    name = "test_private_key_method_provider_test_lib",
+    repository = "@envoy",
+    srcs = [
+        "test_private_key_method_provider.cc",
+    ],
+    hdrs = [
+        "test_private_key_method_provider.h",
+    ],
+    external_deps = ["ssl"],
+    deps = [
+        "//boringssl_compat:bssl_compat_lib",
+        "@envoy//include/envoy/api:api_interface",
+        "@envoy//include/envoy/event:dispatcher_interface",
+        "@envoy//include/envoy/server:transport_socket_config_interface",
+        "@envoy//include/envoy/ssl/private_key:private_key_config_interface",
+        "@envoy//include/envoy/ssl/private_key:private_key_interface",
+        "@envoy//source/common/config:utility_lib",
+        "@envoy//source/common/protobuf:utility_lib",
+        "@envoy_api//envoy/extensions/transport_sockets/tls/v3:pkg_cc_proto",
     ],
 )

--- a/test/extensions/transport_sockets/tls/context_impl_test.cc
+++ b/test/extensions/transport_sockets/tls/context_impl_test.cc
@@ -609,6 +609,75 @@ TEST_F(SslServerContextImplTicketTest, VerifySanWithNoCA) {
                             "is insecure and not allowed");
 }
 
+TEST_F(SslServerContextImplTicketTest, StatelessSessionResumptionEnabledByDefault) {
+  envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
+  const std::string tls_context_yaml = R"EOF(
+  common_tls_context:
+    tls_certificates:
+      certificate_chain:
+        filename: "{{ test_tmpdir }}/unittestcert.pem"
+      private_key:
+        filename: "{{ test_tmpdir }}/unittestkey.pem"
+  )EOF";
+  TestUtility::loadFromYaml(TestEnvironment::substitute(tls_context_yaml), tls_context);
+
+  ServerContextConfigImpl server_context_config(tls_context, factory_context_);
+  EXPECT_FALSE(server_context_config.disableStatelessSessionResumption());
+}
+
+TEST_F(SslServerContextImplTicketTest, StatelessSessionResumptionExplicitlyEnabled) {
+  envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
+  const std::string tls_context_yaml = R"EOF(
+  common_tls_context:
+    tls_certificates:
+      certificate_chain:
+        filename: "{{ test_tmpdir }}/unittestcert.pem"
+      private_key:
+        filename: "{{ test_tmpdir }}/unittestkey.pem"
+  disable_stateless_session_resumption: false
+  )EOF";
+  TestUtility::loadFromYaml(TestEnvironment::substitute(tls_context_yaml), tls_context);
+
+  ServerContextConfigImpl server_context_config(tls_context, factory_context_);
+  EXPECT_FALSE(server_context_config.disableStatelessSessionResumption());
+}
+
+TEST_F(SslServerContextImplTicketTest, StatelessSessionResumptionDisabled) {
+  envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
+  const std::string tls_context_yaml = R"EOF(
+  common_tls_context:
+    tls_certificates:
+      certificate_chain:
+        filename: "{{ test_tmpdir }}/unittestcert.pem"
+      private_key:
+        filename: "{{ test_tmpdir }}/unittestkey.pem"
+  disable_stateless_session_resumption: true
+  )EOF";
+  TestUtility::loadFromYaml(TestEnvironment::substitute(tls_context_yaml), tls_context);
+
+  ServerContextConfigImpl server_context_config(tls_context, factory_context_);
+  EXPECT_TRUE(server_context_config.disableStatelessSessionResumption());
+}
+
+TEST_F(SslServerContextImplTicketTest, StatelessSessionResumptionEnabledWhenKeyIsConfigured) {
+  envoy::extensions::transport_sockets::tls::v3::DownstreamTlsContext tls_context;
+  const std::string tls_context_yaml = R"EOF(
+  common_tls_context:
+    tls_certificates:
+      certificate_chain:
+        filename: "{{ test_tmpdir }}/unittestcert.pem"
+      private_key:
+        filename: "{{ test_tmpdir }}/unittestkey.pem"
+  session_ticket_keys:
+    keys:
+      filename: "{{ test_rundir }}/test/extensions/transport_sockets/tls/test_data/ticket_key_a"
+)EOF";
+  TestUtility::loadFromYaml(TestEnvironment::substitute(tls_context_yaml), tls_context);
+
+  ServerContextConfigImpl server_context_config(tls_context, factory_context_);
+  EXPECT_FALSE(server_context_config.disableStatelessSessionResumption());
+}
+
 class ClientContextConfigImplTest : public SslCertsTest {};
 
 // Validate that empty SNI (according to C string rules) fails config validation.

--- a/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
+++ b/test/extensions/transport_sockets/tls/integration/ssl_integration_test.cc
@@ -89,7 +89,7 @@ TEST_P(SslIntegrationTest, RouterRequestAndResponseWithGiantBodyBuffer) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection({});
   };
-  testRouterRequestAndResponseWithBody(16 * 1024 * 1024, 16 * 1024 * 1024, false, &creator);
+  testRouterRequestAndResponseWithBody(16 * 1024 * 1024, 16 * 1024 * 1024, false, false, &creator);
   checkStats();
 }
 
@@ -97,7 +97,7 @@ TEST_P(SslIntegrationTest, RouterRequestAndResponseWithBodyNoBuffer) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection({});
   };
-  testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
+  testRouterRequestAndResponseWithBody(1024, 512, false, false, &creator);
   checkStats();
 }
 
@@ -108,7 +108,7 @@ TEST_P(SslIntegrationTest, RouterRequestAndResponseWithBodyNoBufferHttp2) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection(ClientSslTransportOptions().setAlpn(true));
   };
-  testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
+  testRouterRequestAndResponseWithBody(1024, 512, false, false, &creator);
   checkStats();
 }
 
@@ -116,7 +116,7 @@ TEST_P(SslIntegrationTest, RouterRequestAndResponseWithBodyNoBufferVerifySAN) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection(ClientSslTransportOptions().setSan(true));
   };
-  testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
+  testRouterRequestAndResponseWithBody(1024, 512, false, false, &creator);
   checkStats();
 }
 
@@ -125,7 +125,7 @@ TEST_P(SslIntegrationTest, RouterRequestAndResponseWithBodyNoBufferHttp2VerifySA
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection(ClientSslTransportOptions().setAlpn(true).setSan(true));
   };
-  testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
+  testRouterRequestAndResponseWithBody(1024, 512, false, false, &creator);
   checkStats();
 }
 
@@ -198,28 +198,20 @@ public:
   void TearDown() override { SslIntegrationTestBase::TearDown(); };
 
   ClientSslTransportOptions rsaOnlyClientOptions() {
-    /*
     if (tls_version_ == envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_3) {
-    */
       return ClientSslTransportOptions().setSigningAlgorithmsForTest("rsa_pss_rsae_sha256");
-    /*
     } else {
       return ClientSslTransportOptions().setCipherSuites({"ECDHE-RSA-AES128-GCM-SHA256"});
     }
-    */
   }
 
   ClientSslTransportOptions ecdsaOnlyClientOptions() {
     auto options = ClientSslTransportOptions().setClientEcdsaCert(true);
-    /*
     if (tls_version_ == envoy::extensions::transport_sockets::tls::v3::TlsParameters::TLSv1_3) {
-    */
       return options.setSigningAlgorithmsForTest("ecdsa_secp256r1_sha256");
-    /*
     } else {
       return options.setCipherSuites({"ECDHE-ECDSA-AES128-GCM-SHA256"});
     }
-    */
   }
 
   static std::string ipClientVersionTestParamsToString(
@@ -252,7 +244,7 @@ TEST_P(SslCertficateIntegrationTest, ServerRsa) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection({});
   };
-  testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
+  testRouterRequestAndResponseWithBody(1024, 512, false, false, &creator);
   checkStats();
 }
 
@@ -263,7 +255,7 @@ TEST_P(SslCertficateIntegrationTest, ServerEcdsa) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection({});
   };
-  testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
+  testRouterRequestAndResponseWithBody(1024, 512, false, false, &creator);
   checkStats();
 }
 
@@ -274,7 +266,7 @@ TEST_P(SslCertficateIntegrationTest, ServerRsaEcdsa) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection({});
   };
-  testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
+  testRouterRequestAndResponseWithBody(1024, 512, false, false, &creator);
   checkStats();
 }
 
@@ -285,7 +277,7 @@ TEST_P(SslCertficateIntegrationTest, ClientRsaOnly) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection(rsaOnlyClientOptions());
   };
-  testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
+  testRouterRequestAndResponseWithBody(1024, 512, false, false, &creator);
   checkStats();
 }
 
@@ -310,7 +302,7 @@ TEST_P(SslCertficateIntegrationTest, ServerRsaEcdsaClientRsaOnly) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection(rsaOnlyClientOptions());
   };
-  testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
+  testRouterRequestAndResponseWithBody(1024, 512, false, false, &creator);
   checkStats();
 }
 
@@ -337,7 +329,7 @@ TEST_P(SslCertficateIntegrationTest, ServerEcdsaClientEcdsaOnly) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection(ecdsaOnlyClientOptions());
   };
-  testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
+  testRouterRequestAndResponseWithBody(1024, 512, false, false, &creator);
   checkStats();
 }
 
@@ -349,7 +341,7 @@ TEST_P(SslCertficateIntegrationTest, ServerRsaEcdsaClientEcdsaOnly) {
   ConnectionCreationFunction creator = [&]() -> Network::ClientConnectionPtr {
     return makeSslClientConnection(ecdsaOnlyClientOptions());
   };
-  testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
+  testRouterRequestAndResponseWithBody(1024, 512, false, false, &creator);
   checkStats();
 }
 
@@ -377,7 +369,7 @@ public:
         bootstrap.mutable_static_resources()->mutable_clusters(0)->mutable_transport_socket();
     transport_socket->set_name("envoy.transport_sockets.tap");
     envoy::config::core::v3::TransportSocket raw_transport_socket;
-    raw_transport_socket.set_name("raw_buffer");
+    raw_transport_socket.set_name("envoy.transport_sockets.raw_buffer");
     envoy::extensions::transport_sockets::tap::v3::Tap tap_config =
         createTapConfig(raw_transport_socket);
     tap_config.mutable_transport_socket()->MergeFrom(raw_transport_socket);
@@ -558,7 +550,7 @@ TEST_P(SslTapIntegrationTest, RequestWithTextProto) {
     return makeSslClientConnection({});
   };
   const uint64_t id = Network::ConnectionImpl::nextGlobalIdForTest() + 1;
-  testRouterRequestAndResponseWithBody(1024, 512, false, &creator);
+  testRouterRequestAndResponseWithBody(1024, 512, false, false, &creator);
   checkStats();
   codec_client_->close();
   test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);
@@ -584,7 +576,7 @@ TEST_P(SslTapIntegrationTest, RequestWithJsonBodyAsStringUpstreamTap) {
     return makeSslClientConnection({});
   };
   const uint64_t id = Network::ConnectionImpl::nextGlobalIdForTest() + 2;
-  testRouterRequestAndResponseWithBody(512, 1024, false, &creator);
+  testRouterRequestAndResponseWithBody(512, 1024, false, false, &creator);
   checkStats();
   codec_client_->close();
   test_server_->waitForCounterGe("http.config_test.downstream_cx_destroy", 1);

--- a/test/extensions/transport_sockets/tls/test_private_key_method_provider.cc
+++ b/test/extensions/transport_sockets/tls/test_private_key_method_provider.cc
@@ -1,0 +1,389 @@
+#include "test/extensions/transport_sockets/tls/test_private_key_method_provider.h"
+
+#include <memory>
+
+#include "envoy/api/api.h"
+
+#include "openssl/ssl.h"
+
+#include "boringssl_compat/bssl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace PrivateKeyMethodProvider {
+
+void TestPrivateKeyConnection::delayed_op() {
+  const std::chrono::milliseconds timeout_0ms{0};
+
+  timer_ = dispatcher_.createTimer([this]() -> void {
+    finished_ = true;
+    this->cb_.onPrivateKeyMethodComplete();
+  });
+  timer_->enableTimer(timeout_0ms);
+}
+
+static int calculateDigest(const EVP_MD* md, const uint8_t* in, size_t in_len, unsigned char* hash,
+                           unsigned int* hash_len) {
+  bssl::ScopedEVP_MD_CTX ctx;
+
+  // Calculate the message digest for signing.
+  if (!EVP_DigestInit_ex(ctx.get(), md, nullptr) || !EVP_DigestUpdate(ctx.get(), in, in_len) ||
+      !EVP_DigestFinal_ex(ctx.get(), hash, hash_len)) {
+    return 0;
+  }
+  return 1;
+}
+
+static ssl_private_key_result_t ecdsaPrivateKeySign(SSL* ssl, uint8_t* out, size_t* out_len,
+                                                    size_t max_out, uint16_t signature_algorithm,
+                                                    const uint8_t* in, size_t in_len) {
+  unsigned char hash[EVP_MAX_MD_SIZE];
+  unsigned int hash_len;
+  TestPrivateKeyConnection* ops = static_cast<TestPrivateKeyConnection*>(
+      SSL_get_ex_data(ssl, TestPrivateKeyMethodProvider::ecdsaConnectionIndex()));
+  unsigned int out_len_unsigned;
+
+  if (!ops) {
+    return ssl_private_key_failure;
+  }
+
+  if (ops->test_options_.method_error_) {
+    // Have an artificial test failure.
+    return ssl_private_key_failure;
+  }
+
+  if (!ops->test_options_.sign_expected_) {
+    return ssl_private_key_failure;
+  }
+
+  const EVP_MD* md = SSL_get_signature_algorithm_digest(signature_algorithm);
+  if (!md) {
+    return ssl_private_key_failure;
+  }
+
+  if (!calculateDigest(md, in, in_len, hash, &hash_len)) {
+    return ssl_private_key_failure;
+  }
+
+  bssl::UniquePtr<EC_KEY> ec_key(EVP_PKEY_get1_EC_KEY(ops->getPrivateKey()));
+  if (!ec_key) {
+    return ssl_private_key_failure;
+  }
+
+  // Borrow "out" because it has been already initialized to the max_out size.
+  if (!ECDSA_sign(0, hash, hash_len, out, &out_len_unsigned, ec_key.get())) {
+    return ssl_private_key_failure;
+  }
+
+  if (ops->test_options_.sync_mode_) {
+    // Return immediately with the results.
+    if (out_len_unsigned > max_out) {
+      return ssl_private_key_failure;
+    }
+    *out_len = out_len_unsigned;
+    return ssl_private_key_success;
+  }
+
+  ops->output_.assign(out, out + out_len_unsigned);
+  // Tell SSL socket that the operation is ready to be called again.
+  ops->delayed_op();
+
+  return ssl_private_key_retry;
+}
+
+static ssl_private_key_result_t ecdsaPrivateKeyDecrypt(SSL*, uint8_t*, size_t*, size_t,
+                                                       const uint8_t*, size_t) {
+  return ssl_private_key_failure;
+}
+
+static ssl_private_key_result_t rsaPrivateKeySign(SSL* ssl, uint8_t* out, size_t* out_len,
+                                                  size_t max_out, uint16_t signature_algorithm,
+                                                  const uint8_t* in, size_t in_len) {
+  TestPrivateKeyConnection* ops = static_cast<TestPrivateKeyConnection*>(
+      SSL_get_ex_data(ssl, TestPrivateKeyMethodProvider::rsaConnectionIndex()));
+  unsigned char hash[EVP_MAX_MD_SIZE] = {0};
+  unsigned int hash_len = EVP_MAX_MD_SIZE;
+  std::vector<uint8_t> in2;
+
+  if (!ops) {
+    return ssl_private_key_failure;
+  }
+
+  if (ops->test_options_.method_error_) {
+    return ssl_private_key_failure;
+  }
+
+  if (!ops->test_options_.sign_expected_) {
+    return ssl_private_key_failure;
+  }
+
+  const EVP_MD* md = SSL_get_signature_algorithm_digest(signature_algorithm);
+  if (!md) {
+    return ssl_private_key_failure;
+  }
+
+  in2.assign(in, in + in_len);
+
+  // If crypto error is set, we'll modify the incoming token by flipping
+  // the bits.
+  if (ops->test_options_.crypto_error_) {
+    for (size_t i = 0; i < in_len; i++) {
+      in2[i] = ~in2[i];
+    }
+  }
+
+  if (!calculateDigest(md, in2.data(), in_len, hash, &hash_len)) {
+    return ssl_private_key_failure;
+  }
+
+  RSA* rsa = EVP_PKEY_get0_RSA(ops->getPrivateKey());
+  if (rsa == nullptr) {
+    return ssl_private_key_failure;
+  }
+
+  // Perform RSA signing.
+  if (SSL_is_signature_algorithm_rsa_pss(signature_algorithm)) {
+    if (!RSA_sign_pss_mgf1(rsa, out_len, out, max_out, hash, hash_len, md, nullptr, -1)) {
+      return ssl_private_key_failure;
+    }
+  } else {
+    unsigned int out_len_unsigned;
+    if (!RSA_sign(EVP_MD_type(md), hash, hash_len, out, &out_len_unsigned, rsa)) {
+      return ssl_private_key_failure;
+    }
+    if (out_len_unsigned > max_out) {
+      return ssl_private_key_failure;
+    }
+    *out_len = out_len_unsigned;
+  }
+
+  if (ops->test_options_.sync_mode_) {
+    return ssl_private_key_success;
+  }
+
+  ops->output_.assign(out, out + *out_len);
+  ops->delayed_op();
+
+  return ssl_private_key_retry;
+}
+
+static ssl_private_key_result_t rsaPrivateKeyDecrypt(SSL* ssl, uint8_t* out, size_t* out_len,
+                                                     size_t max_out, const uint8_t* in,
+                                                     size_t in_len) {
+  TestPrivateKeyConnection* ops = static_cast<TestPrivateKeyConnection*>(
+      SSL_get_ex_data(ssl, TestPrivateKeyMethodProvider::rsaConnectionIndex()));
+
+  if (!ops) {
+    return ssl_private_key_failure;
+  }
+
+  if (ops->test_options_.method_error_) {
+    return ssl_private_key_failure;
+  }
+
+  if (!ops->test_options_.decrypt_expected_) {
+    return ssl_private_key_failure;
+  }
+
+  RSA* rsa = EVP_PKEY_get0_RSA(ops->getPrivateKey());
+  if (rsa == nullptr) {
+    return ssl_private_key_failure;
+  }
+
+  if (!RSA_decrypt(rsa, out_len, out, max_out, in, in_len, RSA_NO_PADDING)) {
+    return ssl_private_key_failure;
+  }
+
+  if (ops->test_options_.sync_mode_) {
+    return ssl_private_key_success;
+  }
+
+  ops->output_.assign(out, out + *out_len);
+  ops->delayed_op();
+
+  return ssl_private_key_retry;
+}
+
+static ssl_private_key_result_t privateKeyComplete(SSL* ssl, uint8_t* out, size_t* out_len,
+                                                   size_t max_out, int id) {
+  TestPrivateKeyConnection* ops = static_cast<TestPrivateKeyConnection*>(SSL_get_ex_data(ssl, id));
+
+  if (!ops->finished_) {
+    // The operation didn't finish yet, retry.
+    return ssl_private_key_retry;
+  }
+
+  if (ops->test_options_.async_method_error_) {
+    return ssl_private_key_failure;
+  }
+
+  if (ops->output_.size() > max_out) {
+    return ssl_private_key_failure;
+  }
+
+  std::copy(ops->output_.begin(), ops->output_.end(), out);
+  *out_len = ops->output_.size();
+
+  return ssl_private_key_success;
+}
+
+static ssl_private_key_result_t rsaPrivateKeyComplete(SSL* ssl, uint8_t* out, size_t* out_len,
+                                                      size_t max_out) {
+  return privateKeyComplete(ssl, out, out_len, max_out,
+                            TestPrivateKeyMethodProvider::rsaConnectionIndex());
+}
+
+static ssl_private_key_result_t ecdsaPrivateKeyComplete(SSL* ssl, uint8_t* out, size_t* out_len,
+                                                        size_t max_out) {
+  return privateKeyComplete(ssl, out, out_len, max_out,
+                            TestPrivateKeyMethodProvider::ecdsaConnectionIndex());
+}
+
+Ssl::BoringSslPrivateKeyMethodSharedPtr
+TestPrivateKeyMethodProvider::getBoringSslPrivateKeyMethod() {
+  return method_;
+}
+
+bool TestPrivateKeyMethodProvider::checkFips() {
+  if (mode_ == "rsa") {
+    RSA* rsa_private_key = EVP_PKEY_get0_RSA(pkey_.get());
+    if (rsa_private_key == nullptr || !RSA_check_fips(rsa_private_key)) {
+      return false;
+    }
+  } else { // if (mode_ == "ecdsa")
+    const EC_KEY* ecdsa_private_key = EVP_PKEY_get0_EC_KEY(pkey_.get());
+    if (ecdsa_private_key == nullptr || !EC_KEY_check_fips(ecdsa_private_key)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+TestPrivateKeyConnection::TestPrivateKeyConnection(
+    Ssl::PrivateKeyConnectionCallbacks& cb, Event::Dispatcher& dispatcher,
+    bssl::UniquePtr<EVP_PKEY> pkey, TestPrivateKeyConnectionTestOptions& test_options)
+    : test_options_(test_options), cb_(cb), dispatcher_(dispatcher), pkey_(std::move(pkey)) {}
+
+void TestPrivateKeyMethodProvider::registerPrivateKeyMethod(SSL* ssl,
+                                                            Ssl::PrivateKeyConnectionCallbacks& cb,
+                                                            Event::Dispatcher& dispatcher) {
+  TestPrivateKeyConnection* ops;
+  // In multi-cert case, when the same provider is used in different modes with the same SSL object,
+  // we need to keep both rsa and ecdsa connection objects in store because the test options for the
+  // two certificates may be different. We need to be able to deduct in the signing, decryption, and
+  // completion functions which options to use, so we associate the connection objects to the same
+  // SSL object using different user data indexes.
+  //
+  // Another way to do this would be to store both test options in one connection object.
+  int index = mode_ == "rsa" ? TestPrivateKeyMethodProvider::rsaConnectionIndex()
+                             : TestPrivateKeyMethodProvider::ecdsaConnectionIndex();
+
+  // Check if there is another certificate of the same mode associated with the context. This would
+  // be an error.
+  ops = static_cast<TestPrivateKeyConnection*>(SSL_get_ex_data(ssl, index));
+  if (ops != nullptr) {
+    throw EnvoyException(
+        "Can't distinguish between two registered providers for the same SSL object.");
+  }
+
+  ops = new TestPrivateKeyConnection(cb, dispatcher, bssl::UpRef(pkey_), test_options_);
+  SSL_set_ex_data(ssl, index, ops);
+}
+
+void TestPrivateKeyMethodProvider::unregisterPrivateKeyMethod(SSL* ssl) {
+  int index = mode_ == "rsa" ? TestPrivateKeyMethodProvider::rsaConnectionIndex()
+                             : TestPrivateKeyMethodProvider::ecdsaConnectionIndex();
+  TestPrivateKeyConnection* ops =
+      static_cast<TestPrivateKeyConnection*>(SSL_get_ex_data(ssl, index));
+  SSL_set_ex_data(ssl, index, nullptr);
+  delete ops;
+}
+
+static int createIndex() {
+  int index = SSL_get_ex_new_index(0, nullptr, nullptr, nullptr, nullptr);
+  RELEASE_ASSERT(index >= 0, "Failed to get SSL user data index.");
+  return index;
+}
+
+int TestPrivateKeyMethodProvider::rsaConnectionIndex() {
+  CONSTRUCT_ON_FIRST_USE(int, createIndex());
+}
+
+int TestPrivateKeyMethodProvider::ecdsaConnectionIndex() {
+  CONSTRUCT_ON_FIRST_USE(int, createIndex());
+}
+
+TestPrivateKeyMethodProvider::TestPrivateKeyMethodProvider(
+    const ProtobufWkt::Any& typed_config,
+    Server::Configuration::TransportSocketFactoryContext& factory_context) {
+  std::string private_key_path;
+
+  auto config = MessageUtil::anyConvert<ProtobufWkt::Struct>(typed_config);
+
+  for (auto& value_it : config.fields()) {
+    auto& value = value_it.second;
+    if (value_it.first == "private_key_file" &&
+        value.kind_case() == ProtobufWkt::Value::kStringValue) {
+      private_key_path = value.string_value();
+    }
+    if (value_it.first == "sync_mode" && value.kind_case() == ProtobufWkt::Value::kBoolValue) {
+      test_options_.sync_mode_ = value.bool_value();
+    }
+    if (value_it.first == "crypto_error" && value.kind_case() == ProtobufWkt::Value::kBoolValue) {
+      test_options_.crypto_error_ = value.bool_value();
+    }
+    if (value_it.first == "method_error" && value.kind_case() == ProtobufWkt::Value::kBoolValue) {
+      test_options_.method_error_ = value.bool_value();
+    }
+    if (value_it.first == "async_method_error" &&
+        value.kind_case() == ProtobufWkt::Value::kBoolValue) {
+      test_options_.async_method_error_ = value.bool_value();
+    }
+    if (value_it.first == "expected_operation" &&
+        value.kind_case() == ProtobufWkt::Value::kStringValue) {
+      if (value.string_value() == "decrypt") {
+        test_options_.decrypt_expected_ = true;
+      } else if (value.string_value() == "sign") {
+        test_options_.sign_expected_ = true;
+      }
+    }
+    if (value_it.first == "mode" && value.kind_case() == ProtobufWkt::Value::kStringValue) {
+      mode_ = value.string_value();
+    }
+  }
+
+  std::string private_key = factory_context.api().fileSystem().fileReadToEnd(private_key_path);
+  bssl::UniquePtr<BIO> bio(
+      BIO_new_mem_buf(const_cast<char*>(private_key.data()), private_key.size()));
+  bssl::UniquePtr<EVP_PKEY> pkey(PEM_read_bio_PrivateKey(bio.get(), nullptr, nullptr, nullptr));
+  if (pkey == nullptr) {
+    throw EnvoyException("Failed to read private key from disk.");
+  }
+
+  method_ = std::make_shared<SSL_PRIVATE_KEY_METHOD>();
+
+  // Have two modes, "rsa" and "ecdsa", for testing multi-cert use cases.
+  if (mode_ == "rsa") {
+    if (EVP_PKEY_id(pkey.get()) != EVP_PKEY_RSA) {
+      throw EnvoyException("Private key is not RSA.");
+    }
+    method_->sign = rsaPrivateKeySign;
+    method_->decrypt = rsaPrivateKeyDecrypt;
+    method_->complete = rsaPrivateKeyComplete;
+  } else if (mode_ == "ecdsa") {
+    if (EVP_PKEY_id(pkey.get()) != EVP_PKEY_EC) {
+      throw EnvoyException("Private key is not ECDSA.");
+    }
+    method_->sign = ecdsaPrivateKeySign;
+    method_->decrypt = ecdsaPrivateKeyDecrypt;
+    method_->complete = ecdsaPrivateKeyComplete;
+  } else {
+    throw EnvoyException("Unknown test provider mode, supported modes are \"rsa\" and \"ecdsa\".");
+  }
+
+  pkey_ = std::move(pkey);
+}
+
+} // namespace PrivateKeyMethodProvider
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/transport_sockets/tls/test_private_key_method_provider.cc~
+++ b/test/extensions/transport_sockets/tls/test_private_key_method_provider.cc~
@@ -1,0 +1,387 @@
+#include "test/extensions/transport_sockets/tls/test_private_key_method_provider.h"
+
+#include <memory>
+
+#include "envoy/api/api.h"
+
+#include "openssl/ssl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace PrivateKeyMethodProvider {
+
+void TestPrivateKeyConnection::delayed_op() {
+  const std::chrono::milliseconds timeout_0ms{0};
+
+  timer_ = dispatcher_.createTimer([this]() -> void {
+    finished_ = true;
+    this->cb_.onPrivateKeyMethodComplete();
+  });
+  timer_->enableTimer(timeout_0ms);
+}
+
+static int calculateDigest(const EVP_MD* md, const uint8_t* in, size_t in_len, unsigned char* hash,
+                           unsigned int* hash_len) {
+  bssl::ScopedEVP_MD_CTX ctx;
+
+  // Calculate the message digest for signing.
+  if (!EVP_DigestInit_ex(ctx.get(), md, nullptr) || !EVP_DigestUpdate(ctx.get(), in, in_len) ||
+      !EVP_DigestFinal_ex(ctx.get(), hash, hash_len)) {
+    return 0;
+  }
+  return 1;
+}
+
+static ssl_private_key_result_t ecdsaPrivateKeySign(SSL* ssl, uint8_t* out, size_t* out_len,
+                                                    size_t max_out, uint16_t signature_algorithm,
+                                                    const uint8_t* in, size_t in_len) {
+  unsigned char hash[EVP_MAX_MD_SIZE];
+  unsigned int hash_len;
+  TestPrivateKeyConnection* ops = static_cast<TestPrivateKeyConnection*>(
+      SSL_get_ex_data(ssl, TestPrivateKeyMethodProvider::ecdsaConnectionIndex()));
+  unsigned int out_len_unsigned;
+
+  if (!ops) {
+    return ssl_private_key_failure;
+  }
+
+  if (ops->test_options_.method_error_) {
+    // Have an artificial test failure.
+    return ssl_private_key_failure;
+  }
+
+  if (!ops->test_options_.sign_expected_) {
+    return ssl_private_key_failure;
+  }
+
+  const EVP_MD* md = SSL_get_signature_algorithm_digest(signature_algorithm);
+  if (!md) {
+    return ssl_private_key_failure;
+  }
+
+  if (!calculateDigest(md, in, in_len, hash, &hash_len)) {
+    return ssl_private_key_failure;
+  }
+
+  bssl::UniquePtr<EC_KEY> ec_key(EVP_PKEY_get1_EC_KEY(ops->getPrivateKey()));
+  if (!ec_key) {
+    return ssl_private_key_failure;
+  }
+
+  // Borrow "out" because it has been already initialized to the max_out size.
+  if (!ECDSA_sign(0, hash, hash_len, out, &out_len_unsigned, ec_key.get())) {
+    return ssl_private_key_failure;
+  }
+
+  if (ops->test_options_.sync_mode_) {
+    // Return immediately with the results.
+    if (out_len_unsigned > max_out) {
+      return ssl_private_key_failure;
+    }
+    *out_len = out_len_unsigned;
+    return ssl_private_key_success;
+  }
+
+  ops->output_.assign(out, out + out_len_unsigned);
+  // Tell SSL socket that the operation is ready to be called again.
+  ops->delayed_op();
+
+  return ssl_private_key_retry;
+}
+
+static ssl_private_key_result_t ecdsaPrivateKeyDecrypt(SSL*, uint8_t*, size_t*, size_t,
+                                                       const uint8_t*, size_t) {
+  return ssl_private_key_failure;
+}
+
+static ssl_private_key_result_t rsaPrivateKeySign(SSL* ssl, uint8_t* out, size_t* out_len,
+                                                  size_t max_out, uint16_t signature_algorithm,
+                                                  const uint8_t* in, size_t in_len) {
+  TestPrivateKeyConnection* ops = static_cast<TestPrivateKeyConnection*>(
+      SSL_get_ex_data(ssl, TestPrivateKeyMethodProvider::rsaConnectionIndex()));
+  unsigned char hash[EVP_MAX_MD_SIZE] = {0};
+  unsigned int hash_len = EVP_MAX_MD_SIZE;
+  std::vector<uint8_t> in2;
+
+  if (!ops) {
+    return ssl_private_key_failure;
+  }
+
+  if (ops->test_options_.method_error_) {
+    return ssl_private_key_failure;
+  }
+
+  if (!ops->test_options_.sign_expected_) {
+    return ssl_private_key_failure;
+  }
+
+  const EVP_MD* md = SSL_get_signature_algorithm_digest(signature_algorithm);
+  if (!md) {
+    return ssl_private_key_failure;
+  }
+
+  in2.assign(in, in + in_len);
+
+  // If crypto error is set, we'll modify the incoming token by flipping
+  // the bits.
+  if (ops->test_options_.crypto_error_) {
+    for (size_t i = 0; i < in_len; i++) {
+      in2[i] = ~in2[i];
+    }
+  }
+
+  if (!calculateDigest(md, in2.data(), in_len, hash, &hash_len)) {
+    return ssl_private_key_failure;
+  }
+
+  RSA* rsa = EVP_PKEY_get0_RSA(ops->getPrivateKey());
+  if (rsa == nullptr) {
+    return ssl_private_key_failure;
+  }
+
+  // Perform RSA signing.
+  if (SSL_is_signature_algorithm_rsa_pss(signature_algorithm)) {
+    if (!RSA_sign_pss_mgf1(rsa, out_len, out, max_out, hash, hash_len, md, nullptr, -1)) {
+      return ssl_private_key_failure;
+    }
+  } else {
+    unsigned int out_len_unsigned;
+    if (!RSA_sign(EVP_MD_type(md), hash, hash_len, out, &out_len_unsigned, rsa)) {
+      return ssl_private_key_failure;
+    }
+    if (out_len_unsigned > max_out) {
+      return ssl_private_key_failure;
+    }
+    *out_len = out_len_unsigned;
+  }
+
+  if (ops->test_options_.sync_mode_) {
+    return ssl_private_key_success;
+  }
+
+  ops->output_.assign(out, out + *out_len);
+  ops->delayed_op();
+
+  return ssl_private_key_retry;
+}
+
+static ssl_private_key_result_t rsaPrivateKeyDecrypt(SSL* ssl, uint8_t* out, size_t* out_len,
+                                                     size_t max_out, const uint8_t* in,
+                                                     size_t in_len) {
+  TestPrivateKeyConnection* ops = static_cast<TestPrivateKeyConnection*>(
+      SSL_get_ex_data(ssl, TestPrivateKeyMethodProvider::rsaConnectionIndex()));
+
+  if (!ops) {
+    return ssl_private_key_failure;
+  }
+
+  if (ops->test_options_.method_error_) {
+    return ssl_private_key_failure;
+  }
+
+  if (!ops->test_options_.decrypt_expected_) {
+    return ssl_private_key_failure;
+  }
+
+  RSA* rsa = EVP_PKEY_get0_RSA(ops->getPrivateKey());
+  if (rsa == nullptr) {
+    return ssl_private_key_failure;
+  }
+
+  if (!RSA_decrypt(rsa, out_len, out, max_out, in, in_len, RSA_NO_PADDING)) {
+    return ssl_private_key_failure;
+  }
+
+  if (ops->test_options_.sync_mode_) {
+    return ssl_private_key_success;
+  }
+
+  ops->output_.assign(out, out + *out_len);
+  ops->delayed_op();
+
+  return ssl_private_key_retry;
+}
+
+static ssl_private_key_result_t privateKeyComplete(SSL* ssl, uint8_t* out, size_t* out_len,
+                                                   size_t max_out, int id) {
+  TestPrivateKeyConnection* ops = static_cast<TestPrivateKeyConnection*>(SSL_get_ex_data(ssl, id));
+
+  if (!ops->finished_) {
+    // The operation didn't finish yet, retry.
+    return ssl_private_key_retry;
+  }
+
+  if (ops->test_options_.async_method_error_) {
+    return ssl_private_key_failure;
+  }
+
+  if (ops->output_.size() > max_out) {
+    return ssl_private_key_failure;
+  }
+
+  std::copy(ops->output_.begin(), ops->output_.end(), out);
+  *out_len = ops->output_.size();
+
+  return ssl_private_key_success;
+}
+
+static ssl_private_key_result_t rsaPrivateKeyComplete(SSL* ssl, uint8_t* out, size_t* out_len,
+                                                      size_t max_out) {
+  return privateKeyComplete(ssl, out, out_len, max_out,
+                            TestPrivateKeyMethodProvider::rsaConnectionIndex());
+}
+
+static ssl_private_key_result_t ecdsaPrivateKeyComplete(SSL* ssl, uint8_t* out, size_t* out_len,
+                                                        size_t max_out) {
+  return privateKeyComplete(ssl, out, out_len, max_out,
+                            TestPrivateKeyMethodProvider::ecdsaConnectionIndex());
+}
+
+Ssl::BoringSslPrivateKeyMethodSharedPtr
+TestPrivateKeyMethodProvider::getBoringSslPrivateKeyMethod() {
+  return method_;
+}
+
+bool TestPrivateKeyMethodProvider::checkFips() {
+  if (mode_ == "rsa") {
+    RSA* rsa_private_key = EVP_PKEY_get0_RSA(pkey_.get());
+    if (rsa_private_key == nullptr || !RSA_check_fips(rsa_private_key)) {
+      return false;
+    }
+  } else { // if (mode_ == "ecdsa")
+    const EC_KEY* ecdsa_private_key = EVP_PKEY_get0_EC_KEY(pkey_.get());
+    if (ecdsa_private_key == nullptr || !EC_KEY_check_fips(ecdsa_private_key)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+TestPrivateKeyConnection::TestPrivateKeyConnection(
+    Ssl::PrivateKeyConnectionCallbacks& cb, Event::Dispatcher& dispatcher,
+    bssl::UniquePtr<EVP_PKEY> pkey, TestPrivateKeyConnectionTestOptions& test_options)
+    : test_options_(test_options), cb_(cb), dispatcher_(dispatcher), pkey_(std::move(pkey)) {}
+
+void TestPrivateKeyMethodProvider::registerPrivateKeyMethod(SSL* ssl,
+                                                            Ssl::PrivateKeyConnectionCallbacks& cb,
+                                                            Event::Dispatcher& dispatcher) {
+  TestPrivateKeyConnection* ops;
+  // In multi-cert case, when the same provider is used in different modes with the same SSL object,
+  // we need to keep both rsa and ecdsa connection objects in store because the test options for the
+  // two certificates may be different. We need to be able to deduct in the signing, decryption, and
+  // completion functions which options to use, so we associate the connection objects to the same
+  // SSL object using different user data indexes.
+  //
+  // Another way to do this would be to store both test options in one connection object.
+  int index = mode_ == "rsa" ? TestPrivateKeyMethodProvider::rsaConnectionIndex()
+                             : TestPrivateKeyMethodProvider::ecdsaConnectionIndex();
+
+  // Check if there is another certificate of the same mode associated with the context. This would
+  // be an error.
+  ops = static_cast<TestPrivateKeyConnection*>(SSL_get_ex_data(ssl, index));
+  if (ops != nullptr) {
+    throw EnvoyException(
+        "Can't distinguish between two registered providers for the same SSL object.");
+  }
+
+  ops = new TestPrivateKeyConnection(cb, dispatcher, bssl::UpRef(pkey_), test_options_);
+  SSL_set_ex_data(ssl, index, ops);
+}
+
+void TestPrivateKeyMethodProvider::unregisterPrivateKeyMethod(SSL* ssl) {
+  int index = mode_ == "rsa" ? TestPrivateKeyMethodProvider::rsaConnectionIndex()
+                             : TestPrivateKeyMethodProvider::ecdsaConnectionIndex();
+  TestPrivateKeyConnection* ops =
+      static_cast<TestPrivateKeyConnection*>(SSL_get_ex_data(ssl, index));
+  SSL_set_ex_data(ssl, index, nullptr);
+  delete ops;
+}
+
+static int createIndex() {
+  int index = SSL_get_ex_new_index(0, nullptr, nullptr, nullptr, nullptr);
+  RELEASE_ASSERT(index >= 0, "Failed to get SSL user data index.");
+  return index;
+}
+
+int TestPrivateKeyMethodProvider::rsaConnectionIndex() {
+  CONSTRUCT_ON_FIRST_USE(int, createIndex());
+}
+
+int TestPrivateKeyMethodProvider::ecdsaConnectionIndex() {
+  CONSTRUCT_ON_FIRST_USE(int, createIndex());
+}
+
+TestPrivateKeyMethodProvider::TestPrivateKeyMethodProvider(
+    const ProtobufWkt::Any& typed_config,
+    Server::Configuration::TransportSocketFactoryContext& factory_context) {
+  std::string private_key_path;
+
+  auto config = MessageUtil::anyConvert<ProtobufWkt::Struct>(typed_config);
+
+  for (auto& value_it : config.fields()) {
+    auto& value = value_it.second;
+    if (value_it.first == "private_key_file" &&
+        value.kind_case() == ProtobufWkt::Value::kStringValue) {
+      private_key_path = value.string_value();
+    }
+    if (value_it.first == "sync_mode" && value.kind_case() == ProtobufWkt::Value::kBoolValue) {
+      test_options_.sync_mode_ = value.bool_value();
+    }
+    if (value_it.first == "crypto_error" && value.kind_case() == ProtobufWkt::Value::kBoolValue) {
+      test_options_.crypto_error_ = value.bool_value();
+    }
+    if (value_it.first == "method_error" && value.kind_case() == ProtobufWkt::Value::kBoolValue) {
+      test_options_.method_error_ = value.bool_value();
+    }
+    if (value_it.first == "async_method_error" &&
+        value.kind_case() == ProtobufWkt::Value::kBoolValue) {
+      test_options_.async_method_error_ = value.bool_value();
+    }
+    if (value_it.first == "expected_operation" &&
+        value.kind_case() == ProtobufWkt::Value::kStringValue) {
+      if (value.string_value() == "decrypt") {
+        test_options_.decrypt_expected_ = true;
+      } else if (value.string_value() == "sign") {
+        test_options_.sign_expected_ = true;
+      }
+    }
+    if (value_it.first == "mode" && value.kind_case() == ProtobufWkt::Value::kStringValue) {
+      mode_ = value.string_value();
+    }
+  }
+
+  std::string private_key = factory_context.api().fileSystem().fileReadToEnd(private_key_path);
+  bssl::UniquePtr<BIO> bio(
+      BIO_new_mem_buf(const_cast<char*>(private_key.data()), private_key.size()));
+  bssl::UniquePtr<EVP_PKEY> pkey(PEM_read_bio_PrivateKey(bio.get(), nullptr, nullptr, nullptr));
+  if (pkey == nullptr) {
+    throw EnvoyException("Failed to read private key from disk.");
+  }
+
+  method_ = std::make_shared<SSL_PRIVATE_KEY_METHOD>();
+
+  // Have two modes, "rsa" and "ecdsa", for testing multi-cert use cases.
+  if (mode_ == "rsa") {
+    if (EVP_PKEY_id(pkey.get()) != EVP_PKEY_RSA) {
+      throw EnvoyException("Private key is not RSA.");
+    }
+    method_->sign = rsaPrivateKeySign;
+    method_->decrypt = rsaPrivateKeyDecrypt;
+    method_->complete = rsaPrivateKeyComplete;
+  } else if (mode_ == "ecdsa") {
+    if (EVP_PKEY_id(pkey.get()) != EVP_PKEY_EC) {
+      throw EnvoyException("Private key is not ECDSA.");
+    }
+    method_->sign = ecdsaPrivateKeySign;
+    method_->decrypt = ecdsaPrivateKeyDecrypt;
+    method_->complete = ecdsaPrivateKeyComplete;
+  } else {
+    throw EnvoyException("Unknown test provider mode, supported modes are \"rsa\" and \"ecdsa\".");
+  }
+
+  pkey_ = std::move(pkey);
+}
+
+} // namespace PrivateKeyMethodProvider
+} // namespace Extensions
+} // namespace Envoy

--- a/test/extensions/transport_sockets/tls/test_private_key_method_provider.h
+++ b/test/extensions/transport_sockets/tls/test_private_key_method_provider.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "envoy/event/dispatcher.h"
+#include "envoy/extensions/transport_sockets/tls/v3/cert.pb.h"
+#include "envoy/server/transport_socket_config.h"
+#include "envoy/ssl/private_key/private_key.h"
+#include "envoy/ssl/private_key/private_key_config.h"
+
+#include "common/config/utility.h"
+#include "common/protobuf/utility.h"
+
+#include "boringssl_compat/bssl.h"
+
+namespace Envoy {
+namespace Extensions {
+namespace PrivateKeyMethodProvider {
+
+struct TestPrivateKeyConnectionTestOptions {
+  // Return private key method value directly without asynchronous operation.
+  bool sync_mode_{};
+
+  // The "decrypt" private key method is expected to he called.
+  bool decrypt_expected_{};
+
+  // The "sign" private key method is expected to he called.
+  bool sign_expected_{};
+
+  // Add a cryptographic error (invalid signature, incorrect decryption).
+  bool crypto_error_{};
+
+  // Return an error from the private key method.
+  bool method_error_{};
+
+  // Return an error from the private key method completion function.
+  bool async_method_error_{};
+};
+
+// An example private key method provider for testing the decrypt() and sign()
+// functionality.
+class TestPrivateKeyConnection {
+public:
+  TestPrivateKeyConnection(Ssl::PrivateKeyConnectionCallbacks& cb, Event::Dispatcher& dispatcher,
+                           bssl::UniquePtr<EVP_PKEY> pkey,
+                           TestPrivateKeyConnectionTestOptions& test_options);
+  EVP_PKEY* getPrivateKey() { return pkey_.get(); }
+  void delayed_op();
+  // Store the output data temporarily.
+  std::vector<uint8_t> output_;
+  // The complete callback can return other value than "retry" only after
+  // onPrivateKeyMethodComplete() function has been called. This is controlled by "finished"
+  // variable.
+  bool finished_{};
+  TestPrivateKeyConnectionTestOptions& test_options_;
+
+private:
+  Ssl::PrivateKeyConnectionCallbacks& cb_;
+  Event::Dispatcher& dispatcher_;
+  bssl::UniquePtr<EVP_PKEY> pkey_;
+  // A zero-length timer controls the callback.
+  Event::TimerPtr timer_;
+};
+
+class TestPrivateKeyMethodProvider : public virtual Ssl::PrivateKeyMethodProvider {
+public:
+  TestPrivateKeyMethodProvider(
+      const ProtobufWkt::Any& typed_config,
+      Server::Configuration::TransportSocketFactoryContext& factory_context);
+  // Ssl::PrivateKeyMethodProvider
+  void registerPrivateKeyMethod(SSL* ssl, Ssl::PrivateKeyConnectionCallbacks& cb,
+                                Event::Dispatcher& dispatcher) override;
+  void unregisterPrivateKeyMethod(SSL* ssl) override;
+  bool checkFips() override;
+  Ssl::BoringSslPrivateKeyMethodSharedPtr getBoringSslPrivateKeyMethod() override;
+
+  static int rsaConnectionIndex();
+  static int ecdsaConnectionIndex();
+
+private:
+  Ssl::BoringSslPrivateKeyMethodSharedPtr method_{};
+  bssl::UniquePtr<EVP_PKEY> pkey_;
+  TestPrivateKeyConnectionTestOptions test_options_;
+  std::string mode_;
+};
+
+class TestPrivateKeyMethodFactory : public Ssl::PrivateKeyMethodProviderInstanceFactory {
+public:
+  // Ssl::PrivateKeyMethodProviderInstanceFactory
+  Ssl::PrivateKeyMethodProviderSharedPtr createPrivateKeyMethodProviderInstance(
+      const envoy::extensions::transport_sockets::tls::v3::PrivateKeyProvider& config,
+      Server::Configuration::TransportSocketFactoryContext& factory_context) override {
+    return std::make_shared<TestPrivateKeyMethodProvider>(config.typed_config(), factory_context);
+  }
+
+  std::string name() const override { return "test"; };
+};
+
+} // namespace PrivateKeyMethodProvider
+} // namespace Extensions
+} // namespace Envoy

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -1079,3 +1079,34 @@ envoy_cc_test(
         "@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg_cc_proto",
     ],
 )
+
+envoy_cc_test(
+    name = "listener_filter_integration_test",
+    srcs = [
+        "listener_filter_integration_test.cc",
+    ],
+    data = [
+        "//test/config/integration/certs",
+    ],
+    deps = [
+        ":integration_lib",
+        "//source/common/config:api_version_lib",
+        "//source/common/event:dispatcher_includes",
+        "//source/common/event:dispatcher_lib",
+        "//source/common/network:utility_lib",
+        "//source/extensions/access_loggers/file:config",
+        "//source/extensions/filters/listener/tls_inspector:config",
+        "//source/extensions/filters/listener/tls_inspector:tls_inspector_lib",
+        "//source/extensions/filters/network/echo:config",
+        "//source/extensions/transport_sockets/tls:config",
+        "//source/extensions/transport_sockets/tls:context_config_lib",
+        "//source/extensions/transport_sockets/tls:context_lib",
+        "//test/mocks/runtime:runtime_mocks",
+        "//test/mocks/secret:secret_mocks",
+        "//test/test_common:utility_lib",
+        "@envoy_api//envoy/config/bootstrap/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/cluster/v3:pkg_cc_proto",
+        "@envoy_api//envoy/config/core/v3:pkg_cc_proto",
+        "@envoy_api//envoy/extensions/access_loggers/file/v3:pkg_cc_proto",
+    ],
+)

--- a/test/integration/autonomous_upstream.cc
+++ b/test/integration/autonomous_upstream.cc
@@ -66,7 +66,8 @@ AutonomousHttpConnection::AutonomousHttpConnection(SharedConnectionWrapper& shar
                                                    Stats::Store& store, Type type,
                                                    AutonomousUpstream& upstream)
     : FakeHttpConnection(shared_connection, store, type, upstream.timeSystem(),
-                         Http::DEFAULT_MAX_REQUEST_HEADERS_KB, Http::DEFAULT_MAX_HEADERS_COUNT),
+                         Http::DEFAULT_MAX_REQUEST_HEADERS_KB, Http::DEFAULT_MAX_HEADERS_COUNT,
+                         envoy::config::core::v3::HttpProtocolOptions::ALLOW),
       upstream_(upstream) {}
 
 Http::RequestDecoder& AutonomousHttpConnection::newStream(Http::ResponseEncoder& response_encoder,

--- a/test/integration/fake_upstream.cc
+++ b/test/integration/fake_upstream.cc
@@ -220,11 +220,12 @@ void FakeStream::finishGrpcStream(Grpc::Status::GrpcStatus status) {
       Http::TestHeaderMapImpl{{"grpc-status", std::to_string(static_cast<uint32_t>(status))}});
 }
 
-FakeHttpConnection::FakeHttpConnection(SharedConnectionWrapper& shared_connection,
-                                       Stats::Store& store, Type type,
-                                       Event::TestTimeSystem& time_system,
-                                       uint32_t max_request_headers_kb,
-                                       uint32_t max_request_headers_count)
+FakeHttpConnection::FakeHttpConnection(
+    SharedConnectionWrapper& shared_connection, Stats::Store& store, Type type,
+    Event::TestTimeSystem& time_system, uint32_t max_request_headers_kb,
+    uint32_t max_request_headers_count,
+    envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
+        headers_with_underscores_action)
     : FakeConnectionBase(shared_connection, time_system) {
   if (type == Type::HTTP1) {
     Http::Http1Settings http1_settings;
@@ -232,7 +233,7 @@ FakeHttpConnection::FakeHttpConnection(SharedConnectionWrapper& shared_connectio
     http1_settings.enable_trailers_ = true;
     codec_ = std::make_unique<Http::Http1::ServerConnectionImpl>(
         shared_connection_.connection(), store, *this, http1_settings, max_request_headers_kb,
-        max_request_headers_count);
+        max_request_headers_count, headers_with_underscores_action);
   } else {
     envoy::config::core::v3::Http2ProtocolOptions http2_options =
         ::Envoy::Http2::Utility::initializeAndValidateOptions(
@@ -241,7 +242,7 @@ FakeHttpConnection::FakeHttpConnection(SharedConnectionWrapper& shared_connectio
     http2_options.set_allow_metadata(true);
     codec_ = std::make_unique<Http::Http2::ServerConnectionImpl>(
         shared_connection_.connection(), *this, store, http2_options, max_request_headers_kb,
-        max_request_headers_count);
+        max_request_headers_count, headers_with_underscores_action);
     ASSERT(type == Type::HTTP2);
   }
 
@@ -472,11 +473,11 @@ void FakeUpstream::threadRoutine() {
   }
 }
 
-AssertionResult FakeUpstream::waitForHttpConnection(Event::Dispatcher& client_dispatcher,
-                                                    FakeHttpConnectionPtr& connection,
-                                                    milliseconds timeout,
-                                                    uint32_t max_request_headers_kb,
-                                                    uint32_t max_request_headers_count) {
+AssertionResult FakeUpstream::waitForHttpConnection(
+    Event::Dispatcher& client_dispatcher, FakeHttpConnectionPtr& connection, milliseconds timeout,
+    uint32_t max_request_headers_kb, uint32_t max_request_headers_count,
+    envoy::config::core::v3::HttpProtocolOptions::HeadersWithUnderscoresAction
+        headers_with_underscores_action) {
   Event::TestTimeSystem& time_system = timeSystem();
   auto end_time = time_system.monotonicTime() + timeout;
   {
@@ -495,9 +496,9 @@ AssertionResult FakeUpstream::waitForHttpConnection(Event::Dispatcher& client_di
     if (new_connections_.empty()) {
       return AssertionFailure() << "Got a new connection event, but didn't create a connection.";
     }
-    connection = std::make_unique<FakeHttpConnection>(consumeConnection(), stats_store_, http_type_,
-                                                      time_system, max_request_headers_kb,
-                                                      max_request_headers_count);
+    connection = std::make_unique<FakeHttpConnection>(
+        consumeConnection(), stats_store_, http_type_, time_system, max_request_headers_kb,
+        max_request_headers_count, headers_with_underscores_action);
   }
   VERIFY_ASSERTION(connection->initialize());
   VERIFY_ASSERTION(connection->readDisable(false));
@@ -528,7 +529,7 @@ FakeUpstream::waitForHttpConnection(Event::Dispatcher& client_dispatcher,
         connection = std::make_unique<FakeHttpConnection>(
             upstream.consumeConnection(), upstream.stats_store_, upstream.http_type_,
             upstream.timeSystem(), Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
-            Http::DEFAULT_MAX_HEADERS_COUNT);
+            Http::DEFAULT_MAX_HEADERS_COUNT, envoy::config::core::v3::HttpProtocolOptions::ALLOW);
         lock.release();
         VERIFY_ASSERTION(connection->initialize());
         VERIFY_ASSERTION(connection->readDisable(false));

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -87,21 +87,18 @@ public:
   // https://github.com/envoyproxy/envoy-filter-example/pull/69 is reverted.
   HttpIntegrationTest(Http::CodecClient::Type downstream_protocol,
                       Network::Address::IpVersion version, TestTimeSystemPtr,
-                      const std::string& config = ConfigHelper::HTTP_PROXY_CONFIG)
+                      const std::string& config = ConfigHelper::httpProxyConfig())
       : HttpIntegrationTest(downstream_protocol, version, config) {}
 
   HttpIntegrationTest(Http::CodecClient::Type downstream_protocol,
                       Network::Address::IpVersion version,
-                      const std::string& config = ConfigHelper::HTTP_PROXY_CONFIG);
+                      const std::string& config = ConfigHelper::httpProxyConfig());
 
   HttpIntegrationTest(Http::CodecClient::Type downstream_protocol,
                       const InstanceConstSharedPtrFn& upstream_address_fn,
                       Network::Address::IpVersion version,
-                      const std::string& config = ConfigHelper::HTTP_PROXY_CONFIG);
+                      const std::string& config = ConfigHelper::httpProxyConfig());
   ~HttpIntegrationTest() override;
-
-  // Waits for the first access log entry.
-  std::string waitForAccessLog(const std::string& filename);
 
 protected:
   void useAccessLog(absl::string_view format = "");
@@ -173,9 +170,10 @@ protected:
                                                     const std::string& authority = "host");
   void testRouterNotFound();
   void testRouterNotFoundWithBody();
+  void testRouterVirtualClusters();
 
   void testRouterRequestAndResponseWithBody(uint64_t request_size, uint64_t response_size,
-                                            bool big_header,
+                                            bool big_header, bool set_content_length_header = false,
                                             ConnectionCreationFunction* creator = nullptr);
   void testRouterHeaderOnlyRequestAndResponse(ConnectionCreationFunction* creator = nullptr,
                                               int upstream_index = 0,
@@ -220,6 +218,8 @@ protected:
   // makes sure they were dropped.
   void testTrailers(uint64_t request_size, uint64_t response_size, bool request_trailers_present,
                     bool response_trailers_present);
+  // Test /drain_listener from admin portal.
+  void testAdminDrain(Http::CodecClient::Type admin_request_type);
 
   Http::CodecClient::Type downstreamProtocol() const { return downstream_protocol_; }
   // Prefix listener stat with IP:port, including IP version dependent loopback address.

--- a/test/integration/integration.h
+++ b/test/integration/integration.h
@@ -152,15 +152,15 @@ public:
   // Creates a test fixture with an upstream bound to INADDR_ANY on an unspecified port using the
   // provided IP |version|.
   BaseIntegrationTest(Network::Address::IpVersion version,
-                      const std::string& config = ConfigHelper::HTTP_PROXY_CONFIG);
+                      const std::string& config = ConfigHelper::httpProxyConfig());
   BaseIntegrationTest(Network::Address::IpVersion version, TestTimeSystemPtr,
-                      const std::string& config = ConfigHelper::HTTP_PROXY_CONFIG)
+                      const std::string& config = ConfigHelper::httpProxyConfig())
       : BaseIntegrationTest(version, config) {}
   // Creates a test fixture with a specified |upstream_address| function that provides the IP and
   // port to use.
   BaseIntegrationTest(const InstanceConstSharedPtrFn& upstream_address_fn,
                       Network::Address::IpVersion version,
-                      const std::string& config = ConfigHelper::HTTP_PROXY_CONFIG);
+                      const std::string& config = ConfigHelper::httpProxyConfig());
 
   virtual ~BaseIntegrationTest() = default;
 
@@ -197,7 +197,10 @@ public:
   void setUpstreamAddress(uint32_t upstream_index,
                           envoy::config::endpoint::v3::LbEndpoint& endpoint) const;
 
-  virtual Network::ClientConnectionPtr makeClientConnection(uint32_t port);
+  Network::ClientConnectionPtr makeClientConnection(uint32_t port);
+  virtual Network::ClientConnectionPtr
+  makeClientConnectionWithOptions(uint32_t port,
+                                  const Network::ConnectionSocket::OptionsSharedPtr& options);
 
   void registerTestServerPorts(const std::vector<std::string>& port_names);
   void createTestServer(const std::string& json_path, const std::vector<std::string>& port_names);
@@ -216,6 +219,13 @@ public:
   Api::ApiPtr api_;
   Api::ApiPtr api_for_server_stat_store_;
   MockBufferFactory* mock_buffer_factory_; // Will point to the dispatcher's factory.
+
+  // Enable the listener access log
+  void useListenerAccessLog(absl::string_view format = "");
+  // Waits for the first access log entry.
+  std::string waitForAccessLog(const std::string& filename);
+
+  std::string listener_access_log_name_;
 
   // Functions for testing reloadable config (xDS)
   void createXdsUpstream();
@@ -318,7 +328,7 @@ public:
       resource->set_name(TestUtility::xdsResourceName(temp_any));
       resource->set_version(version);
       resource->mutable_resource()->PackFrom(API_DOWNGRADE(message));
-      for (const auto alias : aliases) {
+      for (const auto& alias : aliases) {
         resource->add_aliases(alias);
       }
     }

--- a/test/integration/listener_filter_integration_test.cc
+++ b/test/integration/listener_filter_integration_test.cc
@@ -1,0 +1,123 @@
+#include <memory>
+
+#include "envoy/config/bootstrap/v3/bootstrap.pb.h"
+#include "envoy/config/cluster/v3/cluster.pb.h"
+#include "envoy/config/core/v3/base.pb.h"
+#include "envoy/extensions/access_loggers/file/v3/file.pb.h"
+
+#include "common/config/api_version.h"
+#include "common/network/utility.h"
+
+#include "extensions/filters/listener/tls_inspector/tls_inspector.h"
+#include "extensions/transport_sockets/tls/context_manager_impl.h"
+
+#include "test/integration/integration.h"
+#include "test/integration/ssl_utility.h"
+#include "test/integration/utility.h"
+#include "test/mocks/secret/mocks.h"
+
+#include "gtest/gtest.h"
+
+namespace Envoy {
+namespace {
+
+class ListenerFilterIntegrationTest : public testing::TestWithParam<Network::Address::IpVersion>,
+                                      public BaseIntegrationTest {
+public:
+  ListenerFilterIntegrationTest()
+      : BaseIntegrationTest(GetParam(), ConfigHelper::baseConfig() + R"EOF(
+    filter_chains:
+      filters:
+       -  name: envoy.filters.network.echo
+)EOF") {}
+
+  ~ListenerFilterIntegrationTest() override = default;
+  std::string appendMatcher(const std::string& listener_filter, bool disabled) {
+    if (disabled) {
+      return listener_filter +
+             R"EOF(
+filter_disabled:
+  any_match: true
+)EOF";
+    } else {
+      return listener_filter +
+             R"EOF(
+filter_disabled:
+  not_match:
+    any_match: true
+)EOF";
+    }
+  }
+
+  void initializeWithListenerFilter(absl::optional<bool> listener_filter_disabled = absl::nullopt) {
+    config_helper_.renameListener("echo");
+    std::string tls_inspector_config = ConfigHelper::tlsInspectorFilter();
+    if (listener_filter_disabled.has_value()) {
+      tls_inspector_config = appendMatcher(tls_inspector_config, listener_filter_disabled.value());
+    }
+    config_helper_.addListenerFilter(tls_inspector_config);
+    config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+      auto* filter_chain =
+          bootstrap.mutable_static_resources()->mutable_listeners(0)->mutable_filter_chains(0);
+      auto* alpn = filter_chain->mutable_filter_chain_match()->add_application_protocols();
+      *alpn = "envoyalpn";
+    });
+    config_helper_.addSslConfig();
+    BaseIntegrationTest::initialize();
+
+    context_manager_ =
+        std::make_unique<Extensions::TransportSockets::Tls::ContextManagerImpl>(timeSystem());
+  }
+
+  void setupConnections(bool listener_filter_disabled, bool expect_connection_open) {
+    initializeWithListenerFilter(listener_filter_disabled);
+
+    // Set up the SSL client.
+    Network::Address::InstanceConstSharedPtr address =
+        Ssl::getSslAddress(version_, lookupPort("echo"));
+    context_ = Ssl::createClientSslTransportSocketFactory({}, *context_manager_, *api_);
+    ssl_client_ = dispatcher_->createClientConnection(
+        address, Network::Address::InstanceConstSharedPtr(),
+        context_->createTransportSocket(
+            // nullptr
+            std::make_shared<Network::TransportSocketOptionsImpl>(
+                absl::string_view(""), std::vector<std::string>(),
+                std::vector<std::string>{"envoyalpn"})),
+        nullptr);
+    ssl_client_->addConnectionCallbacks(connect_callbacks_);
+    ssl_client_->connect();
+    while (!connect_callbacks_.connected() && !connect_callbacks_.closed()) {
+      dispatcher_->run(Event::Dispatcher::RunType::NonBlock);
+    }
+
+    if (expect_connection_open) {
+      ASSERT(connect_callbacks_.connected());
+      ASSERT_FALSE(connect_callbacks_.closed());
+    } else {
+      ASSERT_FALSE(connect_callbacks_.connected());
+      ASSERT(connect_callbacks_.closed());
+    }
+  }
+  std::unique_ptr<Ssl::ContextManager> context_manager_;
+  Network::TransportSocketFactoryPtr context_;
+  ConnectionStatusCallbacks connect_callbacks_;
+  testing::NiceMock<Secret::MockSecretManager> secret_manager_;
+  Network::ClientConnectionPtr ssl_client_;
+};
+
+// Each listener filter is enabled by default.
+TEST_P(ListenerFilterIntegrationTest, AllListenerFiltersAreEnabledByDefault) {
+  setupConnections(/*listener_filter_disabled=*/false, /*expect_connection_open=*/true);
+  ssl_client_->close(Network::ConnectionCloseType::NoFlush);
+}
+
+// The tls_inspector is disabled. The ALPN won't be sniffed out and no filter chain is matched.
+TEST_P(ListenerFilterIntegrationTest, DisabledTlsInspectorFailsFilterChainFind) {
+  setupConnections(/*listener_filter_disabled=*/true, /*expect_connection_open=*/false);
+}
+
+INSTANTIATE_TEST_SUITE_P(IpVersions, ListenerFilterIntegrationTest,
+                         testing::ValuesIn(TestEnvironment::getIpVersionsForTest()),
+                         TestUtility::ipTestParamsToString);
+} // namespace
+} // namespace Envoy

--- a/test/integration/server.h
+++ b/test/integration/server.h
@@ -102,15 +102,15 @@ public:
     return wrapped_scope_->nullGauge(str);
   }
 
-  Counter& counter(const std::string& name) override {
+  Counter& counterFromString(const std::string& name) override {
     StatNameManagedStorage storage(name, symbolTable());
     return counterFromStatName(storage.statName());
   }
-  Gauge& gauge(const std::string& name, Gauge::ImportMode import_mode) override {
+  Gauge& gaugeFromString(const std::string& name, Gauge::ImportMode import_mode) override {
     StatNameManagedStorage storage(name, symbolTable());
     return gaugeFromStatName(storage.statName(), import_mode);
   }
-  Histogram& histogram(const std::string& name, Histogram::Unit unit) override {
+  Histogram& histogramFromString(const std::string& name, Histogram::Unit unit) override {
     StatNameManagedStorage storage(name, symbolTable());
     return histogramFromStatName(storage.statName(), unit);
   }
@@ -150,9 +150,9 @@ public:
     Thread::LockGuard lock(lock_);
     return store_.counterFromStatNameWithTags(name, tags);
   }
-  Counter& counter(const std::string& name) override {
+  Counter& counterFromString(const std::string& name) override {
     Thread::LockGuard lock(lock_);
-    return store_.counter(name);
+    return store_.counterFromString(name);
   }
   ScopePtr createScope(const std::string& name) override {
     Thread::LockGuard lock(lock_);
@@ -164,9 +164,9 @@ public:
     Thread::LockGuard lock(lock_);
     return store_.gaugeFromStatNameWithTags(name, tags, import_mode);
   }
-  Gauge& gauge(const std::string& name, Gauge::ImportMode import_mode) override {
+  Gauge& gaugeFromString(const std::string& name, Gauge::ImportMode import_mode) override {
     Thread::LockGuard lock(lock_);
-    return store_.gauge(name, import_mode);
+    return store_.gaugeFromString(name, import_mode);
   }
   Histogram& histogramFromStatNameWithTags(const StatName& name, StatNameTagVectorOptConstRef tags,
                                            Histogram::Unit unit) override {
@@ -174,9 +174,9 @@ public:
     return store_.histogramFromStatNameWithTags(name, tags, unit);
   }
   NullGaugeImpl& nullGauge(const std::string& name) override { return store_.nullGauge(name); }
-  Histogram& histogram(const std::string& name, Histogram::Unit unit) override {
+  Histogram& histogramFromString(const std::string& name, Histogram::Unit unit) override {
     Thread::LockGuard lock(lock_);
-    return store_.histogram(name, unit);
+    return store_.histogramFromString(name, unit);
   }
   CounterOptConstRef findCounter(StatName name) const override {
     Thread::LockGuard lock(lock_);

--- a/test/mocks/server/mocks.h
+++ b/test/mocks/server/mocks.h
@@ -174,6 +174,7 @@ public:
   MOCK_METHOD(Http::RequestHeaderMap&, getRequestHeaders, (), (const));
   MOCK_METHOD(NiceMock<Http::MockStreamDecoderFilterCallbacks>&, getDecoderFilterCallbacks, (),
               (const));
+  MOCK_METHOD(Http::Http1StreamEncoderOptionsOptRef, http1StreamEncoderOptions, ());
 };
 
 class MockDrainManager : public DrainManager {
@@ -494,6 +495,7 @@ public:
   MOCK_METHOD(ProtobufMessage::ValidationVisitor&, messageValidationVisitor, ());
   MOCK_METHOD(Api::Api&, api, ());
   Grpc::Context& grpcContext() override { return grpc_context_; }
+  MOCK_METHOD(Server::DrainManager&, drainManager, ());
 
   testing::NiceMock<Upstream::MockClusterManager> cluster_manager_;
   testing::NiceMock<Event::MockDispatcher> dispatcher_;


### PR DESCRIPTION
This change updates Envoy submodule to tag v1.14.1 and applies necessary
changes in extensions and tests.

Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>