### PR TITLE
OSSM-3364 Added more <openssl/ssl.h> functions

### DIFF
--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(bssl-compat STATIC
   source/rand.c
   source/ssl_cipher.c
   source/ssl_ctx.c
+  source/ssl_ctx.cc
   source/ssl_ext.c
   source/ssl.c
   source/stack.c
@@ -186,7 +187,6 @@ set(utests-bssl-source-list
   source/crypto/stack/stack_test.cc
   source/crypto/test/test_util.h
   source/crypto/test/test_util.cc
-  source/ssl/internal.h
   source/ssl/ssl_test.cc
 )
 

--- a/bssl-compat/patch/include/openssl/crypto.h.patch
+++ b/bssl-compat/patch/include/openssl/crypto.h.patch
@@ -1,0 +1,49 @@
+--- a/include/openssl/crypto.h
++++ b/include/openssl/crypto.h
+@@ -12,24 +12,24 @@
+  * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
+ 
+-// #ifndef OPENSSL_HEADER_CRYPTO_H
+-// #define OPENSSL_HEADER_CRYPTO_H
++#ifndef OPENSSL_HEADER_CRYPTO_H
++#define OPENSSL_HEADER_CRYPTO_H
+ 
+-// #include <openssl/base.h>
+-// #include <openssl/sha.h>
++#include <openssl/base.h>
++#include <openssl/sha.h>
+ 
+ // Upstream OpenSSL defines |OPENSSL_malloc|, etc., in crypto.h rather than
+ // mem.h.
+-// #include <openssl/mem.h>
++#include <openssl/mem.h>
+ 
+ // Upstream OpenSSL defines |CRYPTO_LOCK|, etc., in crypto.h rather than
+ // thread.h.
+-// #include <openssl/thread.h>
++#include <openssl/thread.h>
+ 
+ 
+-// #if defined(__cplusplus)
+-// extern "C" {
+-// #endif
++#if defined(__cplusplus)
++extern "C" {
++#endif
+ 
+ 
+ // crypto.h contains functions for initializing the crypto library.
+@@ -194,8 +194,8 @@
+ // OPENSSL_EXPORT int FIPS_query_algorithm_status(const char *algorithm);
+ 
+ 
+-// #if defined(__cplusplus)
+-// }  // extern C
+-// #endif
++#if defined(__cplusplus)
++}  // extern C
++#endif
+ 
+-// #endif  // OPENSSL_HEADER_CRYPTO_H
++#endif  // OPENSSL_HEADER_CRYPTO_H

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -94,7 +94,7 @@
  
  
  // SSL connections.
-@@ -224,15 +225,15 @@
+@@ -224,25 +225,25 @@
  //
  // On creation, an |SSL| is not configured to be either a client or server. Call
  // |SSL_set_connect_state| or |SSL_set_accept_state| to set this.
@@ -112,8 +112,11 @@
 +OPENSSL_EXPORT SSL_CTX *SSL_get_SSL_CTX(const SSL *ssl);
  
  // SSL_set_connect_state configures |ssl| to be a client.
- // OPENSSL_EXPORT void SSL_set_connect_state(SSL *ssl);
-@@ -242,7 +243,7 @@
+-// OPENSSL_EXPORT void SSL_set_connect_state(SSL *ssl);
++OPENSSL_EXPORT void SSL_set_connect_state(SSL *ssl);
+ 
+ // SSL_set_accept_state configures |ssl| to be a server.
+ // OPENSSL_EXPORT void SSL_set_accept_state(SSL *ssl);
  
  // SSL_is_server returns one if |ssl| is configured as a server and zero
  // otherwise.
@@ -122,6 +125,23 @@
  
  // SSL_is_dtls returns one if |ssl| is a DTLS connection and zero otherwise.
  // OPENSSL_EXPORT int SSL_is_dtls(const SSL *ssl);
+@@ -272,14 +273,14 @@
+ //
+ // Note that, although this function and |SSL_set0_wbio| may be called on the
+ // same |BIO|, each call takes a reference. Use |BIO_up_ref| to balance this.
+-// OPENSSL_EXPORT void SSL_set0_rbio(SSL *ssl, BIO *rbio);
++OPENSSL_EXPORT void SSL_set0_rbio(SSL *ssl, BIO *rbio);
+ 
+ // SSL_set0_wbio configures |ssl| to write to |wbio|. It takes ownership of
+ // |wbio|.
+ //
+ // Note that, although this function and |SSL_set0_rbio| may be called on the
+ // same |BIO|, each call takes a reference. Use |BIO_up_ref| to balance this.
+-// OPENSSL_EXPORT void SSL_set0_wbio(SSL *ssl, BIO *wbio);
++OPENSSL_EXPORT void SSL_set0_wbio(SSL *ssl, BIO *wbio);
+ 
+ // SSL_get_rbio returns the |BIO| that |ssl| reads from.
+ // OPENSSL_EXPORT BIO *SSL_get_rbio(const SSL *ssl);
 @@ -313,7 +314,7 @@
  // |fd|.
  //
@@ -131,7 +151,12 @@
  
  // SSL_set_rfd configures |ssl| to read from |fd|. It returns one on success and
  // zero on allocation error. The caller retains ownership of |fd|.
-@@ -344,11 +345,11 @@
+@@ -340,15 +341,15 @@
+ //
+ // TODO(davidben): Ensure 0 is only returned on transport EOF.
+ // https://crbug.com/466303.
+-// OPENSSL_EXPORT int SSL_do_handshake(SSL *ssl);
++OPENSSL_EXPORT int SSL_do_handshake(SSL *ssl);
  
  // SSL_connect configures |ssl| as a client, if unconfigured, and calls
  // |SSL_do_handshake|.
@@ -172,6 +197,15 @@
  
  // SSL_CTX_set_quiet_shutdown sets quiet shutdown on |ctx| to |mode|. If
  // enabled, |SSL_shutdown| will not send a close_notify alert or wait for one
+@@ -475,7 +476,7 @@
+ // SSL_get_error returns a |SSL_ERROR_*| value for the most recent operation on
+ // |ssl|. It should be called after an operation failed to determine whether the
+ // error was fatal and, if not, when to retry.
+-// OPENSSL_EXPORT int SSL_get_error(const SSL *ssl, int ret_code);
++OPENSSL_EXPORT int SSL_get_error(const SSL *ssl, int ret_code);
+ 
+ // SSL_ERROR_NONE indicates the operation succeeded.
+ #ifdef ossl_SSL_ERROR_NONE
 @@ -634,7 +635,7 @@
  // SSL_error_description returns a string representation of |err|, where |err|
  // is one of the |SSL_ERROR_*| constants returned by |SSL_get_error|, or NULL
@@ -181,6 +215,25 @@
  
  // SSL_set_mtu sets the |ssl|'s MTU in DTLS to |mtu|. It returns one on success
  // and zero on failure.
+@@ -716,14 +717,14 @@
+ // SSL_CTX_set_min_proto_version sets the minimum protocol version for |ctx| to
+ // |version|. If |version| is zero, the default minimum version is used. It
+ // returns one on success and zero if |version| is invalid.
+-// OPENSSL_EXPORT int SSL_CTX_set_min_proto_version(SSL_CTX *ctx,
+-//                                                  uint16_t version);
++OPENSSL_EXPORT int SSL_CTX_set_min_proto_version(SSL_CTX *ctx,
++                                                 uint16_t version);
+ 
+ // SSL_CTX_set_max_proto_version sets the maximum protocol version for |ctx| to
+ // |version|. If |version| is zero, the default maximum version is used. It
+ // returns one on success and zero if |version| is invalid.
+-// OPENSSL_EXPORT int SSL_CTX_set_max_proto_version(SSL_CTX *ctx,
+-//                                                  uint16_t version);
++OPENSSL_EXPORT int SSL_CTX_set_max_proto_version(SSL_CTX *ctx,
++                                                 uint16_t version);
+ 
+ // SSL_CTX_get_min_proto_version returns the minimum protocol version for |ctx|
+ // OPENSSL_EXPORT uint16_t SSL_CTX_get_min_proto_version(const SSL_CTX *ctx);
 @@ -928,7 +929,7 @@
  
  // SSL_CTX_use_certificate sets |ctx|'s leaf certificate to |x509|. It returns
@@ -276,6 +329,34 @@
  
  // SSL_CIPHER_get_kx_name returns a string that describes the key-exchange
  // method used by |cipher|. For example, "ECDHE_ECDSA". TLS 1.3 AEAD-only
+@@ -1577,15 +1578,15 @@
+ // SSL_CTX_set_strict_cipher_list configures the cipher list for |ctx|,
+ // evaluating |str| as a cipher string and returning error if |str| contains
+ // anything meaningless. It returns one on success and zero on failure.
+-// OPENSSL_EXPORT int SSL_CTX_set_strict_cipher_list(SSL_CTX *ctx,
+-//                                                   const char *str);
++OPENSSL_EXPORT int SSL_CTX_set_strict_cipher_list(SSL_CTX *ctx,
++                                                  const char *str);
+ 
+ // SSL_CTX_set_cipher_list configures the cipher list for |ctx|, evaluating
+ // |str| as a cipher string. It returns one on success and zero on failure.
+ //
+ // Prefer to use |SSL_CTX_set_strict_cipher_list|. This function tolerates
+ // garbage inputs, unless an empty cipher list results.
+-// OPENSSL_EXPORT int SSL_CTX_set_cipher_list(SSL_CTX *ctx, const char *str);
++OPENSSL_EXPORT int SSL_CTX_set_cipher_list(SSL_CTX *ctx, const char *str);
+ 
+ // SSL_set_strict_cipher_list configures the cipher list for |ssl|, evaluating
+ // |str| as a cipher string and returning error if |str| contains anything
+@@ -1601,7 +1602,7 @@
+ 
+ // SSL_CTX_get_ciphers returns the cipher list for |ctx|, in order of
+ // preference.
+-// OPENSSL_EXPORT STACK_OF(SSL_CIPHER) *SSL_CTX_get_ciphers(const SSL_CTX *ctx);
++OPENSSL_EXPORT STACK_OF(SSL_CIPHER) *SSL_CTX_get_ciphers(const SSL_CTX *ctx);
+ 
+ // SSL_CTX_cipher_in_group returns one if the |i|th cipher (see
+ // |SSL_CTX_get_ciphers|) is in the same equipreference group as the one
 @@ -1609,7 +1610,7 @@
  // OPENSSL_EXPORT int SSL_CTX_cipher_in_group(const SSL_CTX *ctx, size_t i);
  
@@ -549,7 +630,7 @@
  // OPENSSL_EXPORT const SSL_METHOD *SSLv23_server_method(void);
  // OPENSSL_EXPORT const SSL_METHOD *SSLv23_client_method(void);
  // OPENSSL_EXPORT const SSL_METHOD *TLSv1_server_method(void);
-@@ -5450,21 +5451,21 @@
+@@ -5462,21 +5463,21 @@
  // #endif // !defined(BORINGSSL_PREFIX)
  
  
@@ -579,7 +660,7 @@
  // BORINGSSL_MAKE_UP_REF(SSL_SESSION, SSL_SESSION_up_ref)
  
  // enum class OpenRecordResult {
-@@ -5581,13 +5582,13 @@
+@@ -5593,13 +5594,13 @@
  //     Span<const uint8_t> *out_write_traffic_secret);
  
  
@@ -595,11 +676,11 @@
 -// #endif
 +#endif
  
- // #define SSL_R_APP_DATA_IN_HANDSHAKE 100
- // #define SSL_R_ATTEMPT_TO_REUSE_SESSION_IN_DIFFERENT_CONTEXT 101
-@@ -5845,4 +5846,4 @@
- // #define SSL_R_TLSV1_ALERT_NO_APPLICATION_PROTOCOL 1120
- // #define SSL_R_TLSV1_ALERT_ECH_REQUIRED 1121
+ #ifdef ossl_SSL_R_APP_DATA_IN_HANDSHAKE
+ #define SSL_R_APP_DATA_IN_HANDSHAKE ossl_SSL_R_APP_DATA_IN_HANDSHAKE
+@@ -6367,4 +6368,4 @@
+ #define SSL_R_TLSV1_ALERT_ECH_REQUIRED ossl_SSL_R_TLSV1_ALERT_ECH_REQUIRED
+ #endif
  
 -// #endif  // OPENSSL_HEADER_SSL_H
 +#endif  // OPENSSL_HEADER_SSL_H

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -68,6 +68,15 @@
  
  // DTLS_method is the |SSL_METHOD| used for DTLS connections.
  // OPENSSL_EXPORT const SSL_METHOD *DTLS_method(void);
+@@ -195,7 +196,7 @@
+ // crypto/x509. All client connections created with |TLS_with_buffers_method|
+ // will fail unless a certificate verifier is installed with
+ // |SSL_set_custom_verify| or |SSL_CTX_set_custom_verify|.
+-// OPENSSL_EXPORT const SSL_METHOD *TLS_with_buffers_method(void);
++OPENSSL_EXPORT const SSL_METHOD *TLS_with_buffers_method(void);
+ 
+ // DTLS_with_buffers_method is like |DTLS_method|, but avoids all use of
+ // crypto/x509.
 @@ -203,13 +204,13 @@
  
  // SSL_CTX_new returns a newly-allocated |SSL_CTX| with default settings or NULL

--- a/bssl-compat/patch/include/openssl/ssl.h.sh
+++ b/bssl-compat/patch/include/openssl/ssl.h.sh
@@ -20,3 +20,6 @@ for SUBSTITUTION in "${SUBSTITUTIONS[@]}"
 do
 	sed -i -e "${EXPRE}${SUBSTITUTION}${EXPOST}" "$1"
 done
+
+sed -i -e 's|^// \(#[ \t]*define[ \t]*\)\(SSL_R_[a-zA-Z0-9_]*\)[^a-zA-Z0-9_].*$|#ifdef ossl_\2\n\1\2 ossl_\2\n#endif|g' "$1"
+

--- a/bssl-compat/patch/include/openssl/stack.h.patch
+++ b/bssl-compat/patch/include/openssl/stack.h.patch
@@ -566,7 +566,7 @@
  
  // typedef char *OPENSSL_STRING;
  
-@@ -443,40 +428,35 @@
+@@ -443,112 +428,107 @@
  // DEFINE_NAMED_STACK_OF(OPENSSL_STRING, char)
  
  
@@ -616,6 +616,46 @@
 -//                    nullptr);
 -//   }
 -// };
+-
+-// template <typename Stack>
+-// class StackIteratorImpl {
+-//  public:
+-//   using Type = typename StackTraits<Stack>::Type;
+-//   // Iterators must be default-constructable.
+-//   StackIteratorImpl() : sk_(nullptr), idx_(0) {}
+-//   StackIteratorImpl(const Stack *sk, size_t idx) : sk_(sk), idx_(idx) {}
+-
+-//   bool operator==(StackIteratorImpl other) const {
+-//     return sk_ == other.sk_ && idx_ == other.idx_;
+-//   }
+-//   bool operator!=(StackIteratorImpl other) const {
+-//     return !(*this == other);
+-//   }
+-
+-//   Type *operator*() const {
+-//     return reinterpret_cast<Type *>(
+-//         sk_value(reinterpret_cast<const _STACK *>(sk_), idx_));
+-//   }
+-
+-//   StackIteratorImpl &operator++(/* prefix */) {
+-//     idx_++;
+-//     return *this;
+-//   }
+-
+-//   StackIteratorImpl operator++(int /* postfix */) {
+-//     StackIteratorImpl copy(*this);
+-//     ++(*this);
+-//     return copy;
+-//   }
+-
+-//  private:
+-//   const Stack *sk_;
+-//   size_t idx_;
+-// };
+-
+-// template <typename Stack>
+-// using StackIterator =
+-//     std::enable_if_t<StackTraits<Stack>::kIsStack, StackIteratorImpl<Stack>>;
 +template <typename Stack>
 +struct DeleterImpl<Stack, std::enable_if_t<!StackTraits<Stack>::kIsConst>> {
 +  static void Free(Stack *sk) {
@@ -624,12 +664,46 @@
 +                   reinterpret_cast<void (*)(void *)>(DeleterImpl<Type>::Free));
 +  }
 +};
