### PR TITLE
tls: forbid SSL_do_handshake() until ready

### DIFF
--- a/source/extensions/transport_sockets/tls/ssl_socket.h
+++ b/source/extensions/transport_sockets/tls/ssl_socket.h
@@ -43,7 +43,13 @@ struct SslSocketFactoryStats {
 };
 
 enum class InitialState { Client, Server };
-enum class SocketState { PreHandshake, HandshakeInProgress, HandshakeComplete, ShutdownSent };
+enum class SocketState {
+  PreHandshake,
+  HandshakeInProgress,
+  HandshakeReady,
+  HandshakeComplete,
+  ShutdownSent
+};
 
 class SslExtendedSocketInfoImpl : public Envoy::Ssl::SslExtendedSocketInfo {
 public:


### PR DESCRIPTION
Extend sockets' state machine to accommodate the case when the underlying OpenSSL engine doesn't expect `SSL_do_handshake()` call until the asynchronous callback registered by a connection is called by the engine.