### PR TITLE
OpenSSL Testing Errors

### DIFF
--- a/README-openssl.md
+++ b/README-openssl.md
@@ -30,9 +30,20 @@ If you need OpenSSL dynamically linked to Envoy then re-map `@boringssl` to
 To test the OpenSSL features run the following commands.
 
 ```console
-$ bazel test //test/common/...
-$ bazel test //test/extensions/...
-$ bazel test //test/integration/...
+$ bazel test --define openssl=true //test/common/...
+$ bazel test --define openssl=true //test/extensions/...
+$ bazel test --define openssl=true //test/integration/...
+```
+
+### DNS
+
+With test cases that use DNS, ensure that `localhost` is resolvable for ip6.
+
+/etc/hosts
+
+```
+# The following lines are desirable for IPv6 capable hosts
+::1     ip6-localhost ip6-loopback localhost
 ```
 
 ## License

--- a/source/extensions/transport_sockets/tls/BUILD
+++ b/source/extensions/transport_sockets/tls/BUILD
@@ -37,6 +37,9 @@ envoy_cc_library(
         "abseil_synchronization",
         "ssl",
     ],
+    copts = [
+        "-UOPENSSL_IS_BORINGSSL",
+    ],
     deps = [
         ":context_config_lib",
         ":context_lib",

--- a/test/common/crypto/utility_test.cc
+++ b/test/common/crypto/utility_test.cc
@@ -109,7 +109,7 @@ TEST(UtilityTest, TestVerifySignature) {
   EXPECT_EQ(false, result.result_);
   EXPECT_EQ("unknown is not supported.", result.error_message_);
 
-  auto empty_crypto = std::make_unique<PublicKeyObject>();
+  PublicKeyObject* empty_crypto = new PublicKeyObject();
   result = UtilitySingleton::get().verifySignature(hash_func, *empty_crypto, sig, text);
   EXPECT_EQ(false, result.result_);
   EXPECT_EQ("Failed to initialize digest verify.", result.error_message_);


### PR DESCRIPTION
Several errors arose in the testing phase due to missing openssl config on the bazel test.

- Documentation changes for running test
- Documentation addition for ip6
- Change of pointer creation to use of new() instead of std::make_unique due to default destructor being called.