- 
- // template <typename Stack>
- // class StackIteratorImpl {
-@@ -518,23 +498,23 @@
- // using StackIterator =
- //     std::enable_if_t<StackTraits<Stack>::kIsStack, StackIteratorImpl<Stack>>;
++
++template <typename Stack>
++class StackIteratorImpl {
++ public:
++  using Type = typename StackTraits<Stack>::Type;
++  // Iterators must be default-constructable.
++  StackIteratorImpl() : sk_(nullptr), idx_(0) {}
++  StackIteratorImpl(const Stack *sk, size_t idx) : sk_(sk), idx_(idx) {}
++
++  bool operator==(StackIteratorImpl other) const {
++    return sk_ == other.sk_ && idx_ == other.idx_;
++  }
++  bool operator!=(StackIteratorImpl other) const {
++    return !(*this == other);
++  }
++
++  Type *operator*() const {
++    return reinterpret_cast<Type *>(
++        sk_value(reinterpret_cast<const _STACK *>(sk_), idx_));
++  }
++
++  StackIteratorImpl &operator++(/* prefix */) {
++    idx_++;
++    return *this;
++  }
++
++  StackIteratorImpl operator++(int /* postfix */) {
++    StackIteratorImpl copy(*this);
++    ++(*this);
++    return copy;
++  }
++
++ private:
++  const Stack *sk_;
++  size_t idx_;
++};
++
++template <typename Stack>
++using StackIterator =
++    std::enable_if_t<StackTraits<Stack>::kIsStack, StackIteratorImpl<Stack>>;
  
 -// }  // namespace internal
 +}  // namespace internal
