### PR TITLE
OSSM-3364 Added more <openssl/ssl.h> functions

### DIFF
--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library(bssl-compat STATIC
   source/ossl.c
   source/rand.c
   source/ssl_cipher.c
+  source/SSL_CTX_set_tlsext_status_cb.c
   source/SSL_CTX_set1_curves_list.c
   source/SSL_CTX_set1_sigalgs_list.c
   source/ssl_ctx.c
@@ -70,6 +71,7 @@ add_library(bssl-compat STATIC
   source/SSL_get_curve_name.c
   source/SSL_get_peer_signature_algorithm.c
   source/SSL_get_signature_algorithm_name.c
+  source/SSL_get0_ocsp_response.c
   source/SSL_set_tlsext_host_name.c
   source/ssl.c
   source/stack.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -48,6 +48,9 @@ add_library(bssl-compat STATIC
   source/bio.cpp
   source/bn.c
   source/cipher.c
+  source/CRYPTO_BUFFER_free.c
+  source/CRYPTO_BUFFER_new.c
+  source/CRYPTO_BUFFER.h
   source/crypto.c
   source/digest.c
   source/err.c
@@ -57,7 +60,10 @@ add_library(bssl-compat STATIC
   source/mem.c
   source/ossl_ERR_set_error.c
   source/ossl.c
+  source/PEM_bytes_read_bio.c
+  source/PEM_read_bio_RSAPrivateKey.c
   source/rand.c
+  source/RSA_free.c
   source/ssl_cipher.c
   source/SSL_CTX_set_tlsext_status_cb.c
   source/SSL_CTX_set1_curves_list.c
@@ -72,6 +78,7 @@ add_library(bssl-compat STATIC
   source/SSL_get_peer_signature_algorithm.c
   source/SSL_get_signature_algorithm_name.c
   source/SSL_get0_ocsp_response.c
+  source/SSL_set_chain_and_key.cc
   source/SSL_set_tlsext_host_name.c
   source/ssl.c
   source/stack.c
@@ -167,6 +174,8 @@ target_add_bssl_include(bssl-compat
   include/openssl/x509_vfy.h
 )
 set_source_files_properties(source/evp.c PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
+set_source_files_properties(source/RSA_free.c PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
+set_source_files_properties(source/PEM_read_bio_RSAPrivateKey.c PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
 target_include_directories(bssl-compat PUBLIC include)
 target_link_libraries(bssl-compat INTERFACE ${CMAKE_DL_LIBS})
 

--- a/bssl-compat/patch/include/openssl/base.h.patch
+++ b/bssl-compat/patch/include/openssl/base.h.patch
@@ -470,7 +470,7 @@
  // typedef struct asn1_string_st ASN1_UNIVERSALSTRING;
  // typedef struct asn1_string_st ASN1_UTCTIME;
  // typedef struct asn1_string_st ASN1_UTF8STRING;
-@@ -369,21 +373,21 @@
+@@ -369,40 +373,40 @@
  // typedef struct X509_crl_st X509_CRL;
  // typedef struct X509_extension_st X509_EXTENSION;
  // typedef struct X509_info_st X509_INFO;
@@ -499,7 +499,10 @@
  // typedef struct cmac_ctx_st CMAC_CTX;
  // typedef struct conf_st CONF;
  // typedef struct conf_value_st CONF_VALUE;
-@@ -392,17 +396,17 @@
+-// typedef struct crypto_buffer_pool_st CRYPTO_BUFFER_POOL;
+-// typedef struct crypto_buffer_st CRYPTO_BUFFER;
++typedef struct crypto_buffer_pool_st CRYPTO_BUFFER_POOL;
++typedef struct crypto_buffer_st CRYPTO_BUFFER;
  // typedef struct dh_st DH;
  // typedef struct dsa_st DSA;
  // typedef struct ec_group_st EC_GROUP;
@@ -554,8 +557,9 @@
 +typedef struct ssl_early_callback_ctx SSL_CLIENT_HELLO;
  // typedef struct ssl_ech_keys_st SSL_ECH_KEYS;
 -// typedef struct ssl_method_st SSL_METHOD;
+-// typedef struct ssl_private_key_method_st SSL_PRIVATE_KEY_METHOD;
 +typedef ossl_SSL_METHOD SSL_METHOD;
- // typedef struct ssl_private_key_method_st SSL_PRIVATE_KEY_METHOD;
++typedef struct ssl_private_key_method_st SSL_PRIVATE_KEY_METHOD;
  // typedef struct ssl_quic_method_st SSL_QUIC_METHOD;
 -// typedef struct ssl_session_st SSL_SESSION;
 -// typedef struct ssl_st SSL;

--- a/bssl-compat/patch/include/openssl/mem.h.patch
+++ b/bssl-compat/patch/include/openssl/mem.h.patch
@@ -57,6 +57,15 @@
  
  // BIO_vsnprintf has the same behavior as vsnprintf(3).
  // OPENSSL_EXPORT int BIO_vsnprintf(char *buf, size_t n, const char *format,
+@@ -137,7 +137,7 @@
+ 
+ // OPENSSL_memdup returns an allocated, duplicate of |size| bytes from |data| or
+ // NULL on allocation failure.
+-// OPENSSL_EXPORT void *OPENSSL_memdup(const void *data, size_t size);
++OPENSSL_EXPORT void *OPENSSL_memdup(const void *data, size_t size);
+ 
+ // OPENSSL_strlcpy acts like strlcpy(3).
+ // OPENSSL_EXPORT size_t OPENSSL_strlcpy(char *dst, const char *src,
 @@ -165,20 +165,20 @@
  // OPENSSL_EXPORT void OPENSSL_clear_free(void *ptr, size_t len);
  

--- a/bssl-compat/patch/include/openssl/pem.h.patch
+++ b/bssl-compat/patch/include/openssl/pem.h.patch
@@ -1,6 +1,6 @@
 --- a/include/openssl/pem.h
 +++ b/include/openssl/pem.h
-@@ -54,25 +54,25 @@
+@@ -54,53 +54,53 @@
   * copied and put under another distribution licence
   * [including the GNU Public Licence.] */
  
@@ -40,7 +40,59 @@
  
  
  // #define PEM_BUFSIZE 1024
-@@ -250,12 +250,12 @@
+ 
+-// #define PEM_STRING_X509_OLD "X509 CERTIFICATE"
+-// #define PEM_STRING_X509 "CERTIFICATE"
+-// #define PEM_STRING_X509_PAIR "CERTIFICATE PAIR"
+-// #define PEM_STRING_X509_TRUSTED "TRUSTED CERTIFICATE"
+-// #define PEM_STRING_X509_REQ_OLD "NEW CERTIFICATE REQUEST"
+-// #define PEM_STRING_X509_REQ "CERTIFICATE REQUEST"
+-// #define PEM_STRING_X509_CRL "X509 CRL"
+-// #define PEM_STRING_EVP_PKEY "ANY PRIVATE KEY"
+-// #define PEM_STRING_PUBLIC "PUBLIC KEY"
+-// #define PEM_STRING_RSA "RSA PRIVATE KEY"
+-// #define PEM_STRING_RSA_PUBLIC "RSA PUBLIC KEY"
+-// #define PEM_STRING_DSA "DSA PRIVATE KEY"
+-// #define PEM_STRING_DSA_PUBLIC "DSA PUBLIC KEY"
+-// #define PEM_STRING_EC "EC PRIVATE KEY"
+-// #define PEM_STRING_PKCS7 "PKCS7"
+-// #define PEM_STRING_PKCS7_SIGNED "PKCS #7 SIGNED DATA"
+-// #define PEM_STRING_PKCS8 "ENCRYPTED PRIVATE KEY"
+-// #define PEM_STRING_PKCS8INF "PRIVATE KEY"
+-// #define PEM_STRING_DHPARAMS "DH PARAMETERS"
+-// #define PEM_STRING_SSL_SESSION "SSL SESSION PARAMETERS"
+-// #define PEM_STRING_DSAPARAMS "DSA PARAMETERS"
+-// #define PEM_STRING_ECDSA_PUBLIC "ECDSA PUBLIC KEY"
+-// #define PEM_STRING_ECPRIVATEKEY "EC PRIVATE KEY"
+-// #define PEM_STRING_CMS "CMS"
++#define PEM_STRING_X509_OLD "X509 CERTIFICATE"
++#define PEM_STRING_X509 "CERTIFICATE"
++#define PEM_STRING_X509_PAIR "CERTIFICATE PAIR"
++#define PEM_STRING_X509_TRUSTED "TRUSTED CERTIFICATE"
++#define PEM_STRING_X509_REQ_OLD "NEW CERTIFICATE REQUEST"
++#define PEM_STRING_X509_REQ "CERTIFICATE REQUEST"
++#define PEM_STRING_X509_CRL "X509 CRL"
++#define PEM_STRING_EVP_PKEY "ANY PRIVATE KEY"
++#define PEM_STRING_PUBLIC "PUBLIC KEY"
++#define PEM_STRING_RSA "RSA PRIVATE KEY"
++#define PEM_STRING_RSA_PUBLIC "RSA PUBLIC KEY"
++#define PEM_STRING_DSA "DSA PRIVATE KEY"
++#define PEM_STRING_DSA_PUBLIC "DSA PUBLIC KEY"
++#define PEM_STRING_EC "EC PRIVATE KEY"
++#define PEM_STRING_PKCS7 "PKCS7"
++#define PEM_STRING_PKCS7_SIGNED "PKCS #7 SIGNED DATA"
++#define PEM_STRING_PKCS8 "ENCRYPTED PRIVATE KEY"
++#define PEM_STRING_PKCS8INF "PRIVATE KEY"
++#define PEM_STRING_DHPARAMS "DH PARAMETERS"
++#define PEM_STRING_SSL_SESSION "SSL SESSION PARAMETERS"
++#define PEM_STRING_DSAPARAMS "DSA PARAMETERS"
++#define PEM_STRING_ECDSA_PUBLIC "ECDSA PUBLIC KEY"
++#define PEM_STRING_ECPRIVATEKEY "EC PRIVATE KEY"
++#define PEM_STRING_CMS "CMS"
+ 
+ // enc_type is one off
+ // #define PEM_TYPE_ENCRYPTED 10
+@@ -250,67 +250,67 @@
  
  // These are the same except they are for the declarations
  
@@ -58,13 +110,20 @@
  
  // #define DECLARE_PEM_write_fp_const(name, type) \
  //   OPENSSL_EXPORT int PEM_write_##name(FILE *fp, const type *x);
-@@ -265,12 +265,12 @@
- //       FILE *fp, type *x, const EVP_CIPHER *enc, unsigned char *kstr, int klen, \
- //       pem_password_cb *cb, void *u);
  
+-// #define DECLARE_PEM_write_cb_fp(name, type)                                    \
+-//   OPENSSL_EXPORT int PEM_write_##name(                                         \
+-//       FILE *fp, type *x, const EVP_CIPHER *enc, unsigned char *kstr, int klen, \
+-//       pem_password_cb *cb, void *u);
+-
 -// #define DECLARE_PEM_read_bio(name, type)                      \
 -//   OPENSSL_EXPORT type *PEM_read_bio_##name(BIO *bp, type **x, \
 -//                                            pem_password_cb *cb, void *u);
++#define DECLARE_PEM_write_cb_fp(name, type)                                    \
++  OPENSSL_EXPORT int PEM_write_##name(                                         \
++      FILE *fp, type *x, const EVP_CIPHER *enc, unsigned char *kstr, int klen, \
++      pem_password_cb *cb, void *u);
++
 +#define DECLARE_PEM_read_bio(name, type)                      \
 +  OPENSSL_EXPORT type *PEM_read_bio_##name(BIO *bp, type **x, \
 +                                           pem_password_cb *cb, void *u);
@@ -76,8 +135,15 @@
  
  // #define DECLARE_PEM_write_bio_const(name, type) \
  //   OPENSSL_EXPORT int PEM_write_bio_##name(BIO *bp, const type *x);
-@@ -281,9 +281,9 @@
- //       pem_password_cb *cb, void *u);
+ 
+-// #define DECLARE_PEM_write_cb_bio(name, type)                                  \
+-//   OPENSSL_EXPORT int PEM_write_bio_##name(                                    \
+-//       BIO *bp, type *x, const EVP_CIPHER *enc, unsigned char *kstr, int klen, \
+-//       pem_password_cb *cb, void *u);
++#define DECLARE_PEM_write_cb_bio(name, type)                                  \
++  OPENSSL_EXPORT int PEM_write_bio_##name(                                    \
++      BIO *bp, type *x, const EVP_CIPHER *enc, unsigned char *kstr, int klen, \
++      pem_password_cb *cb, void *u);
  
  
 -// #define DECLARE_PEM_write(name, type) \
@@ -89,10 +155,12 @@
  
  // #define DECLARE_PEM_write_const(name, type) \
  //   DECLARE_PEM_write_bio_const(name, type)   \
-@@ -293,13 +293,13 @@
- //   DECLARE_PEM_write_cb_bio(name, type)   \
- //   DECLARE_PEM_write_cb_fp(name, type)
+ //   DECLARE_PEM_write_fp_const(name, type)
  
+-// #define DECLARE_PEM_write_cb(name, type) \
+-//   DECLARE_PEM_write_cb_bio(name, type)   \
+-//   DECLARE_PEM_write_cb_fp(name, type)
+-
 -// #define DECLARE_PEM_read(name, type) \
 -//   DECLARE_PEM_read_bio(name, type)   \
 -//   DECLARE_PEM_read_fp(name, type)
@@ -100,6 +168,10 @@
 -// #define DECLARE_PEM_rw(name, type) \
 -//   DECLARE_PEM_read(name, type)     \
 -//   DECLARE_PEM_write(name, type)
++#define DECLARE_PEM_write_cb(name, type) \
++  DECLARE_PEM_write_cb_bio(name, type)   \
++  DECLARE_PEM_write_cb_fp(name, type)
++
 +#define DECLARE_PEM_read(name, type) \
 +  DECLARE_PEM_read_bio(name, type)   \
 +  DECLARE_PEM_read_fp(name, type)
@@ -110,8 +182,14 @@
  
  // #define DECLARE_PEM_rw_const(name, type) \
  //   DECLARE_PEM_read(name, type)           \
-@@ -310,7 +310,7 @@
- //   DECLARE_PEM_write_cb(name, type)
+ //   DECLARE_PEM_write_const(name, type)
+ 
+-// #define DECLARE_PEM_rw_cb(name, type) \
+-//   DECLARE_PEM_read(name, type)        \
+-//   DECLARE_PEM_write_cb(name, type)
++#define DECLARE_PEM_rw_cb(name, type) \
++  DECLARE_PEM_read(name, type)        \
++  DECLARE_PEM_write_cb(name, type)
  
  // "userdata": new with OpenSSL 0.9.4
 -// typedef int pem_password_cb(char *buf, int size, int rwflag, void *userdata);
@@ -119,6 +197,19 @@
  
  // OPENSSL_EXPORT int PEM_get_EVP_CIPHER_INFO(char *header,
  //                                            EVP_CIPHER_INFO *cipher);
+@@ -336,9 +336,9 @@
+ // OPENSSL_EXPORT int PEM_write_bio(BIO *bp, const char *name, const char *hdr,
+ //                                  const unsigned char *data, long len);
+ 
+-// OPENSSL_EXPORT int PEM_bytes_read_bio(unsigned char **pdata, long *plen,
+-//                                       char **pnm, const char *name, BIO *bp,
+-//                                       pem_password_cb *cb, void *u);
++OPENSSL_EXPORT int PEM_bytes_read_bio(unsigned char **pdata, long *plen,
++                                      char **pnm, const char *name, BIO *bp,
++                                      pem_password_cb *cb, void *u);
+ // OPENSSL_EXPORT void *PEM_ASN1_read_bio(d2i_of_void *d2i, const char *name,
+ //                                        BIO *bp, void **x, pem_password_cb *cb,
+ //                                        void *u);
 @@ -381,7 +381,7 @@
  //                                  char *str);
  
@@ -128,6 +219,15 @@
  
  // DECLARE_PEM_rw(X509_AUX, X509)
  
+@@ -395,7 +395,7 @@
+ 
+ // DECLARE_PEM_rw(PKCS8_PRIV_KEY_INFO, PKCS8_PRIV_KEY_INFO)
+ 
+-// DECLARE_PEM_rw_cb(RSAPrivateKey, RSA)
++DECLARE_PEM_rw_cb(RSAPrivateKey, RSA)
+ 
+ // DECLARE_PEM_rw_const(RSAPublicKey, RSA)
+ // DECLARE_PEM_rw(RSA_PUBKEY, RSA)
 @@ -460,9 +460,9 @@
  //                                              void *u);
  

--- a/bssl-compat/patch/include/openssl/pool.h.patch
+++ b/bssl-compat/patch/include/openssl/pool.h.patch
@@ -1,0 +1,77 @@
+--- a/include/openssl/pool.h
++++ b/include/openssl/pool.h
+@@ -12,16 +12,16 @@
+  * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
+ 
+-// #ifndef OPENSSL_HEADER_POOL_H
+-// #define OPENSSL_HEADER_POOL_H
++#ifndef OPENSSL_HEADER_POOL_H
++#define OPENSSL_HEADER_POOL_H
+ 
+-// #include <openssl/base.h>
++#include <openssl/base.h>
+ 
+-// #include <openssl/stack.h>
++#include <openssl/stack.h>
+ 
+-// #if defined(__cplusplus)
+-// extern "C" {
+-// #endif
++#if defined(__cplusplus)
++extern "C" {
++#endif
+ 
+ 
+ // Buffers and buffer pools.
+@@ -45,8 +45,8 @@
+ // reference to a previously existing |CRYPTO_BUFFER| that contained the same
+ // data. Otherwise, the returned, fresh |CRYPTO_BUFFER| will be added to the
+ // pool.
+-// OPENSSL_EXPORT CRYPTO_BUFFER *CRYPTO_BUFFER_new(const uint8_t *data, size_t len,
+-//                                                 CRYPTO_BUFFER_POOL *pool);
++OPENSSL_EXPORT CRYPTO_BUFFER *CRYPTO_BUFFER_new(const uint8_t *data, size_t len,
++                                                CRYPTO_BUFFER_POOL *pool);
+ 
+ // CRYPTO_BUFFER_alloc creates an unpooled |CRYPTO_BUFFER| of the given size and
+ // writes the underlying data pointer to |*out_data|. It returns NULL on error.
+@@ -71,7 +71,7 @@
+ // CRYPTO_BUFFER_free decrements the reference count of |buf|. If there are no
+ // other references, or if the only remaining reference is from a pool, then
+ // |buf| will be freed.
+-// OPENSSL_EXPORT void CRYPTO_BUFFER_free(CRYPTO_BUFFER *buf);
++OPENSSL_EXPORT void CRYPTO_BUFFER_free(CRYPTO_BUFFER *buf);
+ 
+ // CRYPTO_BUFFER_up_ref increments the reference count of |buf| and returns
+ // one.
+@@ -88,21 +88,21 @@
+ // OPENSSL_EXPORT void CRYPTO_BUFFER_init_CBS(const CRYPTO_BUFFER *buf, CBS *out);
+ 
+ 
+-// #if defined(__cplusplus)
+-// }  // extern C
++#if defined(__cplusplus)
++}  // extern C
+ 
+-// extern "C++" {
++extern "C++" {
+ 
+-// BSSL_NAMESPACE_BEGIN
++BSSL_NAMESPACE_BEGIN
+ 
+ // BORINGSSL_MAKE_DELETER(CRYPTO_BUFFER_POOL, CRYPTO_BUFFER_POOL_free)
+-// BORINGSSL_MAKE_DELETER(CRYPTO_BUFFER, CRYPTO_BUFFER_free)
++BORINGSSL_MAKE_DELETER(CRYPTO_BUFFER, CRYPTO_BUFFER_free)
+ // BORINGSSL_MAKE_UP_REF(CRYPTO_BUFFER, CRYPTO_BUFFER_up_ref)
+ 
+-// BSSL_NAMESPACE_END
++BSSL_NAMESPACE_END
+ 
+-// }  // extern C++
++}  // extern C++
+ 
+-// #endif
++#endif
+ 
+-// #endif  // OPENSSL_HEADER_POOL_H
++#endif  // OPENSSL_HEADER_POOL_H

--- a/bssl-compat/patch/include/openssl/rsa.h.patch
+++ b/bssl-compat/patch/include/openssl/rsa.h.patch
@@ -1,0 +1,76 @@
+--- a/include/openssl/rsa.h
++++ b/include/openssl/rsa.h
+@@ -54,18 +54,18 @@
+  * copied and put under another distribution licence
+  * [including the GNU Public Licence.] */
+ 
+-// #ifndef OPENSSL_HEADER_RSA_H
+-// #define OPENSSL_HEADER_RSA_H
++#ifndef OPENSSL_HEADER_RSA_H
++#define OPENSSL_HEADER_RSA_H
+ 
+-// #include <openssl/base.h>
++#include <openssl/base.h>
+ 
+-// #include <openssl/engine.h>
+-// #include <openssl/ex_data.h>
+-// #include <openssl/thread.h>
+-
+-// #if defined(__cplusplus)
+-// extern "C" {
+-// #endif
++#include <openssl/engine.h>
++#include <openssl/ex_data.h>
++#include <openssl/thread.h>
++
++#if defined(__cplusplus)
++extern "C" {
++#endif
+ 
+ 
+ // rsa.h contains functions for handling encryption and signature using RSA.
+@@ -87,7 +87,7 @@
+ 
+ // RSA_free decrements the reference count of |rsa| and frees it if the
+ // reference count drops to zero.
+-// OPENSSL_EXPORT void RSA_free(RSA *rsa);
++OPENSSL_EXPORT void RSA_free(RSA *rsa);
+ 
+ // RSA_up_ref increments the reference count of |rsa| and returns one. It does
+ // not mutate |rsa| for thread-safety purposes and may be used concurrently.
+@@ -789,21 +789,21 @@
+ // };
+ 
+ 
+-// #if defined(__cplusplus)
+-// }  // extern C
++#if defined(__cplusplus)
++}  // extern C
+ 
+-// extern "C++" {
++extern "C++" {
+ 
+-// BSSL_NAMESPACE_BEGIN
++BSSL_NAMESPACE_BEGIN
+ 
+-// BORINGSSL_MAKE_DELETER(RSA, RSA_free)
++BORINGSSL_MAKE_DELETER(RSA, RSA_free)
+ // BORINGSSL_MAKE_UP_REF(RSA, RSA_up_ref)
+ 
+-// BSSL_NAMESPACE_END
++BSSL_NAMESPACE_END
+ 
+-// }  // extern C++
++}  // extern C++
+ 
+-// #endif
++#endif
+ 
+ #ifdef ossl_RSA_R_BAD_ENCODING
+ #define RSA_R_BAD_ENCODING ossl_RSA_R_BAD_ENCODING
+@@ -953,4 +953,4 @@
+ #define RSA_R_BLOCK_TYPE_IS_NOT_02 ossl_RSA_R_BLOCK_TYPE_IS_NOT_02
+ #endif
+ 
+-// #endif  // OPENSSL_HEADER_RSA_H
++#endif  // OPENSSL_HEADER_RSA_H

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -424,6 +424,17 @@
  
  // SSL_get0_peer_certificates returns the peer's certificate chain, or NULL if
  // unavailable or the peer did not use certificates. This is the unverified list
+@@ -1683,8 +1684,8 @@
+ // OCSPResponse type as defined in RFC 2560.
+ //
+ // WARNING: the returned data is not guaranteed to be well formed.
+-// OPENSSL_EXPORT void SSL_get0_ocsp_response(const SSL *ssl, const uint8_t **out,
+-//                                            size_t *out_len);
++OPENSSL_EXPORT void SSL_get0_ocsp_response(const SSL *ssl, const uint8_t **out,
++                                           size_t *out_len);
+ 
+ // SSL_get_tls_unique writes at most |max_out| bytes of the tls-unique value
+ // for |ssl| to |out| and sets |*out_len| to the number of bytes written. It
 @@ -1753,7 +1754,7 @@
  // SSL_SESSION_new returns a newly-allocated blank |SSL_SESSION| or NULL on
  // error. This may be useful when writing tests but should otherwise not be
@@ -606,7 +617,15 @@
  
  // SSL_get_servername, for a server, returns the hostname supplied by the
  // client or NULL if there was none. The |type| argument must be
-@@ -2868,7 +2869,7 @@
+@@ -2862,7 +2863,6 @@
+ #ifdef ossl_SSL_TLSEXT_ERR_NOACK
+ #define SSL_TLSEXT_ERR_NOACK ossl_SSL_TLSEXT_ERR_NOACK
+ #endif
+-
+ // SSL_set_SSL_CTX changes |ssl|'s |SSL_CTX|. |ssl| will use the
+ // certificate-related settings from |ctx|, and |SSL_get_SSL_CTX| will report
+ // |ctx|. This function may be used during the callbacks registered by
+@@ -2876,7 +2876,7 @@
  // the session cache between different domains.
  //
  // TODO(davidben): Should other settings change after this call?
@@ -615,7 +634,7 @@
  
  
  // Application-layer protocol negotiation.
-@@ -4037,8 +4038,8 @@
+@@ -4045,8 +4045,8 @@
  //                                                 CRYPTO_EX_dup *dup_unused,
  //                                                 CRYPTO_EX_free *free_func);
  
@@ -626,7 +645,7 @@
  // OPENSSL_EXPORT int SSL_CTX_get_ex_new_index(long argl, void *argp,
  //                                             CRYPTO_EX_unused *unused,
  //                                             CRYPTO_EX_dup *dup_unused,
-@@ -4262,13 +4263,13 @@
+@@ -4270,13 +4270,13 @@
  // such as HTTP/1.1, and not others, such as HTTP/2.
  // OPENSSL_EXPORT void SSL_set_shed_handshake_config(SSL *ssl, int enable);
  
@@ -647,7 +666,7 @@
  
  // SSL_set_renegotiate_mode configures how |ssl|, a client, reacts to
  // renegotiation attempts by a server. If |ssl| is a server, peer-initiated
-@@ -4297,8 +4298,8 @@
+@@ -4305,8 +4305,8 @@
  //
  // There is no support in BoringSSL for initiating renegotiations as a client
  // or server.
@@ -658,7 +677,7 @@
  
  // SSL_renegotiate starts a deferred renegotiation on |ssl| if it was configured
  // with |ssl_renegotiate_explicit| and has a pending HelloRequest. It returns
-@@ -4359,45 +4360,45 @@
+@@ -4367,45 +4367,45 @@
  // callbacks that are called very early on during the server handshake. At this
  // point, much of the SSL* hasn't been filled out and only the ClientHello can
  // be depended on.
@@ -734,7 +753,7 @@
  
  // SSL_CTX_set_select_certificate_cb sets a callback that is called before most
  // ClientHello processing and before the decision whether to resume a session
-@@ -4413,9 +4414,9 @@
+@@ -4421,9 +4421,9 @@
  //
  // Note: The |SSL_CLIENT_HELLO| is only valid for the duration of the callback
  // and is not valid while the handshake is paused.
@@ -747,7 +766,7 @@
  
  // SSL_CTX_set_dos_protection_cb sets a callback that is called once the
  // resumption decision for a ClientHello has been made. It can return one to
-@@ -4531,7 +4532,7 @@
+@@ -4539,7 +4539,7 @@
  
  // SSL_get_peer_signature_algorithm returns the signature algorithm used by the
  // peer. If not applicable, it returns zero.
@@ -756,7 +775,7 @@
  
  // SSL_get_client_random writes up to |max_out| bytes of the most recent
  // handshake's client_random to |out| and returns the number of bytes written.
-@@ -4665,8 +4666,8 @@
+@@ -4673,8 +4673,8 @@
  
  // These client- and server-specific methods call their corresponding generic
  // methods.
@@ -767,7 +786,7 @@
  // OPENSSL_EXPORT const SSL_METHOD *SSLv23_server_method(void);
  // OPENSSL_EXPORT const SSL_METHOD *SSLv23_client_method(void);
  // OPENSSL_EXPORT const SSL_METHOD *TLSv1_server_method(void);
-@@ -4877,7 +4878,7 @@
+@@ -4885,7 +4885,7 @@
  // This API is compatible with OpenSSL. However, BoringSSL-specific code should
  // prefer |SSL_CTX_set_signing_algorithm_prefs| because it's clearer and it's
  // more convenient to codesearch for specific algorithm values.
@@ -776,7 +795,20 @@
  
  // SSL_set1_sigalgs_list takes a textual specification of a set of signature
  // algorithms and configures them on |ssl|. It returns one on success and zero
-@@ -5462,21 +5463,21 @@
+@@ -5238,9 +5238,9 @@
+ // OCSP responses like other server credentials, such as certificates or SCT
+ // lists. Configure, store, and refresh them eagerly. This avoids downtime if
+ // the CA's OCSP responder is briefly offline.
+-// OPENSSL_EXPORT int SSL_CTX_set_tlsext_status_cb(SSL_CTX *ctx,
+-//                                                 int (*callback)(SSL *ssl,
+-//                                                                 void *arg));
++OPENSSL_EXPORT int SSL_CTX_set_tlsext_status_cb(SSL_CTX *ctx,
++                                                int (*callback)(SSL *ssl,
++                                                                void *arg));
+ 
+ // SSL_CTX_set_tlsext_status_arg sets additional data for
+ // |SSL_CTX_set_tlsext_status_cb|'s callback and returns one.
+@@ -5470,21 +5470,21 @@
  // #endif // !defined(BORINGSSL_PREFIX)
  
  
@@ -806,7 +838,7 @@
  // BORINGSSL_MAKE_UP_REF(SSL_SESSION, SSL_SESSION_up_ref)
  
  // enum class OpenRecordResult {
-@@ -5593,13 +5594,13 @@
+@@ -5601,13 +5601,13 @@
  //     Span<const uint8_t> *out_write_traffic_secret);
  
  
@@ -824,7 +856,7 @@
  
  #ifdef ossl_SSL_R_APP_DATA_IN_HANDSHAKE
  #define SSL_R_APP_DATA_IN_HANDSHAKE ossl_SSL_R_APP_DATA_IN_HANDSHAKE
-@@ -6367,4 +6368,4 @@
+@@ -6375,4 +6375,4 @@
  #define SSL_R_TLSV1_ALERT_ECH_REQUIRED ossl_SSL_R_TLSV1_ALERT_ECH_REQUIRED
  #endif
  

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -306,6 +306,19 @@
  
  // SSL_get_signature_algorithm_key_type returns the key type associated with
  // |sigalg| as an |EVP_PKEY_*| constant or |EVP_PKEY_NONE| if unknown.
+@@ -1202,9 +1203,9 @@
+ // client or server. References to the given |CRYPTO_BUFFER| and |EVP_PKEY|
+ // objects are added as needed. Exactly one of |privkey| or |privkey_method|
+ // may be non-NULL. Returns one on success and zero on error.
+-// OPENSSL_EXPORT int SSL_set_chain_and_key(
+-//     SSL *ssl, CRYPTO_BUFFER *const *certs, size_t num_certs, EVP_PKEY *privkey,
+-//     const SSL_PRIVATE_KEY_METHOD *privkey_method);
++OPENSSL_EXPORT int SSL_set_chain_and_key(
++    SSL *ssl, CRYPTO_BUFFER *const *certs, size_t num_certs, EVP_PKEY *privkey,
++    const SSL_PRIVATE_KEY_METHOD *privkey_method);
+ 
+ // SSL_CTX_get0_chain returns the list of |CRYPTO_BUFFER|s that were set by
+ // |SSL_CTX_set_chain_and_key|. Reference counts are not incremented by this
 @@ -1254,8 +1255,8 @@
  // |type| parameter is one of the |SSL_FILETYPE_*| values and determines whether
  // the file's contents are read as PEM or DER.

--- a/bssl-compat/patch/include/openssl/ssl.h.sh
+++ b/bssl-compat/patch/include/openssl/ssl.h.sh
@@ -12,6 +12,8 @@ SUBSTITUTIONS+=('TLS1_2_VERSION')
 SUBSTITUTIONS+=('TLS1_3_VERSION')
 SUBSTITUTIONS+=('DTLS1_VERSION')
 SUBSTITUTIONS+=('DTLS1_2_VERSION')
+SUBSTITUTIONS+=('SSL_R_[a-zA-Z0-9_]*')
+SUBSTITUTIONS+=('SSL_TLSEXT_ERR_[A-Z_]*')
 
 EXPRE='s|^//[ \t]#[ \t]*define[ \t]*[^a-zA-Z0-9_]\('
 EXPOST='\)[^a-zA-Z0-9_].*$|#ifdef ossl_\1\n#define \1 ossl_\1\n#endif|'
@@ -20,6 +22,3 @@ for SUBSTITUTION in "${SUBSTITUTIONS[@]}"
 do
 	sed -i -e "${EXPRE}${SUBSTITUTION}${EXPOST}" "$1"
 done
-
-sed -i -e 's|^// \(#[ \t]*define[ \t]*\)\(SSL_R_[a-zA-Z0-9_]*\)[^a-zA-Z0-9_].*$|#ifdef ossl_\2\n\1\2 ossl_\2\n#endif|g' "$1"
-

--- a/bssl-compat/source/CRYPTO_BUFFER.h
+++ b/bssl-compat/source/CRYPTO_BUFFER.h
@@ -1,0 +1,13 @@
+#ifndef BSSL_COMPAT_CRYPTO_BUFFER_H
+#define BSSL_COMPAT_CRYPTO_BUFFER_H
+
+/*
+ * This is a minimal/trivial implementation of CRYPTO_BUFFER
+ */
+struct crypto_buffer_st {
+  uint8_t *data;
+  size_t len;
+};
+
+#endif // BSSL_COMPAT_CRYPTO_BUFFER_H
+

--- a/bssl-compat/source/CRYPTO_BUFFER_free.c
+++ b/bssl-compat/source/CRYPTO_BUFFER_free.c
@@ -1,0 +1,16 @@
+#include <openssl/pool.h>
+#include <openssl/mem.h>
+#include "CRYPTO_BUFFER.h"
+
+
+/*
+ * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/pool.h#L74
+ */
+void CRYPTO_BUFFER_free(CRYPTO_BUFFER *buf) {
+  if (buf == NULL) {
+    return;
+  }
+
+  OPENSSL_free(buf->data);
+  OPENSSL_free(buf);
+}

--- a/bssl-compat/source/CRYPTO_BUFFER_new.c
+++ b/bssl-compat/source/CRYPTO_BUFFER_new.c
@@ -1,0 +1,32 @@
+#include <openssl/pool.h>
+#include <openssl/mem.h>
+#include "crypto/internal.h"
+#include "CRYPTO_BUFFER.h"
+#include "log.h"
+
+
+/*
+ * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/pool.h#L48
+ */
+CRYPTO_BUFFER *CRYPTO_BUFFER_new(const uint8_t *data, size_t len, CRYPTO_BUFFER_POOL *pool) {
+  if(pool) {
+    bssl_compat_fatal("%s() with non-null pool not implemented", __func__);
+  }
+
+  CRYPTO_BUFFER *const buf = OPENSSL_malloc(sizeof(CRYPTO_BUFFER));
+  if(buf == NULL) {
+    return NULL;
+  }
+
+  OPENSSL_memset(buf, 0, sizeof(CRYPTO_BUFFER));
+
+  buf->data = OPENSSL_memdup(data, len);
+  if(len != 0 && buf->data == NULL) {
+    OPENSSL_free(buf);
+    return NULL;
+  }
+
+  buf->len = len;
+
+  return buf;
+}

--- a/bssl-compat/source/PEM_bytes_read_bio.c
+++ b/bssl-compat/source/PEM_bytes_read_bio.c
@@ -1,0 +1,7 @@
+#include <openssl/pem.h>
+#include <ossl/openssl/pem.h>
+
+
+int PEM_bytes_read_bio(unsigned char **pdata, long *plen, char **pnm, const char *name, BIO *bp, pem_password_cb *cb, void *u) {
+  return ossl_PEM_bytes_read_bio(pdata, plen, pnm, name, bp, cb, u);
+}

--- a/bssl-compat/source/PEM_read_bio_RSAPrivateKey.c
+++ b/bssl-compat/source/PEM_read_bio_RSAPrivateKey.c
@@ -1,0 +1,8 @@
+#include <openssl/pem.h>
+#include <ossl.h>
+
+
+RSA *PEM_read_bio_RSAPrivateKey(BIO *out, RSA **x, pem_password_cb *cb, void *u) {
+  // FIXME: Reimplement with: https://www.openssl.org/docs/man3.0/man3/OSSL_DECODER_from_bio.html
+  return ossl.ossl_PEM_read_bio_RSAPrivateKey(out, x, cb, u);
+}

--- a/bssl-compat/source/RSA_free.c
+++ b/bssl-compat/source/RSA_free.c
@@ -1,0 +1,10 @@
+#include <openssl/rsa.h>
+#include <ossl/openssl/rsa.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/rsa.h#L90
+ */
+void RSA_free(RSA *rsa) {
+  ossl_RSA_free(rsa);
+}

--- a/bssl-compat/source/SSL_CTX_set_tlsext_status_cb.c
+++ b/bssl-compat/source/SSL_CTX_set_tlsext_status_cb.c
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/ssl.h#L5079
+ * https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set_tlsext_status_cb.html
+ */
+int SSL_CTX_set_tlsext_status_cb(SSL_CTX *ctx, int (*callback)(SSL *ssl, void *arg)) {
+  return ossl_SSL_CTX_set_tlsext_status_cb(ctx, callback);
+}

--- a/bssl-compat/source/SSL_get0_ocsp_response.c
+++ b/bssl-compat/source/SSL_get0_ocsp_response.c
@@ -1,0 +1,21 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/ssl.h#L1614
+ * https://www.openssl.org/docs/man3.0/man3/SSL_get_tlsext_status_ocsp_resp.html
+ */
+void SSL_get0_ocsp_response(const SSL *ssl, const uint8_t **out, size_t *out_len) {
+  unsigned char *data;
+  long len = ossl_SSL_get_tlsext_status_ocsp_resp((SSL*)ssl, &data);
+
+  if(len == -1) {
+    *out = NULL;
+    *out_len = 0;
+    return;
+  }
+
+  *out = data;
+  *out_len = len;
+}

--- a/bssl-compat/source/SSL_set_chain_and_key.cc
+++ b/bssl-compat/source/SSL_set_chain_and_key.cc
@@ -1,0 +1,46 @@
+#include <openssl/ssl.h>
+#include "CRYPTO_BUFFER.h"
+#include "log.h"
+
+
+/*
+ * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/ssl.h#L1133
+ * https://www.openssl.org/docs/man3.0/man3/SSL_use_cert_and_key.html
+ */
+int SSL_set_chain_and_key(SSL *ssl, CRYPTO_BUFFER *const *certs, size_t num_certs, EVP_PKEY *privkey, const SSL_PRIVATE_KEY_METHOD *privkey_method) {
+  if(privkey_method) {
+    bssl_compat_fatal("%s() : privkey_method parameter is not supported");
+  }
+
+  bssl::UniquePtr<X509> leaf;
+  bssl::UniquePtr<STACK_OF(X509)> chain {sk_X509_new_null()};
+
+  for(size_t i = 0; i < num_certs; i++) {
+    bssl::UniquePtr<BIO> bio {BIO_new_mem_buf(certs[i]->data, certs[i]->len)};
+    if (!bio) {
+      return 0;
+    }
+
+    bssl::UniquePtr<X509> cert {ossl_d2i_X509_bio(bio.get(), nullptr)};
+    if (!cert) {
+      return 0;
+    }
+
+    if(i == 0) {
+      leaf = std::move(cert);
+    }
+    else {
+      if(sk_X509_push(chain.get(), cert.get()) <= 0) {
+        return 0;
+      }
+    }
+
+    cert.release();
+  }
+
+  if (!ossl_SSL_use_cert_and_key(ssl, leaf.get(), privkey, reinterpret_cast<ossl_STACK_OF(ossl_X509)*>(chain.get()), 1)) {
+    return 0;
+  }
+
+  return 1;
+}

--- a/bssl-compat/source/test/test_ssl.cc
+++ b/bssl-compat/source/test/test_ssl.cc
@@ -3,6 +3,7 @@
 #include <openssl/bytestring.h>
 #include <openssl/ssl.h>
 #include <openssl/tls1.h>
+#include <openssl/pem.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
@@ -11,9 +12,14 @@
 
 #include "certs/client_2_cert_chain.pem.h"
 #include "certs/client_2_key.pem.h"
+#include "certs/server_1_cert.pem.h"
+#include "certs/server_1_key.pem.h"
+#include "certs/server_2_cert.pem.h"
 #include "certs/server_2_cert_chain.pem.h"
 #include "certs/server_2_key.pem.h"
 #include "certs/root_ca_cert.pem.h"
+#include "certs/intermediate_ca_1_cert.pem.h"
+#include "certs/intermediate_ca_2_cert.pem.h"
 
 
 class TempFile {
@@ -836,6 +842,101 @@ TEST(SSLTest, test_SSL_get0_ocsp_response) {
 
     ASSERT_EQ(sizeof(OCSP_RESPONSE), ocsp_resp_len);
     ASSERT_EQ(0, memcmp(OCSP_RESPONSE, ocsp_resp_data, ocsp_resp_len));
+
+    char buf[sizeof(MESSAGE)];
+    ASSERT_EQ(sizeof(MESSAGE), SSL_write(ssl.get(), MESSAGE, sizeof(MESSAGE)));
+    ASSERT_EQ(sizeof(MESSAGE), SSL_read(ssl.get(), buf, sizeof(buf)));
+  }
+
+  server.join();
+}
+
+TEST(SSLTest, test_SSL_set_chain_and_key) {
+  TempFile root_ca_cert_pem { root_ca_cert_pem_str };
+
+  static const char MESSAGE[] { "HELLO" };
+  std::promise<in_port_t> server_port;
+
+  signal(SIGPIPE, SIG_IGN);
+
+  // Start a TLS server
+  std::thread server([&]() {
+    bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_server_method()));
+    bssl::UniquePtr<SSL> ssl { SSL_new(ctx.get()) };
+
+    bssl::UniquePtr<EVP_PKEY> key;
+    {
+      bssl::UniquePtr<BIO> bio {BIO_new_mem_buf(server_2_key_pem_str, strlen(server_2_key_pem_str))};
+      ASSERT_TRUE(bio);
+      bssl::UniquePtr<RSA> rsa {PEM_read_bio_RSAPrivateKey(bio.get(), nullptr, nullptr, nullptr)};
+      ASSERT_TRUE(rsa);
+      bssl::UniquePtr<EVP_PKEY> tmp(EVP_PKEY_new());
+      ASSERT_EQ(1, EVP_PKEY_assign_RSA(tmp.get(), rsa.get()));
+      rsa.release();
+      key = std::move(tmp);
+    }
+
+    std::vector<CRYPTO_BUFFER*> chain;
+    for(const char *pem_str : { server_2_cert_pem_str, intermediate_ca_2_cert_pem_str, intermediate_ca_1_cert_pem_str }) {
+      bssl::UniquePtr<BIO> bio(BIO_new_mem_buf(pem_str, strlen(pem_str)));
+      long der_len = 0;
+      uint8_t* der_data = nullptr;
+      ASSERT_EQ(1, PEM_bytes_read_bio(&der_data, &der_len, nullptr, PEM_STRING_X509, bio.get(), nullptr, nullptr));
+      bssl::UniquePtr<uint8_t> tmp(der_data); // Prevents memory leak.
+      chain.push_back(CRYPTO_BUFFER_new(der_data, der_len, nullptr));
+    }
+
+    ASSERT_EQ(1, SSL_set_chain_and_key(ssl.get(), chain.data(), chain.size(), key.get(), nullptr));
+    
+    while(chain.size()) {
+      CRYPTO_BUFFER_free(chain.back());
+      chain.pop_back();
+    }
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    socklen_t addrlen = sizeof(addr);
+
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_LT(0, sock);
+    ASSERT_EQ(0, bind(sock, (struct sockaddr*)&addr, sizeof(addr)));
+    ASSERT_EQ(0, listen(sock, 1));
+    ASSERT_EQ(0, getsockname(sock, (struct sockaddr*)&addr, &addrlen));
+    server_port.set_value(ntohs(addr.sin_port)); // Tell the client our port number
+    int client = accept(sock, nullptr, nullptr);
+    ASSERT_LT(0, client);
+
+    ASSERT_EQ(1, SSL_set_fd(ssl.get(), client));
+    ASSERT_EQ(1, SSL_accept(ssl.get())) << ERR_error_string(ERR_get_error(), nullptr);
+    ASSERT_EQ(1, SSL_is_server(ssl.get()));
+
+    char buf[sizeof(MESSAGE)];
+    ASSERT_EQ(sizeof(MESSAGE), SSL_read(ssl.get(), buf, sizeof(buf)));
+    ASSERT_EQ(sizeof(MESSAGE), SSL_write(ssl.get(), MESSAGE, sizeof(MESSAGE)));
+
+    SSL_shutdown(ssl.get());
+    close(client);
+    close(sock);
+  });
+
+  {
+    bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_client_method()));
+    SSL_CTX_set_verify(ctx.get(), SSL_VERIFY_PEER, nullptr);
+    ASSERT_EQ(1, SSL_CTX_load_verify_locations(ctx.get(), root_ca_cert_pem.path(), nullptr));
+    bssl::UniquePtr<SSL> ssl (SSL_new(ctx.get()));
+
+    struct sockaddr_in addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = inet_addr("127.0.0.1");
+    addr.sin_port = htons(server_port.get_future().get());
+
+    int sock = socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_EQ(0, connect(sock, (const struct sockaddr *)&addr, sizeof(addr)));
+    ASSERT_EQ(1, SSL_set_fd(ssl.get(), sock));
+    ASSERT_TRUE(SSL_connect(ssl.get()) > 0)  << ERR_error_string(ERR_get_error(), nullptr);
 
     char buf[sizeof(MESSAGE)];
     ASSERT_EQ(sizeof(MESSAGE), SSL_write(ssl.get(), MESSAGE, sizeof(MESSAGE)));


### PR DESCRIPTION
Added SSL_set_chain_and_key()
Added PEM_read_bio_RSAPrivateKey()
Added PEM_bytes_read_bio()
Added CRYPTO_BUFFER_new()
Added CRYPTO_BUFFER_free()
Added RSA_free()
Added SSL_get0_ocsp_response()
Added SSL_CTX_set_tlsext_status_cb()

Signed-off-by: Ted Poole <tpoole@redhat.com>