### PR TITLE
OSSM-3364 Added more <openssl/ssl.h> functions

### DIFF
--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -61,7 +61,9 @@ add_library(bssl-compat STATIC
   source/ssl_cipher.c
   source/ssl_ctx.c
   source/ssl_ctx.cc
+  source/SSL_early_callback_ctx_extension_get.c
   source/ssl_ext.c
+  source/SSL_set_tlsext_host_name.c
   source/ssl.c
   source/stack.c
 )

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -195,6 +195,7 @@ set(utests-source-list
   source/test/test_asn1.cc
   source/test/test_bn.cc
   source/test/test_cipher.cc
+  source/test/test_crypto.cc
   source/test/test_evp.cc
   source/test/test_ssl.cc
   source/test/test_stack.cc

--- a/bssl-compat/patch/include/openssl/bytestring.h.patch
+++ b/bssl-compat/patch/include/openssl/bytestring.h.patch
@@ -78,8 +78,9 @@
 +OPENSSL_EXPORT int CBS_skip(CBS *cbs, size_t len);
  
 -// CBS_data returns a pointer to the contents of |cbs|.
+-// OPENSSL_EXPORT const uint8_t *CBS_data(const CBS *cbs);
 +//  CBS_data returns a pointer to the contents of |cbs|.
- // OPENSSL_EXPORT const uint8_t *CBS_data(const CBS *cbs);
++OPENSSL_EXPORT const uint8_t *CBS_data(const CBS *cbs);
  
  // CBS_len returns the number of bytes remaining in |cbs|.
 -// OPENSSL_EXPORT size_t CBS_len(const CBS *cbs);
@@ -87,7 +88,12 @@
  
  // CBS_stow copies the current contents of |cbs| into |*out_ptr| and
  // |*out_len|. If |*out_ptr| is not NULL, the contents are freed with
-@@ -102,7 +102,7 @@
+@@ -98,11 +98,11 @@
+ 
+ // CBS_get_u8 sets |*out| to the next uint8_t from |cbs| and advances |cbs|. It
+ // returns one on success and zero on error.
+-// OPENSSL_EXPORT int CBS_get_u8(CBS *cbs, uint8_t *out);
++OPENSSL_EXPORT int CBS_get_u8(CBS *cbs, uint8_t *out);
  
  // CBS_get_u16 sets |*out| to the next, big-endian uint16_t from |cbs| and
  // advances |cbs|. It returns one on success and zero on error.
@@ -96,6 +102,15 @@
  
  // CBS_get_u16le sets |*out| to the next, little-endian uint16_t from |cbs| and
  // advances |cbs|. It returns one on success and zero on error.
+@@ -148,7 +148,7 @@
+ // CBS_get_u16_length_prefixed sets |*out| to the contents of a 16-bit,
+ // big-endian, length-prefixed value from |cbs| and advances |cbs| over it. It
+ // returns one on success and zero on error.
+-// OPENSSL_EXPORT int CBS_get_u16_length_prefixed(CBS *cbs, CBS *out);
++OPENSSL_EXPORT int CBS_get_u16_length_prefixed(CBS *cbs, CBS *out);
+ 
+ // CBS_get_u24_length_prefixed sets |*out| to the contents of a 24-bit,
+ // big-endian, length-prefixed value from |cbs| and advances |cbs| over it. It
 @@ -183,7 +183,7 @@
  
  // CBS_ASN1_TAG_SHIFT is how much the in-memory representation shifts the class

--- a/bssl-compat/patch/include/openssl/crypto.h.patch
+++ b/bssl-compat/patch/include/openssl/crypto.h.patch
@@ -34,6 +34,15 @@
  
  
  // crypto.h contains functions for initializing the crypto library.
+@@ -89,7 +89,7 @@
+ 
+ // FIPS_mode returns zero unless BoringSSL is built with BORINGSSL_FIPS, in
+ // which case it returns one.
+-// OPENSSL_EXPORT int FIPS_mode(void);
++OPENSSL_EXPORT int FIPS_mode(void);
+ 
+ // fips_counter_t denotes specific APIs/algorithms. A counter is maintained for
+ // each in FIPS mode so that tests can be written to assert that the expected,
 @@ -194,8 +194,8 @@
  // OPENSSL_EXPORT int FIPS_query_algorithm_status(const char *algorithm);
  

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -256,7 +256,7 @@
  
  // SSL_CTX_get0_privatekey returns |ctx|'s private key.
  // OPENSSL_EXPORT EVP_PKEY *SSL_CTX_get0_privatekey(const SSL_CTX *ctx);
-@@ -1129,9 +1130,9 @@
+@@ -1129,23 +1130,23 @@
  // SSL_set_ocsp_response sets the OCSP response that is sent to clients which
  // request it. It returns one on success and zero on error. The caller retains
  // ownership of |response|.
@@ -268,7 +268,33 @@
 +                                         size_t response_len);
  
  // SSL_SIGN_* are signature algorithm values as defined in TLS 1.3.