@@ -663,10 +737,26 @@
 +BSSL_NAMESPACE_END
  
  // Define begin() and end() for stack types so C++ range for loops work.
- // template <typename Stack>
-@@ -548,7 +528,7 @@
- //       sk, sk_num(reinterpret_cast<const _STACK *>(sk)));
- // }
+-// template <typename Stack>
+-// inline bssl::internal::StackIterator<Stack> begin(const Stack *sk) {
+-//   return bssl::internal::StackIterator<Stack>(sk, 0);
+-// }
+-
+-// template <typename Stack>
+-// inline bssl::internal::StackIterator<Stack> end(const Stack *sk) {
+-//   return bssl::internal::StackIterator<Stack>(
+-//       sk, sk_num(reinterpret_cast<const _STACK *>(sk)));
+-// }
++template <typename Stack>
++inline bssl::internal::StackIterator<Stack> begin(const Stack *sk) {
++  return bssl::internal::StackIterator<Stack>(sk, 0);
++}
++
++template <typename Stack>
++inline bssl::internal::StackIterator<Stack> end(const Stack *sk) {
++  return bssl::internal::StackIterator<Stack>(
++      sk, sk_num(reinterpret_cast<const _STACK *>(sk)));
++}
  
 -// }  // extern C++
 -// #endif

