### PR TITLE
Made headers available to other bazel rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ platform. Clang is strongly recommended for a successful build.
 
 After installing clang and Bazelisk/Bazel, build Envoy handshaker with:
 ```
-CC=clang CXX=clang++ bazel build --config=clang :envoy
+patch envoy/bazel/repositories.bzl -i bazel/envoy.patch
+CC=clang CXX=clang++ bazel build --config=clang --define crypto=system :envoy
 ```
 
 ## Testing

--- a/bazel/envoy.patch
+++ b/bazel/envoy.patch
@@ -1,0 +1,18 @@
+--- envoy/bazel/repositories.bzl
++++ envoy/bazel/repositories.bzl
+@@ -151,14 +151,9 @@
+     # Setup external Bazel rules
+     _foreign_cc_dependencies()
+ 
+-    # Binding to an alias pointing to the selected version of BoringSSL:
+-    # - BoringSSL FIPS from @boringssl_fips//:ssl,
+-    # - non-FIPS BoringSSL from @boringssl//:ssl.
+-    _boringssl()
+-    _boringssl_fips()
+     native.bind(
+         name = "ssl",
+-        actual = "@envoy//bazel:boringssl",
++        actual = "@bssl-compat//:bssl-compat",
+     )
+ 
+     # The long repo names (`com_github_fmtlib_fmt` instead of `fmtlib`) are

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -87,6 +87,10 @@ target_link_libraries(bssl-compat INTERFACE ${CMAKE_DL_LIBS})
 
 
 install(TARGETS bssl-compat LIBRARY DESTINATION lib)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/openssl DESTINATION include)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ext DESTINATION include)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ossl DESTINATION include)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/ossl.h DESTINATION include)
 
 ################################################################################
 # Unit Tests

--- a/bssl-compat/boringssl.cmake
+++ b/bssl-compat/boringssl.cmake
@@ -1,6 +1,8 @@
 
 function(add_gitignore ignorefile)
-  execute_process(COMMAND echo "${ignorefile}" COMMAND sort -u -o "${CMAKE_CURRENT_SOURCE_DIR}/.gitignore" - "${CMAKE_CURRENT_SOURCE_DIR}/.gitignore")
+  # Bazel build does not allow changing original source files, temporarily commented the call to execute_process()
+  # TODO: find another solution for updating .gitignore
+  # execute_process(COMMAND echo "${ignorefile}" COMMAND sort -u -o "${CMAKE_CURRENT_SOURCE_DIR}/.gitignore" - "${CMAKE_CURRENT_SOURCE_DIR}/.gitignore")
 endfunction()
 
 # Copy, and optionally patch, the openssl/*.h headers from the ${CMAKE_CURRENT_SOURCE_DIR}/boringssl


### PR DESCRIPTION
bssl-compat headers are now visible and can be used during envoy bazel build