- // #define SSL_SIGN_RSA_PKCS1_SHA1 0x0201
+-// #define SSL_SIGN_RSA_PKCS1_SHA1 0x0201
+-// #define SSL_SIGN_RSA_PKCS1_SHA256 0x0401
+-// #define SSL_SIGN_RSA_PKCS1_SHA384 0x0501
+-// #define SSL_SIGN_RSA_PKCS1_SHA512 0x0601
+-// #define SSL_SIGN_ECDSA_SHA1 0x0203
+-// #define SSL_SIGN_ECDSA_SECP256R1_SHA256 0x0403
+-// #define SSL_SIGN_ECDSA_SECP384R1_SHA384 0x0503
+-// #define SSL_SIGN_ECDSA_SECP521R1_SHA512 0x0603
+-// #define SSL_SIGN_RSA_PSS_RSAE_SHA256 0x0804
+-// #define SSL_SIGN_RSA_PSS_RSAE_SHA384 0x0805
+-// #define SSL_SIGN_RSA_PSS_RSAE_SHA512 0x0806
+-// #define SSL_SIGN_ED25519 0x0807
++#define SSL_SIGN_RSA_PKCS1_SHA1 0x0201
++#define SSL_SIGN_RSA_PKCS1_SHA256 0x0401
++#define SSL_SIGN_RSA_PKCS1_SHA384 0x0501
++#define SSL_SIGN_RSA_PKCS1_SHA512 0x0601
++#define SSL_SIGN_ECDSA_SHA1 0x0203
++#define SSL_SIGN_ECDSA_SECP256R1_SHA256 0x0403
++#define SSL_SIGN_ECDSA_SECP384R1_SHA384 0x0503
++#define SSL_SIGN_ECDSA_SECP521R1_SHA512 0x0603
++#define SSL_SIGN_RSA_PSS_RSAE_SHA256 0x0804
++#define SSL_SIGN_RSA_PSS_RSAE_SHA384 0x0805
++#define SSL_SIGN_RSA_PSS_RSAE_SHA512 0x0806
++#define SSL_SIGN_ED25519 0x0807
+ 
+ // SSL_SIGN_RSA_PKCS1_MD5_SHA1 is an internal signature algorithm used to
+ // specify raw RSASSA-PKCS1-v1_5 with an MD5/SHA-1 concatenation, as used in TLS
 @@ -1254,8 +1255,8 @@
  // |type| parameter is one of the |SSL_FILETYPE_*| values and determines whether
  // the file's contents are read as PEM or DER.
@@ -468,6 +494,19 @@
  
  // SSL_CTX_enable_ocsp_stapling enables OCSP stapling on all client SSL objects
  // created from |ctx|.
+@@ -2708,9 +2709,9 @@
+ // preference list when verifying signatures from the peer's long-term key. It
+ // returns one on zero on error. |prefs| should not include the internal-only
+ // value |SSL_SIGN_RSA_PKCS1_MD5_SHA1|.
+-// OPENSSL_EXPORT int SSL_CTX_set_verify_algorithm_prefs(SSL_CTX *ctx,
+-//                                                       const uint16_t *prefs,
+-//                                                       size_t num_prefs);
++OPENSSL_EXPORT int SSL_CTX_set_verify_algorithm_prefs(SSL_CTX *ctx,
++                                                      const uint16_t *prefs,
++                                                      size_t num_prefs);
+ 
+ // SSL_set_verify_algorithm_prefs configures |ssl| to use |prefs| as the
+ // preference list when verifying signatures from the peer's long-term key. It
 @@ -2739,8 +2740,8 @@
  
  // SSL_CTX_set_client_CA_list sets |ctx|'s client certificate CA list to

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -529,6 +529,20 @@
  
  // SSL_add_bio_cert_subjects_to_stack behaves like
  // |SSL_add_file_cert_subjects_to_stack| but reads from |bio|.