--- a/bssl-compat/patch/source/ssl/ssl_test.cc.patch
+++ b/bssl-compat/patch/source/ssl/ssl_test.cc.patch
@@ -1,6 +1,6 @@
 --- a/source/ssl/ssl_test.cc
 +++ b/source/ssl/ssl_test.cc
-@@ -12,51 +12,56 @@
+@@ -12,56 +12,60 @@
   * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
   * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
  
@@ -32,10 +32,6 @@
 -// #include <openssl/rand.h>
 -// #include <openssl/x509.h>
 -// #include <openssl/x509v3.h>
--
--// #include "internal.h"
--// #include "../crypto/internal.h"
--// #include "../crypto/test/test_util.h"
 +#include <stdio.h>
 +#include <string.h>
 +#include <time.h>
@@ -58,23 +54,23 @@
 +#include <openssl/err.h>
 +#include <openssl/hmac.h>
 +#include <openssl/hpke.h>
-+#include <openssl/mem.h>
 +#include <openssl/pem.h>
 +#include <openssl/sha.h>
 +#include <openssl/ssl.h>
 +#include <openssl/rand.h>
 +#include <openssl/x509.h>
 +#include <openssl/x509v3.h>
-+
-+#include "internal.h"
-+#include "../crypto/internal.h"
+ 
+ // #include "internal.h"
+ // #include "../crypto/internal.h"
+-// #include "../crypto/test/test_util.h"
 +#include "../crypto/test/test_util.h"
