### PR TITLE
bssl-compat: Add rand function used by Envoy

### DIFF
--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(bssl-compat
     source/cbb.c
     source/bn.c
     source/asn1_a_int.c
+    source/bssl_openssl.c
     )
 
 target_include_directories(bssl-compat PRIVATE

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -66,3 +66,6 @@ target_include_directories(bssl-compat PUBLIC
         )
 
 target_link_libraries(bssl-compat PRIVATE crypto)
+add_executable(test_rand)
+target_sources(test_rand PRIVATE source/test/test_rand.c)
+target_link_libraries(test_rand PRIVATE bssl-compat)

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -53,12 +53,16 @@ add_library(bssl-compat
     source/bn.c
     source/asn1_a_int.c
     source/bssl_openssl.c
+    source/rand.c
     )
 
-target_include_directories(bssl-compat PRIVATE
+target_link_libraries(bssl-compat PRIVATE crypto)
+target_include_directories(bssl-compat PUBLIC
         # needed for ssl includes
         ${openssl_SOURCE_DIR}/include
         include
 #       needed only if ssl/ssl.h is used.
 #       ${openssl_SOURCE_DIR}
         )
+
+target_link_libraries(bssl-compat PRIVATE crypto)

--- a/bssl-compat/include/bssl_compat/bssl_openssl.h
+++ b/bssl-compat/include/bssl_compat/bssl_openssl.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef BSSL_OPENSSL_H
+#define BSSL_OPENSSL_H
+
+// OpenSSL functions needed by the implementation
+struct openssl_func {
+};
+
+extern struct openssl_func openssl;
+
+#endif

--- a/bssl-compat/include/bssl_compat/openssl/rand.h
+++ b/bssl-compat/include/bssl_compat/openssl/rand.h
@@ -1,0 +1,31 @@
+/* Copyright (c) 2014, Google Inc.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+ * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
+
+#ifndef BSSL_COMPAT_HEADER_RAND_H
+#define BSSL_COMPAT_HEADER_RAND_H
+
+#include <bssl_compat/bssl_compat.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+// RAND_bytes writes |len| bytes of random data to |buf| and returns one.
+OPENSSL_EXPORT int RAND_bytes(uint8_t *buf, size_t len);
+
+#if defined(__cplusplus)
+}  // extern C
+#endif
+
+#endif  // OPENSSL_HEADER_RAND_H

--- a/bssl-compat/source/bssl_openssl.c
+++ b/bssl-compat/source/bssl_openssl.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdio.h>
+#include <dlfcn.h>
+#include <errno.h>
+#include <stdlib.h>
+
+#include "bssl_compat/bssl_openssl.h"
+
+#define OPENSSL_LIBCRYPTO "libcrypto.so"
+
+/* Constructor/destructor functions to run when library is loaded/unloaded */
+static void bssl_openssl_init(void)  __attribute__ ((constructor));
+static void bssl_openssl_close(void) __attribute__ ((destructor));
+
+static void *libcrypto;
+struct openssl_func openssl;
+
+/* Load needed OpenSSL symbols, fail hard if the attempt is unsuccessful  */
+static void bssl_openssl_init(void) {
+
+	libcrypto = dlopen(OPENSSL_LIBCRYPTO, RTLD_NOW | RTLD_LOCAL);
+	if (libcrypto == NULL)
+		goto err;
+
+	return;
+
+ err:
+	fprintf(stderr, "%s: %s\n", __FUNCTION__, dlerror());
+	exit(ELIBACC);
+}
+
+static void bssl_openssl_close(void) {
+	dlclose(libcrypto);
+}

--- a/bssl-compat/source/bssl_openssl.c
+++ b/bssl-compat/source/bssl_openssl.c
@@ -39,6 +39,10 @@ static void bssl_openssl_init(void) {
 	if (libcrypto == NULL)
 		goto err;
 
+	if (!(openssl.RAND_bytes =
+	      (int(*)(unsigned char *, int))(dlsym(libcrypto, "RAND_bytes"))))
+		goto err;
+
 	return;
 
  err:

--- a/bssl-compat/source/rand.c
+++ b/bssl-compat/source/rand.c
@@ -16,14 +16,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef BSSL_OPENSSL_H
-#define BSSL_OPENSSL_H
+#include "bssl_compat/bssl_compat.h"
+#include "bssl_compat/bssl_openssl.h"
 
-// OpenSSL functions needed by the implementation
-struct openssl_func {
-	int (*RAND_bytes)(unsigned char *, int);
-};
+OPENSSL_EXPORT int RAND_bytes(uint8_t *buf, size_t len) {
 
-extern struct openssl_func openssl;
+	if (openssl.RAND_bytes((unsigned char *)buf, (int)len) <= 0)
+		return 0;
 
-#endif
+	return 1;
+}

--- a/bssl-compat/source/test/test_rand.c
+++ b/bssl-compat/source/test/test_rand.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2022 Intel Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "bssl_compat/openssl/rand.h"
+
+#include <stdio.h>
+#include <stdint.h>
+
+int main (void) {
+	int r, i;
+	uint8_t a[16] = { 0 };
+	uint8_t b[16] = { 0 };
+
+	r = RAND_bytes(a, sizeof(a));
+	printf("RAND_bytes returned %d: ", r);
+
+	for (i = 0; i < sizeof(a); i++)
+		printf("%02x ", a[i]);
+	printf("\n");
+
+	r = RAND_bytes(b, sizeof(b));
+	printf("RAND_bytes returned %d: ", r);
+
+	for (i = 0; i < sizeof(b); i++)
+		printf("%02x ", b[i]);
+	printf("\n");
+
+	for (i = 0; i < sizeof(a); i++) {
+		if (a[i] != b[i])
+			return 0;
+	}
+
+	return 1;
+}


### PR DESCRIPTION
Accessing RAND_bytes() from OpenSSL with dlsym() keeps the library in line with C calling conventions. I was trying out C++ namespaces, but that caused the source code and calling conventions become C++, which wasn't what was intended. There is also a minimal "test" program in my branch envoy_rand_dlopen_test should anyone want to print out a string of random bytes.

Currently this links to the first OpenSSL library found, which is the one installed by the system. Some work needed here if OpenSSL is to be downloaded, compiled and linked against.

---
Add RAND_bytes() function which is the only function used from
the RAND_ family by Envoy. Find the identically named OpenSSL
function with dlsym and store its value for next calls to this
function.

Watch out for return values, OpenSSL uses < 0 to indicate errors
in version 1.1.1 (and 0 in 3.0) where BoringSSL always uses 0.

Signed-off-by: Patrik Flykt <patrik.flykt@intel.com>