+@@ -2816,11 +2817,11 @@
+ // deployments to select one of a several certificates on a single IP. Only the
+ // host_name name type is supported.
+ 
+-// #define TLSEXT_NAMETYPE_host_name 0
++#define TLSEXT_NAMETYPE_host_name 0
+ 
+ // SSL_set_tlsext_host_name, for a client, configures |ssl| to advertise |name|
+ // in the server_name extension. It returns one on success and zero on error.
+-// OPENSSL_EXPORT int SSL_set_tlsext_host_name(SSL *ssl, const char *name);
++OPENSSL_EXPORT int SSL_set_tlsext_host_name(SSL *ssl, const char *name);
+ 
+ // SSL_get_servername, for a server, returns the hostname supplied by the
+ // client or NULL if there was none. The |type| argument must be
 @@ -2868,7 +2869,7 @@
  // the session cache between different domains.
  //
@@ -581,7 +595,7 @@
  
  // SSL_renegotiate starts a deferred renegotiation on |ssl| if it was configured
  // with |ssl_renegotiate_explicit| and has a pending HelloRequest. It returns
-@@ -4359,36 +4360,36 @@
+@@ -4359,45 +4360,45 @@
  // callbacks that are called very early on during the server handshake. At this
  // point, much of the SSL* hasn't been filled out and only the ClientHello can
  // be depended on.
@@ -645,6 +659,18 @@
  
  // SSL_early_callback_ctx_extension_get searches the extensions in
  // |client_hello| for an extension of the given type. If not found, it returns
+ // zero. Otherwise it sets |out_data| to point to the extension contents (not
+ // including the type and length bytes), sets |out_len| to the length of the
+ // extension contents and returns one.
+-// OPENSSL_EXPORT int SSL_early_callback_ctx_extension_get(
+-//     const SSL_CLIENT_HELLO *client_hello, uint16_t extension_type,
+-//     const uint8_t **out_data, size_t *out_len);
++OPENSSL_EXPORT int SSL_early_callback_ctx_extension_get(
++    const SSL_CLIENT_HELLO *client_hello, uint16_t extension_type,
++    const uint8_t **out_data, size_t *out_len);
+ 
+ // SSL_CTX_set_select_certificate_cb sets a callback that is called before most
+ // ClientHello processing and before the decision whether to resume a session
 @@ -4413,9 +4414,9 @@
  //
  // Note: The |SSL_CLIENT_HELLO| is only valid for the duration of the callback

--- a/bssl-compat/patch/source/crypto/bytestring/cbs.c.patch
+++ b/bssl-compat/patch/source/crypto/bytestring/cbs.c.patch
@@ -46,6 +46,14 @@
 -//   const uint8_t *dummy;
 -//   return cbs_get(cbs, &dummy, len);
 -// }
+-
+-// const uint8_t *CBS_data(const CBS *cbs) {
+-//   return cbs->data;
+-// }
+-
+-// size_t CBS_len(const CBS *cbs) {
+-//   return cbs->len;
+-// }
 +void CBS_init(CBS *cbs, const uint8_t *data, size_t len) {
 +  cbs->data = data;
 +  cbs->len = len;
@@ -66,21 +74,18 @@
 +  const uint8_t *dummy;
 +  return cbs_get(cbs, &dummy, len);
 +}
- 
- // const uint8_t *CBS_data(const CBS *cbs) {
- //   return cbs->data;
- // }
- 
--// size_t CBS_len(const CBS *cbs) {
--//   return cbs->len;
--// }
++
++const uint8_t *CBS_data(const CBS *cbs) {
++  return cbs->data;
++}
++
 +size_t CBS_len(const CBS *cbs) {
 +  return cbs->len;
 +}
  
  // int CBS_stow(const CBS *cbs, uint8_t **out_ptr, size_t *out_len) {
  //   OPENSSL_free(*out_ptr);