-+
+ 
+-// #if defined(OPENSSL_WINDOWS)
 +#ifdef BSSL_COMPAT
 +#include <ossl/openssl/ssl.h>
 +#endif
- 
--// #if defined(OPENSSL_WINDOWS)
++
 +#if defined(OPENSSL_WINDOWS)
  // Windows defines struct timeval in winsock2.h.
 -// OPENSSL_MSVC_PRAGMA(warning(push, 3))
@@ -83,24 +79,30 @@
 -// #else
 -// #include <sys/time.h>
 -// #endif
--
--// #if defined(OPENSSL_THREADS)
--// #include <thread>
--// #endif
 +OPENSSL_MSVC_PRAGMA(warning(push, 3))
 +#include <winsock2.h>
 +OPENSSL_MSVC_PRAGMA(warning(pop))
 +#else
 +#include <sys/time.h>
 +#endif
-+
+ 
+-// #if defined(OPENSSL_THREADS)
+-// #include <thread>
+-// #endif
 +#if defined(OPENSSL_THREADS)
 +#include <thread>
 +#endif
  
  
- // BSSL_NAMESPACE_BEGIN
-@@ -1196,14 +1201,14 @@
+-// BSSL_NAMESPACE_BEGIN
++BSSL_NAMESPACE_BEGIN
+ 
+-// namespace {
++namespace {
+ 
+ // #define TRACED_CALL(code)                     \
+ //   do {                                        \
+@@ -1196,14 +1200,14 @@
  //   }
  // }
  
@@ -123,7 +125,7 @@
  
  // static bssl::UniquePtr<EVP_PKEY> KeyFromPEM(const char *pem) {
  //   bssl::UniquePtr<BIO> bio(BIO_new_mem_buf(pem, strlen(pem)));
-@@ -1214,25 +1219,25 @@
+@@ -1214,25 +1218,25 @@
  //       PEM_read_bio_PrivateKey(bio.get(), nullptr, nullptr, nullptr));
  // }
  
@@ -168,7 +170,7 @@
  
  // static bssl::UniquePtr<EVP_PKEY> GetTestKey() {
  //   static const char kKeyPEM[] =
-@@ -4214,43 +4219,46 @@
+@@ -4214,43 +4218,46 @@
  //   X509_cmp(cert, cert);
  // }
  
@@ -252,7 +254,72 @@
  
  // TEST(SSLTest, SetChainAndKeyMismatch) {
  //   bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_with_buffers_method()));
-@@ -5721,25 +5729,28 @@
+@@ -4920,33 +4927,37 @@
+ // }
+ 
+ // The client should gracefully handle no suitable ciphers being enabled.
+-// TEST(SSLTest, NoCiphersAvailable) {
+-//   bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+-//   ASSERT_TRUE(ctx);
+-
+-//   // Configure |client_ctx| with a cipher list that does not intersect with its
+-//   // version configuration.
+-//   ASSERT_TRUE(SSL_CTX_set_strict_cipher_list(
+-//       ctx.get(), "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"));
+-//   ASSERT_TRUE(SSL_CTX_set_max_proto_version(ctx.get(), TLS1_1_VERSION));
+-
+-//   bssl::UniquePtr<SSL> ssl(SSL_new(ctx.get()));
+-//   ASSERT_TRUE(ssl);
+-//   SSL_set_connect_state(ssl.get());
+-
+-//   UniquePtr<BIO> rbio(BIO_new(BIO_s_mem())), wbio(BIO_new(BIO_s_mem()));
+-//   ASSERT_TRUE(rbio);
+-//   ASSERT_TRUE(wbio);
+-//   SSL_set0_rbio(ssl.get(), rbio.release());
+-//   SSL_set0_wbio(ssl.get(), wbio.release());
+-
+-//   int ret = SSL_do_handshake(ssl.get());
+-//   EXPECT_EQ(-1, ret);
+-//   EXPECT_EQ(SSL_ERROR_SSL, SSL_get_error(ssl.get(), ret));
+-//   uint32_t err = ERR_get_error();
+-//   EXPECT_EQ(ERR_LIB_SSL, ERR_GET_LIB(err));
+-//   EXPECT_EQ(SSL_R_NO_CIPHERS_AVAILABLE, ERR_GET_REASON(err));
+-// }
++TEST(SSLTest, NoCiphersAvailable) {
++  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
++  ASSERT_TRUE(ctx);
++
++  // Configure |client_ctx| with a cipher list that does not intersect with its
++  // version configuration.
++  ASSERT_TRUE(SSL_CTX_set_strict_cipher_list(
++      ctx.get(), "ECDHE-RSA-AES128-GCM-SHA256"));
++  ASSERT_TRUE(SSL_CTX_set_max_proto_version(ctx.get(), TLS1_1_VERSION));
++
++  bssl::UniquePtr<SSL> ssl(SSL_new(ctx.get()));
++  ASSERT_TRUE(ssl);
++  SSL_set_connect_state(ssl.get());
++
++  UniquePtr<BIO> rbio(BIO_new(BIO_s_mem())), wbio(BIO_new(BIO_s_mem()));
++  ASSERT_TRUE(rbio);
++  ASSERT_TRUE(wbio);
++  SSL_set0_rbio(ssl.get(), rbio.release());
++  SSL_set0_wbio(ssl.get(), wbio.release());
++
++  int ret = SSL_do_handshake(ssl.get());
++  EXPECT_EQ(-1, ret);
++  EXPECT_EQ(SSL_ERROR_SSL, SSL_get_error(ssl.get(), ret));
++  uint32_t err = ERR_get_error();
++  EXPECT_EQ(ERR_LIB_SSL, ERR_GET_LIB(err));
++#ifdef BSSL_COMPAT
++  EXPECT_EQ(ossl_SSL_R_NO_PROTOCOLS_AVAILABLE, ERR_GET_REASON(err));
++#else
++  EXPECT_EQ(SSL_R_NO_CIPHERS_AVAILABLE, ERR_GET_REASON(err));
++#endif
++}
+ 
+ // TEST_P(SSLVersionTest, SessionVersion) {
+ //   SSL_CTX_set_session_cache_mode(client_ctx_.get(), SSL_SESS_CACHE_BOTH);
+@@ -5721,25 +5732,28 @@
  // }
  
  // SSL_CTX_get0_certificate needs to lock internally. Test this works.
@@ -300,3 +367,11 @@
  
  // Functions which access properties on the negotiated session are thread-safe
  // where needed. Prior to TLS 1.3, clients resuming sessions and servers
+@@ -8260,5 +8274,5 @@
+ //   }
+ // }
+ 
+-// }  // namespace
+-// BSSL_NAMESPACE_END
++}  // namespace
++BSSL_NAMESPACE_END

