### PR TITLE
Enabled bazel build for bssl-compat

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,7 +11,7 @@ http_archive(
 
 load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
-rules_foreign_cc_dependencies()
+rules_foreign_cc_dependencies(register_default_tools = False, register_built_tools = False)
 
 openssl_files = """\
 filegroup(

--- a/bssl-compat/BUILD
+++ b/bssl-compat/BUILD
@@ -22,6 +22,8 @@ cmake(
     out_static_libs = ["libbssl-compat.a"],
     visibility = ["//visibility:public"],
     deps = [":openssl"],
+    generate_crosstool_file = False,
+    tags = ["requires-network"],
 )
 
 alias(

--- a/bssl-compat/boringssl.cmake
+++ b/bssl-compat/boringssl.cmake
@@ -5,9 +5,9 @@ endfunction()
 
 # Copy, and optionally patch, the openssl/*.h headers from the ${CMAKE_CURRENT_SOURCE_DIR}/boringssl
 # directory into the ${CMAKE_CURRENT_SOURCE_DIR}/include directory, to form our public interface.
-file(GLOB bsslheaders RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/boringssl/src/include/" "${CMAKE_CURRENT_SOURCE_DIR}/boringssl/src/include/openssl/*.h")
+file(GLOB bsslheaders RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}/boringssl/include/" "${CMAKE_CURRENT_SOURCE_DIR}/boringssl/include/openssl/*.h")
 foreach(bsslheader ${bsslheaders})
-  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/boringssl/src/include/${bsslheader}" "${CMAKE_CURRENT_SOURCE_DIR}/include/${bsslheader}" COPYONLY)
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/boringssl/include/${bsslheader}" "${CMAKE_CURRENT_SOURCE_DIR}/include/${bsslheader}" COPYONLY)
   if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/patch/include/${bsslheader}.patch")
     execute_process(COMMAND patch -s "${CMAKE_CURRENT_SOURCE_DIR}/include/${bsslheader}" "${CMAKE_CURRENT_SOURCE_DIR}/patch/include/${bsslheader}.patch")
     message("Copied ${bsslheader} (patched)")
@@ -15,14 +15,14 @@ foreach(bsslheader ${bsslheaders})
     message("Copied ${bsslheader}")
   endif()
   set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES "${CMAKE_CURRENT_SOURCE_DIR}/include/${bsslheader}")
-  add_gitignore("include/${bsslheader} # Copied from boringssl/src/include/${bsslheader}")
+  add_gitignore("include/${bsslheader} # Copied from boringssl/include/${bsslheader}")
 endforeach()
 
 
 # Copy the specified file from the BoringSSL source tree into our build
 # directory, and patch it if a corresponding patch file exists.
 function(copy_bssl_src bsslfile)
-  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/boringssl/src/${bsslfile}" "${CMAKE_CURRENT_SOURCE_DIR}/source/${bsslfile}" COPYONLY)
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/boringssl/${bsslfile}" "${CMAKE_CURRENT_SOURCE_DIR}/source/${bsslfile}" COPYONLY)
   if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/patch/source/${bsslfile}.patch")
     execute_process(COMMAND patch -s "${CMAKE_CURRENT_SOURCE_DIR}/source/${bsslfile}" "${CMAKE_CURRENT_SOURCE_DIR}/patch/source/${bsslfile}.patch")
     message("Copied ${bsslfile} (patched)")
@@ -30,7 +30,7 @@ function(copy_bssl_src bsslfile)
     message("Copied ${bsslfile}")
   endif()
   set_property(DIRECTORY APPEND PROPERTY ADDITIONAL_CLEAN_FILES "${CMAKE_CURRENT_SOURCE_DIR}/source/${bsslfile}")
-  add_gitignore("source/${bsslfile} # Copied from boringssl/src/${bsslfile}")
+  add_gitignore("source/${bsslfile} # Copied from boringssl/${bsslfile}")
 endfunction()
 
 

--- a/bssl-compat/tools/generate_ERR_GET_LIB.py
+++ b/bssl-compat/tools/generate_ERR_GET_LIB.py
@@ -2,7 +2,7 @@
 import os
 import re
 
-bssl_compat_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+bssl_compat_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 bssl_err_h = os.path.join(bssl_compat_dir, "include", "openssl", "err.h")
 ossl_err_h = os.path.join(bssl_compat_dir, "include", "ossl", "openssl", "err.h")
 ERR_GET_LIB_c = os.path.join(bssl_compat_dir, "source", "ERR_GET_LIB.c")

--- a/bssl-compat/tools/generate_ERR_GET_REASON.py
+++ b/bssl-compat/tools/generate_ERR_GET_REASON.py
@@ -4,7 +4,7 @@ import re
 import json
 import yaml
 
-bssl_compat_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+bssl_compat_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 bssl_err_h = os.path.join(bssl_compat_dir, "include", "openssl", "err.h")
 ossl_err_h = os.path.join(bssl_compat_dir, "include", "ossl", "openssl", "err.h")
 ERR_GET_REASON_c = os.path.join(bssl_compat_dir, "source", "ERR_GET_REASON.c")


### PR DESCRIPTION
- switched to non-bazel "main" boringssl branch for boringssl submodule to enable copying all files into the bazel sandbox; removed "src" from path (main branch doesn't have "src" folder)
- added "requires-network" tag (cmake needs to download googletest from github)
- replaced realpath() with abspath(); realpath points to local code directory (read-only for bazel build, not possible to generate files), abspath points to sandbox
- added rules_foreign_cc_dependencies parameters (the same as in envoy) to fix cmake build with bazel rules_foreign_cc

For now with these changes bssl-compat part can be build with bazel `CC=clang CXX=clang++ bazel build --config=clang @bssl-compat//:bssl-compat`, but not the whole repo.
When trying to build the full envoy-openssl repo with bazel, there are errors from envoy submodule (handshake-related envoy code), will try to work on it in a separate PR.