-@@ -90,20 +90,20 @@
+@@ -90,38 +90,38 @@
  //   return CRYPTO_memcmp(cbs->data, data, len) == 0;
  // }
  
@@ -98,6 +103,24 @@
 -//   *out = result;
 -//   return 1;
 -// }
+-
+-// int CBS_get_u8(CBS *cbs, uint8_t *out) {
+-//   const uint8_t *v;
+-//   if (!cbs_get(cbs, &v, 1)) {
+-//     return 0;
+-//   }
+-//   *out = *v;
+-//   return 1;
+-// }
+-
+-// int CBS_get_u16(CBS *cbs, uint16_t *out) {
+-//   uint64_t v;
+-//   if (!cbs_get_u(cbs, &v, 2)) {
+-//     return 0;
+-//   }
+-//   *out = v;
+-//   return 1;
+-// }
 +static int cbs_get_u(CBS *cbs, uint64_t *out, size_t len) {
 +  uint64_t result = 0;
 +  const uint8_t *data;
@@ -112,21 +135,16 @@
 +  *out = result;
 +  return 1;
 +}
- 
- // int CBS_get_u8(CBS *cbs, uint8_t *out) {
- //   const uint8_t *v;
-@@ -114,14 +114,14 @@
- //   return 1;
- // }
- 
--// int CBS_get_u16(CBS *cbs, uint16_t *out) {
--//   uint64_t v;
--//   if (!cbs_get_u(cbs, &v, 2)) {
--//     return 0;
--//   }
--//   *out = v;
--//   return 1;
--// }
++
++int CBS_get_u8(CBS *cbs, uint8_t *out) {
++  const uint8_t *v;
++  if (!cbs_get(cbs, &v, 1)) {
++    return 0;
++  }
++  *out = *v;
++  return 1;
++}
++
 +int CBS_get_u16(CBS *cbs, uint16_t *out) {
 +  uint64_t v;
 +  if (!cbs_get_u(cbs, &v, 2)) {
@@ -138,3 +156,64 @@
  
  // int CBS_get_u16le(CBS *cbs, uint16_t *out) {
  //   if (!CBS_get_u16(cbs, out)) {
+@@ -178,14 +178,14 @@
+ //   return 1;
+ // }
+ 
+-// int CBS_get_bytes(CBS *cbs, CBS *out, size_t len) {
+-//   const uint8_t *v;
+-//   if (!cbs_get(cbs, &v, len)) {
+-//     return 0;
+-//   }
+-//   CBS_init(out, v, len);
+-//   return 1;
+-// }
++int CBS_get_bytes(CBS *cbs, CBS *out, size_t len) {
++  const uint8_t *v;
++  if (!cbs_get(cbs, &v, len)) {
++    return 0;
++  }
++  CBS_init(out, v, len);
++  return 1;
++}
+ 
+ // int CBS_copy_bytes(CBS *cbs, uint8_t *out, size_t len) {
+ //   const uint8_t *v;
+@@ -196,24 +196,24 @@
+ //   return 1;
+ // }
+ 
+-// static int cbs_get_length_prefixed(CBS *cbs, CBS *out, size_t len_len) {
+-//   uint64_t len;
+-//   if (!cbs_get_u(cbs, &len, len_len)) {
+-//     return 0;
+-//   }
+-//   // If |len_len| <= 3 then we know that |len| will fit into a |size_t|, even on
+-//   // 32-bit systems.
+-//   assert(len_len <= 3);
+-//   return CBS_get_bytes(cbs, out, len);
+-// }
++static int cbs_get_length_prefixed(CBS *cbs, CBS *out, size_t len_len) {
++  uint64_t len;
++  if (!cbs_get_u(cbs, &len, len_len)) {
++    return 0;
++  }
++  // If |len_len| <= 3 then we know that |len| will fit into a |size_t|, even on
++  // 32-bit systems.
++  assert(len_len <= 3);
++  return CBS_get_bytes(cbs, out, len);
++}
+ 
+ // int CBS_get_u8_length_prefixed(CBS *cbs, CBS *out) {
+ //   return cbs_get_length_prefixed(cbs, out, 1);
+ // }
+ 
+-// int CBS_get_u16_length_prefixed(CBS *cbs, CBS *out) {
+-//   return cbs_get_length_prefixed(cbs, out, 2);
+-// }
++int CBS_get_u16_length_prefixed(CBS *cbs, CBS *out) {
++  return cbs_get_length_prefixed(cbs, out, 2);
++}
+ 
+ // int CBS_get_u24_length_prefixed(CBS *cbs, CBS *out) {
+ //   return cbs_get_length_prefixed(cbs, out, 3);

--- a/bssl-compat/source/SSL_early_callback_ctx_extension_get.c
+++ b/bssl-compat/source/SSL_early_callback_ctx_extension_get.c
@@ -1,0 +1,32 @@
+#include <openssl/ssl.h>
+#include <openssl/bytestring.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/ssl.h#L4254
+ */
+int SSL_early_callback_ctx_extension_get(const SSL_CLIENT_HELLO *client_hello, uint16_t extension_type, const uint8_t **out_data, size_t *out_len) {
+  CBS extensions;
+  CBS_init(&extensions, client_hello->extensions, client_hello->extensions_len);
+
+  while(CBS_len(&extensions)) {
+    CBS extension;
+    uint16_t type;
+
+    if (!CBS_get_u16(&extensions, &type)) {
+      return 0; // Failed to get extension type
+    }
+
+    if (!CBS_get_u16_length_prefixed(&extensions, &extension)) {
+      return 0; // Failed to get extension bytes
+    }
+
+    if (type == extension_type) {
+      *out_data = CBS_data(&extension);
+      *out_len = CBS_len(&extension);
+      return 1; // Success
+    }
+  }
+
+  return 0; // Failed to find extension
+}

--- a/bssl-compat/source/SSL_set_tlsext_host_name.c
+++ b/bssl-compat/source/SSL_set_tlsext_host_name.c
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+int SSL_set_tlsext_host_name(SSL *ssl, const char *name) {
+  return ossl_SSL_set_tlsext_host_name(ssl, name);
+}

--- a/bssl-compat/source/crypto.c
+++ b/bssl-compat/source/crypto.c
@@ -1,8 +1,7 @@
 #include <openssl/crypto.h>
-#include <ossl/openssl/crypto.h>
 #include <ossl/openssl/evp.h>
 
 
 int FIPS_mode(void) {
-  return ossl_FIPS_mode();
+  return ossl_EVP_default_properties_is_fips_enabled(NULL);
 }

--- a/bssl-compat/source/ssl_ctx.c
+++ b/bssl-compat/source/ssl_ctx.c
@@ -16,11 +16,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <ossl/openssl/ssl.h>
 #include <openssl/ssl.h>
 #include <openssl/mem.h>
 #include <openssl/bytestring.h>
 #include <ext/openssl/ssl.h>
-#include <ossl/openssl/ssl.h>
 #include "log.h"
 
 
@@ -144,6 +144,55 @@ void SSL_CTX_set_verify(SSL_CTX *ctx, int mode, int (*callback)(int ok, X509_STO
     bssl_compat_fatal("%s() with non-null callback not implemented", __func__);
   }
   ossl_SSL_CTX_set_verify(ctx, mode, NULL);
+}
+
+/*
+ * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/ssl.h#L2639
+ * https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set1_sigalgs.html
+ */
+int SSL_CTX_set_verify_algorithm_prefs(SSL_CTX *ctx, const uint16_t *prefs, size_t num_prefs) {
+  static const struct { // Copied from boringssl/ssl/ssl_privkey.cc
+    int pkey_type;
+    int hash_nid;
+    uint16_t signature_algorithm;
+  } kSignatureAlgorithmsMapping[] = {
+      {EVP_PKEY_RSA, NID_sha1, SSL_SIGN_RSA_PKCS1_SHA1},
+      {EVP_PKEY_RSA, NID_sha256, SSL_SIGN_RSA_PKCS1_SHA256},
+      {EVP_PKEY_RSA, NID_sha384, SSL_SIGN_RSA_PKCS1_SHA384},
+      {EVP_PKEY_RSA, NID_sha512, SSL_SIGN_RSA_PKCS1_SHA512},
+      {EVP_PKEY_RSA_PSS, NID_sha256, SSL_SIGN_RSA_PSS_RSAE_SHA256},
+      {EVP_PKEY_RSA_PSS, NID_sha384, SSL_SIGN_RSA_PSS_RSAE_SHA384},
+      {EVP_PKEY_RSA_PSS, NID_sha512, SSL_SIGN_RSA_PSS_RSAE_SHA512},
+      {EVP_PKEY_EC, NID_sha1, SSL_SIGN_ECDSA_SHA1},
+      {EVP_PKEY_EC, NID_sha256, SSL_SIGN_ECDSA_SECP256R1_SHA256},
+      {EVP_PKEY_EC, NID_sha384, SSL_SIGN_ECDSA_SECP384R1_SHA384},
+      {EVP_PKEY_EC, NID_sha512, SSL_SIGN_ECDSA_SECP521R1_SHA512},
+      {EVP_PKEY_ED25519, NID_undef, SSL_SIGN_ED25519},
+  };
+  static const int mmax = sizeof(kSignatureAlgorithmsMapping) /
+                          sizeof(kSignatureAlgorithmsMapping[0]);
+
+  int sigalgs[num_prefs * 2];
+
+  for(size_t pi = 0; pi < num_prefs; pi++) {
+    int mi;
+
+    for(mi = 0; mi < mmax; mi++) {
+      if(kSignatureAlgorithmsMapping[mi].signature_algorithm == prefs[pi]) {
+        sigalgs[pi * 2] = kSignatureAlgorithmsMapping[mi].hash_nid;
+        sigalgs[pi * 2 + 1] = kSignatureAlgorithmsMapping[mi].pkey_type;
+        break;
+      }
+    }
+
+    if(mi == mmax) {
+      ossl_ERR_raise_data(ossl_ERR_LIB_SSL, ossl_ERR_R_INTERNAL_ERROR,
+                        "unknown signature algorithm : %d", prefs[pi]);
+      return 0;
+    }
+  }
+
+  return ossl_SSL_CTX_set1_sigalgs(ctx, sigalgs, num_prefs * 2);
 }
 
 /*

--- a/bssl-compat/source/test/test_crypto.cc
+++ b/bssl-compat/source/test/test_crypto.cc
@@ -1,0 +1,7 @@
+#include <gtest/gtest.h>
+#include <openssl/crypto.h>
+
+TEST(TestCrypto, test_FIPS_mode) {
+  ASSERT_EQ(0, FIPS_mode());
+}
+

--- a/bssl-compat/source/test/test_ssl.cc
+++ b/bssl-compat/source/test/test_ssl.cc
@@ -363,3 +363,14 @@ TEST(SSLTest, test_SSL_CTX_set_strict_cipher_list) {
   ASSERT_EQ(1, SSL_CTX_set_strict_cipher_list(ctx.get(), cipherstr.c_str()));
   ASSERT_EQ(0, SSL_CTX_set_strict_cipher_list(ctx.get(), "rubbish:garbage"));
 }
+
+TEST(SSLTest, test_SSL_CTX_set_verify_algorithm_prefs) {
+  bssl::UniquePtr<SSL_CTX> ctx {SSL_CTX_new(TLS_server_method())};
+
+  uint16_t prefs[] {
+    SSL_SIGN_RSA_PSS_RSAE_SHA256,
+    SSL_SIGN_ECDSA_SECP256R1_SHA256
+  };
+
+  ASSERT_EQ(1, SSL_CTX_set_verify_algorithm_prefs(ctx.get(), prefs, (sizeof(prefs) / sizeof(prefs[0]))));
+}


### PR DESCRIPTION
Added:

- SSL_early_callback_ctx_extension_get()
- SSL_set_tlsext_host_name()
- FIPS_mode()
- SSL_CTX_set_verify_algorithm_prefs()

Signed-off-by: Ted Poole <tpoole@redhat.com>