--- a/bssl-compat/source/ssl.c
+++ b/bssl-compat/source/ssl.c
@@ -169,6 +169,18 @@ STACK_OF(X509) *SSL_get_peer_full_cert_chain(const SSL *ssl) {
   return result;
 }
 
+void SSL_set0_rbio(SSL *ssl, BIO *rbio) {
+  ossl_SSL_set0_rbio(ssl, rbio);
+}
+
+void SSL_set0_wbio(SSL *ssl, BIO *wbio) {
+  ossl_SSL_set0_wbio(ssl, wbio);
+}
+
+void SSL_set_connect_state(SSL *ssl) {
+  ossl_SSL_set_connect_state(ssl);
+}
+
 SSL_CTX *SSL_set_SSL_CTX(SSL *ssl, SSL_CTX *ctx) {
   return ossl_SSL_set_SSL_CTX(ssl, ctx);
 }

--- a/bssl-compat/source/ssl_ctx.c
+++ b/bssl-compat/source/ssl_ctx.c
@@ -122,3 +122,11 @@ void SSL_CTX_set_verify(SSL_CTX *ctx, int mode, int (*callback)(int ok, X509_STO
   }
   ossl_SSL_CTX_set_verify(ctx, mode, NULL);
 }
+
+/*
+ * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/ssl.h#L198
+ * https://www.openssl.org/docs/man3.0/man3/TLS_method.html
+ */
+const SSL_METHOD *TLS_with_buffers_method(void) {
+  return ossl_TLS_method();
+}

--- a/bssl-compat/source/ssl_ctx.c
+++ b/bssl-compat/source/ssl_ctx.c
@@ -24,6 +24,9 @@
 #include "log.h"
 
 
+STACK_OF(SSL_CIPHER) *SSL_CTX_get_ciphers(const SSL_CTX *ctx) {
+  return (STACK_OF(SSL_CIPHER)*)ossl_SSL_CTX_get_ciphers(ctx);
+}
 
 X509 *SSL_CTX_get0_certificate(const SSL_CTX *ctx) {
   return ossl_SSL_CTX_get0_certificate(ctx);
@@ -104,12 +107,32 @@ int SSL_CTX_use_PrivateKey(SSL_CTX *ctx, EVP_PKEY *pkey) {
   return (ossl_SSL_CTX_use_PrivateKey(ctx, pkey) == 1) ? 1 : 0;
 }
 
+int SSL_CTX_set_cipher_list(SSL_CTX *ctx, const char *str) {
+  return ossl_SSL_CTX_set_cipher_list(ctx, str);
+}
+
 /*
  * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/ssl.h#L2670
  * https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set_client_CA_list.html
  */
 void SSL_CTX_set_client_CA_list(SSL_CTX *ctx, STACK_OF(X509_NAME) *name_list) {
   ossl_SSL_CTX_set_client_CA_list(ctx, (ossl_STACK_OF(ossl_X509_NAME)*)name_list);
+}
+
+/*
+ * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/ssl.h#L661
+ * https://www.openssl.org/docs/man3.0/man3/SSL_CTX_get_max_proto_version.html
+ */
+int SSL_CTX_set_min_proto_version(SSL_CTX *ctx, uint16_t version) {
+  return ossl_SSL_CTX_set_min_proto_version(ctx, version);
+}
+
+/*
+ * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/ssl.h#L667
+ * https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set_max_proto_version.html
+ */
+int SSL_CTX_set_max_proto_version(SSL_CTX *ctx, uint16_t version) {
+  return ossl_SSL_CTX_set_max_proto_version(ctx, version);
 }
 
 /*
@@ -130,3 +153,4 @@ void SSL_CTX_set_verify(SSL_CTX *ctx, int mode, int (*callback)(int ok, X509_STO
 const SSL_METHOD *TLS_with_buffers_method(void) {
   return ossl_TLS_method();
 }
+

--- a/bssl-compat/source/ssl_ctx.cc
+++ b/bssl-compat/source/ssl_ctx.cc
@@ -1,0 +1,47 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+#include <string>
+
+
+/*
+ * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/ssl.h#L1508
+ *
+ * https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set_cipher_list.html
+ * https://www.openssl.org/docs/man3.0/man3/SSL_CTX_get_ciphers.html
+ * https://www.openssl.org/docs/man3.0/man3/SSL_CIPHER_get_name.html
+ */
+int SSL_CTX_set_strict_cipher_list(SSL_CTX *ctx, const char *str) {
+  // OpenSSL's SSL_CTX_set_cipher_list() performs virtually no checking on str.
+  // It only returns 0 (fail) if no cipher could be selected from the list at
+  // all. Otherwise it returns 1 (pass) even if there is only one cipher in the
+  // string that makes sense, and the rest are unsupported or even just rubbish.
+  if (ossl_SSL_CTX_set_cipher_list(ctx, str) == 0) {
+    ERR_print_errors_fp(stderr);
+    return 0;
+  }
+
+  STACK_OF(SSL_CIPHER)* ciphers = reinterpret_cast<STACK_OF(SSL_CIPHER)*>(ossl_SSL_CTX_get_ciphers(ctx));
+  char* dup = strdup(str);
+  char* token = strtok(dup, ":+![|]");
+  while (token != NULL) {
+    std::string str1(token);
+    bool found = false;
+    for (int i = 0; i < sk_SSL_CIPHER_num(ciphers); i++) {
+      const SSL_CIPHER* cipher = sk_SSL_CIPHER_value(ciphers, i);
+      std::string str2(SSL_CIPHER_get_name(cipher));
+      if (str1.compare(str2) == 0) {
+        found = true;
+      }
+    }
+
+    if (!found && str1.compare("-ALL") && str1.compare("ALL")) {
+      free(dup);
+      return 0;
+    }
+
+    token = strtok(NULL, ":[]|");
+  }
+
+  free(dup);
+  return 1;
+}

--- a/bssl-compat/source/test/test_ssl.cc
+++ b/bssl-compat/source/test/test_ssl.cc
@@ -348,3 +348,18 @@ TEST(SSLTest, test_SSL_get_peer_full_cert_chain) {
 
   server.join();
 }
+
+TEST(SSLTest, test_SSL_CTX_set_strict_cipher_list) {
+  bssl::UniquePtr<SSL_CTX> ctx {SSL_CTX_new(TLS_server_method())};
+  STACK_OF(SSL_CIPHER) *ciphers {SSL_CTX_get_ciphers(ctx.get())};
+
+  std::string cipherstr;
+
+  for(const SSL_CIPHER *cipher : ciphers) {
+    cipherstr += (cipherstr.size() ? ":" : "");
+    cipherstr += SSL_CIPHER_get_name(cipher);
+  }
+
+  ASSERT_EQ(1, SSL_CTX_set_strict_cipher_list(ctx.get(), cipherstr.c_str()));
+  ASSERT_EQ(0, SSL_CTX_set_strict_cipher_list(ctx.get(), "rubbish:garbage"));
+}


### PR DESCRIPTION
Added the following functions:

- TLS_with_buffers_method()
- SSL_CTX_set_strict_cipher_list()
- SSL_set_connect_state()
- SSL_set0_rbio()
- SSL_set0_wbio()
- SSL_CTX_get_ciphers()
- SSL_CTX_set_min_proto_version()
- SSL_CTX_set_max_proto_version()
- SSL_CTX_set_cipher_list()

Signed-off-by: Ted Poole <tpoole@redhat.com>