### PR TITLE
OSSM-3364 Added more <openssl/ssl.h> functions

### DIFF
--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -73,6 +73,7 @@ add_library(bssl-compat STATIC
   source/SSL_CTX_set_tlsext_status_cb.c
   source/SSL_CTX_set1_curves_list.c
   source/SSL_CTX_set1_sigalgs_list.c
+  source/SSL_CTX_use_PrivateKey.cc
   source/ssl_ctx.c
   source/ssl_ctx.cc
   source/SSL_early_callback_ctx_extension_get.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -84,6 +84,7 @@ add_library(bssl-compat STATIC
   source/SSL_get_cipher_by_value.c
   source/SSL_get_curve_id.c
   source/SSL_get_curve_name.c
+  source/SSL_get_peer_certificate.cc
   source/SSL_get_peer_signature_algorithm.c
   source/SSL_get_signature_algorithm_name.c
   source/SSL_get_wbio.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -85,6 +85,7 @@ add_library(bssl-compat STATIC
   source/SSL_get_curve_name.c
   source/SSL_get_peer_signature_algorithm.c
   source/SSL_get_signature_algorithm_name.c
+  source/SSL_get_wbio.cc
   source/SSL_get0_ocsp_response.c
   source/SSL_get1_session.c
   source/SSL_SESSION_from_bytes.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -89,6 +89,7 @@ add_library(bssl-compat STATIC
   source/SSL_SESSION_to_bytes.c
   source/SSL_set_chain_and_key.cc
   source/SSL_set_tlsext_host_name.c
+  source/TLS_method.cc
   source/ssl.c
   source/stack.c
 )

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -101,6 +101,7 @@ add_library(bssl-compat STATIC
   source/ssl.c
   source/stack.c
   source/TLS_method.cc
+  source/X509_get_pubkey.cc
 )
 
 target_add_bssl_source(bssl-compat

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -89,6 +89,7 @@ add_library(bssl-compat STATIC
   source/SSL_SESSION_to_bytes.c
   source/SSL_set_accept_state.cc
   source/SSL_set_chain_and_key.cc
+  source/SSL_set_connect_state.cc
   source/SSL_set_tlsext_host_name.c
   source/SSL_version.cc
   source/SSL_write.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -89,9 +89,10 @@ add_library(bssl-compat STATIC
   source/SSL_SESSION_to_bytes.c
   source/SSL_set_chain_and_key.cc
   source/SSL_set_tlsext_host_name.c
-  source/TLS_method.cc
+  source/SSL_write.cc
   source/ssl.c
   source/stack.c
+  source/TLS_method.cc
 )
 
 target_add_bssl_source(bssl-compat

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -84,6 +84,7 @@ add_library(bssl-compat STATIC
   source/SSL_get_cipher_by_value.c
   source/SSL_get_curve_id.c
   source/SSL_get_curve_name.c
+  source/SSL_get_peer_cert_chain.cc
   source/SSL_get_peer_certificate.cc
   source/SSL_get_peer_signature_algorithm.c
   source/SSL_get_signature_algorithm_name.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -89,6 +89,7 @@ add_library(bssl-compat STATIC
   source/SSL_SESSION_to_bytes.c
   source/SSL_set_chain_and_key.cc
   source/SSL_set_tlsext_host_name.c
+  source/SSL_version.cc
   source/SSL_write.cc
   source/ssl.c
   source/stack.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -54,6 +54,7 @@ add_library(bssl-compat STATIC
   source/crypto.c
   source/d2i_SSL_SESSION.c
   source/digest.c
+  source/DTLS_method.cc
   source/err.c
   source/EVP_DecodeBase64.c
   source/EVP_DecodedLength.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -87,6 +87,7 @@ add_library(bssl-compat STATIC
   source/SSL_SESSION_get_id.c
   source/SSL_SESSION_is_resumable.c
   source/SSL_SESSION_to_bytes.c
+  source/SSL_set_accept_state.cc
   source/SSL_set_chain_and_key.cc
   source/SSL_set_tlsext_host_name.c
   source/SSL_version.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library(bssl-compat STATIC
   source/ossl_ERR_set_error.c
   source/ossl.c
   source/PEM_bytes_read_bio.c
+  source/PEM_read_bio_PrivateKey.cc
   source/PEM_read_bio_RSAPrivateKey.c
   source/rand.c
   source/RSA_free.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -91,6 +91,7 @@ add_library(bssl-compat STATIC
   source/SSL_set_bio.cc
   source/SSL_set_chain_and_key.cc
   source/SSL_set_connect_state.cc
+  source/SSL_set_session.cc
   source/SSL_set_tlsext_host_name.c
   source/SSL_version.cc
   source/SSL_write.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -45,6 +45,7 @@ add_custom_target(ossl-gen DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/include/ossl.h)
 
 add_library(bssl-compat STATIC
   source/asn1.c
+  source/BIO_up_ref.cc
   source/bio.cpp
   source/bn.c
   source/cipher.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -88,6 +88,7 @@ add_library(bssl-compat STATIC
   source/SSL_SESSION_is_resumable.c
   source/SSL_SESSION_to_bytes.c
   source/SSL_set_accept_state.cc
+  source/SSL_set_bio.cc
   source/SSL_set_chain_and_key.cc
   source/SSL_set_connect_state.cc
   source/SSL_set_tlsext_host_name.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(bssl-compat STATIC
   source/rand.c
   source/RSA_free.c
   source/ssl_cipher.c
+  source/SSL_CTX_set_cert_verify_callback.cc
   source/SSL_CTX_set_tlsext_status_cb.c
   source/SSL_CTX_set1_curves_list.c
   source/SSL_CTX_set1_sigalgs_list.c

--- a/bssl-compat/patch/include/openssl/base.h.patch
+++ b/bssl-compat/patch/include/openssl/base.h.patch
@@ -673,9 +673,7 @@
  // SFINAE.
 -// template <typename T, typename Enable = void>
 -// struct DeleterImpl {};
-+template <typename T, typename Enable = void>
-+struct DeleterImpl {};
- 
+-
 -// template <typename T>
 -// struct Deleter {
 -//   void operator()(T *ptr) {
@@ -711,7 +709,9 @@
 -//     cleanup(&ctx_);
 -//     init(&ctx_);
 -//   }
--
++template <typename T, typename Enable = void>
++struct DeleterImpl {};
+ 
 -//  private:
 -//   T ctx_;
 -// };
@@ -757,7 +757,7 @@
  
  // template <typename T, typename CleanupRet, void (*init)(T *),
  //           CleanupRet (*cleanup)(T *), void (*move)(T *, T *)>
-@@ -587,21 +591,21 @@
+@@ -587,38 +591,38 @@
  //   T ctx_;
  // };
  
@@ -787,11 +787,28 @@
 +template <typename T>
 +using UniquePtr = std::unique_ptr<T, internal::Deleter<T>>;
  
- // #define BORINGSSL_MAKE_UP_REF(type, up_ref_func)             \
- //   inline UniquePtr<type> UpRef(type *v) {                    \
-@@ -615,10 +619,10 @@
- //     return UpRef(ptr.get());                                 \
- //   }
+-// #define BORINGSSL_MAKE_UP_REF(type, up_ref_func)             \
+-//   inline UniquePtr<type> UpRef(type *v) {                    \
+-//     if (v != nullptr) {                                      \
+-//       up_ref_func(v);                                        \
+-//     }                                                        \
+-//     return UniquePtr<type>(v);                               \
+-//   }                                                          \
+-//                                                              \
+-//   inline UniquePtr<type> UpRef(const UniquePtr<type> &ptr) { \
+-//     return UpRef(ptr.get());                                 \
+-//   }
++#define BORINGSSL_MAKE_UP_REF(type, up_ref_func)             \
++  inline UniquePtr<type> UpRef(type *v) {                    \
++    if (v != nullptr) {                                      \
++      up_ref_func(v);                                        \
++    }                                                        \
++    return UniquePtr<type>(v);                               \
++  }                                                          \
++                                                             \
++  inline UniquePtr<type> UpRef(const UniquePtr<type> &ptr) { \
++    return UpRef(ptr.get());                                 \
++  }
  
 -// BSSL_NAMESPACE_END
 +BSSL_NAMESPACE_END

--- a/bssl-compat/patch/include/openssl/bio.h.patch
+++ b/bssl-compat/patch/include/openssl/bio.h.patch
@@ -54,7 +54,15 @@
  
  // BIO_vfree performs the same actions as |BIO_free|, but has a void return
  // value. This is provided for API-compat.
-@@ -105,7 +105,7 @@
+@@ -98,14 +98,14 @@
+ // OPENSSL_EXPORT void BIO_vfree(BIO *bio);
+ 
+ // BIO_up_ref increments the reference count of |bio| and returns one.
+-// OPENSSL_EXPORT int BIO_up_ref(BIO *bio);
++OPENSSL_EXPORT int BIO_up_ref(BIO *bio);
+ 
+ 
+ // Basic I/O.
  
  // BIO_read attempts to read |len| bytes into |data|. It returns the number of
  // bytes read, zero on EOF, or a negative number on error.
@@ -256,8 +264,9 @@
 +BSSL_NAMESPACE_BEGIN
  
 -// BORINGSSL_MAKE_DELETER(BIO, BIO_free)
+-// BORINGSSL_MAKE_UP_REF(BIO, BIO_up_ref)
 +BORINGSSL_MAKE_DELETER(BIO, BIO_free)
- // BORINGSSL_MAKE_UP_REF(BIO, BIO_up_ref)
++BORINGSSL_MAKE_UP_REF(BIO, BIO_up_ref)
  // BORINGSSL_MAKE_DELETER(BIO_METHOD, BIO_meth_free)
  
 -// BSSL_NAMESPACE_END

--- a/bssl-compat/patch/include/openssl/pem.h.patch
+++ b/bssl-compat/patch/include/openssl/pem.h.patch
@@ -228,6 +228,15 @@
  
  // DECLARE_PEM_rw_const(RSAPublicKey, RSA)
  // DECLARE_PEM_rw(RSA_PUBKEY, RSA)
+@@ -417,7 +417,7 @@
+ // DECLARE_PEM_rw_const(DHparams, DH)
+ 
+ 
+-// DECLARE_PEM_rw_cb(PrivateKey, EVP_PKEY)
++DECLARE_PEM_rw_cb(PrivateKey, EVP_PKEY)
+ 
+ // DECLARE_PEM_rw(PUBKEY, EVP_PKEY)
+ 
 @@ -460,9 +460,9 @@
  //                                              void *u);
  

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -59,7 +59,7 @@
  
  
  // SSL implementation.
-@@ -186,7 +187,7 @@
+@@ -186,16 +187,16 @@
  // configuration may not be used.
  
  // TLS_method is the |SSL_METHOD| used for TLS connections.
@@ -67,8 +67,10 @@
 +OPENSSL_EXPORT const SSL_METHOD *TLS_method(void);
  
  // DTLS_method is the |SSL_METHOD| used for DTLS connections.
- // OPENSSL_EXPORT const SSL_METHOD *DTLS_method(void);
-@@ -195,7 +196,7 @@
+-// OPENSSL_EXPORT const SSL_METHOD *DTLS_method(void);
++OPENSSL_EXPORT const SSL_METHOD *DTLS_method(void);
+ 
+ // TLS_with_buffers_method is like |TLS_method|, but avoids all use of
  // crypto/x509. All client connections created with |TLS_with_buffers_method|
  // will fail unless a certificate verifier is installed with
  // |SSL_set_custom_verify| or |SSL_CTX_set_custom_verify|.

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -473,6 +473,15 @@
  
  // SSL_get_peer_cert_chain returns the peer's certificate chain or NULL if
  // unavailable or the peer did not use certificates. This is the unverified list
+@@ -1643,7 +1644,7 @@
+ // WARNING: This function behaves differently between client and server. If
+ // |ssl| is a server, the returned chain does not include the leaf certificate.
+ // If a client, it does.
+-// OPENSSL_EXPORT STACK_OF(X509) *SSL_get_peer_cert_chain(const SSL *ssl);
++OPENSSL_EXPORT STACK_OF(X509) *SSL_get_peer_cert_chain(const SSL *ssl);
+ 
+ // SSL_get_peer_full_cert_chain returns the peer's certificate chain, or NULL if
+ // unavailable or the peer did not use certificates. This is the unverified list
 @@ -1655,7 +1656,7 @@
  // (if any) will be the leaf certificate. In constrast,
  // |SSL_get_peer_cert_chain| returns only the intermediate certificates if the

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -655,6 +655,19 @@
  
  // SSL_get_verify_result returns the result of certificate verification. It is
  // either |X509_V_OK| or a |X509_V_ERR_*| value.
+@@ -2649,9 +2650,9 @@
+ //
+ // The callback may use |SSL_get_ex_data_X509_STORE_CTX_idx| to recover the
+ // |SSL| object from |store_ctx|.
+-// OPENSSL_EXPORT void SSL_CTX_set_cert_verify_callback(
+-//     SSL_CTX *ctx, int (*callback)(X509_STORE_CTX *store_ctx, void *arg),
+-//     void *arg);
++OPENSSL_EXPORT void SSL_CTX_set_cert_verify_callback(
++    SSL_CTX *ctx, int (*callback)(X509_STORE_CTX *store_ctx, void *arg),
++    void *arg);
+ 
+ // SSL_enable_signed_cert_timestamps causes |ssl| (which must be the client end
+ // of a connection) to request SCTs from the server. See
 @@ -2673,7 +2674,7 @@
  //
  // Call |SSL_get0_ocsp_response| to recover the OCSP response after the

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -263,6 +263,15 @@
  
  // SSL_use_certificate sets |ssl|'s leaf certificate to |x509|. It returns one
  // on success and zero on failure.
+@@ -936,7 +937,7 @@
+ 
+ // SSL_CTX_use_PrivateKey sets |ctx|'s private key to |pkey|. It returns one on
+ // success and zero on failure.
+-// OPENSSL_EXPORT int SSL_CTX_use_PrivateKey(SSL_CTX *ctx, EVP_PKEY *pkey);
++OPENSSL_EXPORT int SSL_CTX_use_PrivateKey(SSL_CTX *ctx, EVP_PKEY *pkey);
+ 
+ // SSL_use_PrivateKey sets |ssl|'s private key to |pkey|. It returns one on
+ // success and zero on failure.
 @@ -1074,10 +1075,10 @@
  // OPENSSL_EXPORT int SSL_check_private_key(const SSL *ssl);
  

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -128,7 +128,7 @@
  
  // SSL_is_dtls returns one if |ssl| is a DTLS connection and zero otherwise.
  // OPENSSL_EXPORT int SSL_is_dtls(const SSL *ssl);
-@@ -265,21 +266,21 @@
+@@ -265,27 +266,27 @@
  // Due to the very complex historical behavior of this function, calling this
  // function if |ssl| already has |BIO|s configured is deprecated. Prefer
  // |SSL_set0_rbio| and |SSL_set0_wbio| instead.
@@ -153,6 +153,13 @@
  
  // SSL_get_rbio returns the |BIO| that |ssl| reads from.
  // OPENSSL_EXPORT BIO *SSL_get_rbio(const SSL *ssl);
+ 
+ // SSL_get_wbio returns the |BIO| that |ssl| writes to.
+-// OPENSSL_EXPORT BIO *SSL_get_wbio(const SSL *ssl);
++OPENSSL_EXPORT BIO *SSL_get_wbio(const SSL *ssl);
+ 
+ // SSL_get_fd calls |SSL_get_rfd|.
+ // OPENSSL_EXPORT int SSL_get_fd(const SSL *ssl);
 @@ -313,7 +314,7 @@
  // |fd|.
  //

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -464,6 +464,15 @@
  
  
  // Connection information.
+@@ -1633,7 +1634,7 @@
+ // SSL_get_peer_certificate returns the peer's leaf certificate or NULL if the
+ // peer did not use certificates. The caller must call |X509_free| on the
+ // result to release it.
+-// OPENSSL_EXPORT X509 *SSL_get_peer_certificate(const SSL *ssl);
++OPENSSL_EXPORT X509 *SSL_get_peer_certificate(const SSL *ssl);
+ 
+ // SSL_get_peer_cert_chain returns the peer's certificate chain or NULL if
+ // unavailable or the peer did not use certificates. This is the unverified list
 @@ -1655,7 +1656,7 @@
  // (if any) will be the leaf certificate. In constrast,
  // |SSL_get_peer_cert_chain| returns only the intermediate certificates if the

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -116,7 +116,8 @@
 +OPENSSL_EXPORT void SSL_set_connect_state(SSL *ssl);
  
  // SSL_set_accept_state configures |ssl| to be a server.
- // OPENSSL_EXPORT void SSL_set_accept_state(SSL *ssl);
+-// OPENSSL_EXPORT void SSL_set_accept_state(SSL *ssl);
++OPENSSL_EXPORT void SSL_set_accept_state(SSL *ssl);
  
  // SSL_is_server returns one if |ssl| is configured as a server and zero
  // otherwise.

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -234,6 +234,15 @@
  
  // SSL_CTX_get_min_proto_version returns the minimum protocol version for |ctx|
  // OPENSSL_EXPORT uint16_t SSL_CTX_get_min_proto_version(const SSL_CTX *ctx);
+@@ -752,7 +753,7 @@
+ // SSL_version returns the TLS or DTLS protocol version used by |ssl|, which is
+ // one of the |*_VERSION| values. (E.g. |TLS1_2_VERSION|.) Before the version
+ // is negotiated, the result is undefined.
+-// OPENSSL_EXPORT int SSL_version(const SSL *ssl);
++OPENSSL_EXPORT int SSL_version(const SSL *ssl);
+ 
+ 
+ // Options.
 @@ -928,7 +929,7 @@
  
  // SSL_CTX_use_certificate sets |ctx|'s leaf certificate to |x509|. It returns

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -542,6 +542,15 @@
  
  // SSL_SESSION_has_ticket returns one if |session| has a ticket and zero
  // otherwise.
+@@ -2048,7 +2049,7 @@
+ // |SSL_SESSION_get0_ocsp_response|.
+ //
+ // It is an error to call this function after the handshake has begun.
+-// OPENSSL_EXPORT int SSL_set_session(SSL *ssl, SSL_SESSION *session);
++OPENSSL_EXPORT int SSL_set_session(SSL *ssl, SSL_SESSION *session);
+ 
+ // SSL_DEFAULT_SESSION_TIMEOUT is the default lifetime, in seconds, of a
+ // session in TLS 1.2 or earlier. This is how long we are willing to use the
 @@ -2393,7 +2394,7 @@
  // colon-separated list |curves|. Each element of |curves| should be a curve
  // name (e.g. P-256, X25519, ...). It returns one on success and zero on

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -126,7 +126,15 @@
  
  // SSL_is_dtls returns one if |ssl| is a DTLS connection and zero otherwise.
  // OPENSSL_EXPORT int SSL_is_dtls(const SSL *ssl);
-@@ -272,14 +273,14 @@
+@@ -265,21 +266,21 @@
+ // Due to the very complex historical behavior of this function, calling this
+ // function if |ssl| already has |BIO|s configured is deprecated. Prefer
+ // |SSL_set0_rbio| and |SSL_set0_wbio| instead.
+-// OPENSSL_EXPORT void SSL_set_bio(SSL *ssl, BIO *rbio, BIO *wbio);
++OPENSSL_EXPORT void SSL_set_bio(SSL *ssl, BIO *rbio, BIO *wbio);
+ 
+ // SSL_set0_rbio configures |ssl| to read from |rbio|. It takes ownership of
+ // |rbio|.
  //
  // Note that, although this function and |SSL_set0_wbio| may be called on the
  // same |BIO|, each call takes a reference. Use |BIO_up_ref| to balance this.

--- a/bssl-compat/patch/include/openssl/x509.h.patch
+++ b/bssl-compat/patch/include/openssl/x509.h.patch
@@ -82,6 +82,15 @@
  
  // X509_VERSION_* are X.509 version numbers. Note the numerical values of all
  // defined X.509 versions are one less than the named version.
+@@ -197,7 +197,7 @@
+ // public key was unsupported or could not be decoded. This function returns a
+ // reference to the |EVP_PKEY|. The caller must release the result with
+ // |EVP_PKEY_free| when done.
+-// OPENSSL_EXPORT EVP_PKEY *X509_get_pubkey(X509 *x509);
++OPENSSL_EXPORT EVP_PKEY *X509_get_pubkey(X509 *x509);
+ 
+ // X509_get0_pubkey_bitstr returns the BIT STRING portion of |x509|'s public
+ // key. Note this does not contain the AlgorithmIdentifier portion.
 @@ -835,8 +835,8 @@
  // moved to the subject alternative name extension. In modern usage, X.509 names
  // are primarily opaque identifiers to link a certificate with its issuer.

--- a/bssl-compat/patch/source/ssl/ssl_test.cc.patch
+++ b/bssl-compat/patch/source/ssl/ssl_test.cc.patch
@@ -1,6 +1,6 @@
 --- a/source/ssl/ssl_test.cc
 +++ b/source/ssl/ssl_test.cc
-@@ -12,56 +12,60 @@
+@@ -12,56 +12,61 @@
   * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
   * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
  
@@ -69,6 +69,7 @@
 -// #if defined(OPENSSL_WINDOWS)
 +#ifdef BSSL_COMPAT
 +#include <ossl/openssl/ssl.h>
++#include <ossl/openssl/provider.h>
 +#endif
 +
 +#if defined(OPENSSL_WINDOWS)
@@ -102,7 +103,47 @@
  
  // #define TRACED_CALL(code)                     \
  //   do {                                        \
-@@ -1196,14 +1200,14 @@
+@@ -72,22 +77,26 @@
+ //     }                                         \
+ //   } while (false)
+ 
+-// struct VersionParam {
+-//   uint16_t version;
+-//   enum { is_tls, is_dtls } ssl_method;
+-//   const char name[8];
+-// };
++struct VersionParam {
++  uint16_t version;
++  enum { is_tls, is_dtls } ssl_method;
++  const char name[8];
++};
+ 
+ // static const size_t kTicketKeyLen = 48;
+ 
+-// static const VersionParam kAllVersions[] = {
+-//     {TLS1_VERSION, VersionParam::is_tls, "TLS1"},
+-//     {TLS1_1_VERSION, VersionParam::is_tls, "TLS1_1"},
+-//     {TLS1_2_VERSION, VersionParam::is_tls, "TLS1_2"},
+-//     {TLS1_3_VERSION, VersionParam::is_tls, "TLS1_3"},
+-//     {DTLS1_VERSION, VersionParam::is_dtls, "DTLS1"},
+-//     {DTLS1_2_VERSION, VersionParam::is_dtls, "DTLS1_2"},
+-// };
++static const VersionParam kAllVersions[] = {
++#ifndef BSSL_COMPAT // OpenSSL 3.0.x no longer supports TLS 1.0 or TLS1.1
++    {TLS1_VERSION, VersionParam::is_tls, "TLS1"},
++    {TLS1_1_VERSION, VersionParam::is_tls, "TLS1_1"},
++#endif
++    {TLS1_2_VERSION, VersionParam::is_tls, "TLS1_2"},
++    {TLS1_3_VERSION, VersionParam::is_tls, "TLS1_3"},
++#ifndef BSSL_COMPAT // OpenSSL 3.0.x no longer supports DTLS 1.0
++    {DTLS1_VERSION, VersionParam::is_dtls, "DTLS1"},
++#endif
++    {DTLS1_2_VERSION, VersionParam::is_dtls, "DTLS1_2"},
++};
+ 
+ // struct ExpectedCipher {
+ //   unsigned long id;
+@@ -1196,63 +1205,63 @@
  //   }
  // }
  
@@ -114,21 +155,16 @@
 -//   return bssl::UniquePtr<X509>(
 -//       PEM_read_bio_X509(bio.get(), nullptr, nullptr, nullptr));
 -// }
-+static bssl::UniquePtr<X509> CertFromPEM(const char *pem) {
-+  bssl::UniquePtr<BIO> bio(BIO_new_mem_buf(pem, strlen(pem)));
-+  if (!bio) {
-+    return nullptr;
-+  }
-+  return bssl::UniquePtr<X509>(
-+      PEM_read_bio_X509(bio.get(), nullptr, nullptr, nullptr));
-+}
- 
- // static bssl::UniquePtr<EVP_PKEY> KeyFromPEM(const char *pem) {
- //   bssl::UniquePtr<BIO> bio(BIO_new_mem_buf(pem, strlen(pem)));
-@@ -1214,25 +1218,25 @@
- //       PEM_read_bio_PrivateKey(bio.get(), nullptr, nullptr, nullptr));
- // }
- 
+-
+-// static bssl::UniquePtr<EVP_PKEY> KeyFromPEM(const char *pem) {
+-//   bssl::UniquePtr<BIO> bio(BIO_new_mem_buf(pem, strlen(pem)));
+-//   if (!bio) {
+-//     return nullptr;
+-//   }
+-//   return bssl::UniquePtr<EVP_PKEY>(
+-//       PEM_read_bio_PrivateKey(bio.get(), nullptr, nullptr, nullptr));
+-// }
+-
 -// static bssl::UniquePtr<X509> GetTestCertificate() {
 -//   static const char kCertPEM[] =
 -//       "-----BEGIN CERTIFICATE-----\n"
@@ -148,6 +184,44 @@
 -//       "-----END CERTIFICATE-----\n";
 -//   return CertFromPEM(kCertPEM);
 -// }
+-
+-// static bssl::UniquePtr<EVP_PKEY> GetTestKey() {
+-//   static const char kKeyPEM[] =
+-//       "-----BEGIN RSA PRIVATE KEY-----\n"
+-//       "MIICXgIBAAKBgQDYK8imMuRi/03z0K1Zi0WnvfFHvwlYeyK9Na6XJYaUoIDAtB92\n"
+-//       "kWdGMdAQhLciHnAjkXLI6W15OoV3gA/ElRZ1xUpxTMhjP6PyY5wqT5r6y8FxbiiF\n"
+-//       "KKAnHmUcrgfVW28tQ+0rkLGMryRtrukXOgXBv7gcrmU7G1jC2a7WqmeI8QIDAQAB\n"
+-//       "AoGBAIBy09Fd4DOq/Ijp8HeKuCMKTHqTW1xGHshLQ6jwVV2vWZIn9aIgmDsvkjCe\n"
+-//       "i6ssZvnbjVcwzSoByhjN8ZCf/i15HECWDFFh6gt0P5z0MnChwzZmvatV/FXCT0j+\n"
+-//       "WmGNB/gkehKjGXLLcjTb6dRYVJSCZhVuOLLcbWIV10gggJQBAkEA8S8sGe4ezyyZ\n"
+-//       "m4e9r95g6s43kPqtj5rewTsUxt+2n4eVodD+ZUlCULWVNAFLkYRTBCASlSrm9Xhj\n"
+-//       "QpmWAHJUkQJBAOVzQdFUaewLtdOJoPCtpYoY1zd22eae8TQEmpGOR11L6kbxLQsk\n"
+-//       "aMly/DOnOaa82tqAGTdqDEZgSNmCeKKknmECQAvpnY8GUOVAubGR6c+W90iBuQLj\n"
+-//       "LtFp/9ihd2w/PoDwrHZaoUYVcT4VSfJQog/k7kjE4MYXYWL8eEKg3WTWQNECQQDk\n"
+-//       "104Wi91Umd1PzF0ijd2jXOERJU1wEKe6XLkYYNHWQAe5l4J4MWj9OdxFXAxIuuR/\n"
+-//       "tfDwbqkta4xcux67//khAkEAvvRXLHTaa6VFzTaiiO8SaFsHV3lQyXOtMrBpB5jd\n"
+-//       "moZWgjHvB2W9Ckn7sDqsPB+U2tyX0joDdQEyuiMECDY8oQ==\n"
+-//       "-----END RSA PRIVATE KEY-----\n";
+-//   return KeyFromPEM(kKeyPEM);
+-// }
++static bssl::UniquePtr<X509> CertFromPEM(const char *pem) {
++  bssl::UniquePtr<BIO> bio(BIO_new_mem_buf(pem, strlen(pem)));
++  if (!bio) {
++    return nullptr;
++  }
++  return bssl::UniquePtr<X509>(
++      PEM_read_bio_X509(bio.get(), nullptr, nullptr, nullptr));
++}
++
++static bssl::UniquePtr<EVP_PKEY> KeyFromPEM(const char *pem) {
++  bssl::UniquePtr<BIO> bio(BIO_new_mem_buf(pem, strlen(pem)));
++  if (!bio) {
++    return nullptr;
++  }
++  return bssl::UniquePtr<EVP_PKEY>(
++      PEM_read_bio_PrivateKey(bio.get(), nullptr, nullptr, nullptr));
++}
++
 +static bssl::UniquePtr<X509> GetTestCertificate() {
 +  static const char kCertPEM[] =
 +      "-----BEGIN CERTIFICATE-----\n"
@@ -167,10 +241,792 @@
 +      "-----END CERTIFICATE-----\n";
 +  return CertFromPEM(kCertPEM);
 +}
++
++static bssl::UniquePtr<EVP_PKEY> GetTestKey() {
++  static const char kKeyPEM[] =
++      "-----BEGIN RSA PRIVATE KEY-----\n"
++      "MIICXgIBAAKBgQDYK8imMuRi/03z0K1Zi0WnvfFHvwlYeyK9Na6XJYaUoIDAtB92\n"
++      "kWdGMdAQhLciHnAjkXLI6W15OoV3gA/ElRZ1xUpxTMhjP6PyY5wqT5r6y8FxbiiF\n"
++      "KKAnHmUcrgfVW28tQ+0rkLGMryRtrukXOgXBv7gcrmU7G1jC2a7WqmeI8QIDAQAB\n"
++      "AoGBAIBy09Fd4DOq/Ijp8HeKuCMKTHqTW1xGHshLQ6jwVV2vWZIn9aIgmDsvkjCe\n"
++      "i6ssZvnbjVcwzSoByhjN8ZCf/i15HECWDFFh6gt0P5z0MnChwzZmvatV/FXCT0j+\n"
++      "WmGNB/gkehKjGXLLcjTb6dRYVJSCZhVuOLLcbWIV10gggJQBAkEA8S8sGe4ezyyZ\n"
++      "m4e9r95g6s43kPqtj5rewTsUxt+2n4eVodD+ZUlCULWVNAFLkYRTBCASlSrm9Xhj\n"
++      "QpmWAHJUkQJBAOVzQdFUaewLtdOJoPCtpYoY1zd22eae8TQEmpGOR11L6kbxLQsk\n"
++      "aMly/DOnOaa82tqAGTdqDEZgSNmCeKKknmECQAvpnY8GUOVAubGR6c+W90iBuQLj\n"
++      "LtFp/9ihd2w/PoDwrHZaoUYVcT4VSfJQog/k7kjE4MYXYWL8eEKg3WTWQNECQQDk\n"
++      "104Wi91Umd1PzF0ijd2jXOERJU1wEKe6XLkYYNHWQAe5l4J4MWj9OdxFXAxIuuR/\n"
++      "tfDwbqkta4xcux67//khAkEAvvRXLHTaa6VFzTaiiO8SaFsHV3lQyXOtMrBpB5jd\n"
++      "moZWgjHvB2W9Ckn7sDqsPB+U2tyX0joDdQEyuiMECDY8oQ==\n"
++      "-----END RSA PRIVATE KEY-----\n";
++  return KeyFromPEM(kKeyPEM);
++}
  
- // static bssl::UniquePtr<EVP_PKEY> GetTestKey() {
- //   static const char kKeyPEM[] =
-@@ -4214,43 +4218,46 @@
+ // static bssl::UniquePtr<SSL_CTX> CreateContextWithTestCertificate(
+ //     const SSL_METHOD *method) {
+@@ -1408,36 +1417,44 @@
+ //   return KeyFromPEM(kKeyPEM);
+ // }
+ 
+-// static bool CompleteHandshakes(SSL *client, SSL *server) {
+-//   // Drive both their handshakes to completion.
+-//   for (;;) {
+-//     int client_ret = SSL_do_handshake(client);
+-//     int client_err = SSL_get_error(client, client_ret);
+-//     if (client_err != SSL_ERROR_NONE &&
+-//         client_err != SSL_ERROR_WANT_READ &&
+-//         client_err != SSL_ERROR_WANT_WRITE &&
+-//         client_err != SSL_ERROR_PENDING_TICKET) {
+-//       fprintf(stderr, "Client error: %s\n", SSL_error_description(client_err));
+-//       return false;
+-//     }
+-
+-//     int server_ret = SSL_do_handshake(server);
+-//     int server_err = SSL_get_error(server, server_ret);
+-//     if (server_err != SSL_ERROR_NONE &&
+-//         server_err != SSL_ERROR_WANT_READ &&
+-//         server_err != SSL_ERROR_WANT_WRITE &&
+-//         server_err != SSL_ERROR_PENDING_TICKET) {
+-//       fprintf(stderr, "Server error: %s\n", SSL_error_description(server_err));
+-//       return false;
+-//     }
+-
+-//     if (client_ret == 1 && server_ret == 1) {
+-//       break;
+-//     }
+-//   }
++static bool CompleteHandshakes(SSL *client, SSL *server) {
++  // Drive both their handshakes to completion.
++  for (;;) {
++    int client_ret = SSL_do_handshake(client);
++    int client_err = SSL_get_error(client, client_ret);
++    if (client_err != SSL_ERROR_NONE &&
++        client_err != SSL_ERROR_WANT_READ &&
++        client_err != SSL_ERROR_WANT_WRITE &&
++#ifdef SSL_ERROR_PENDING_TICKET
++        client_err != SSL_ERROR_PENDING_TICKET) {
++#else
++        true) {
++#endif
++      fprintf(stderr, "Client error: %s\n", SSL_error_description(client_err));
++      return false;
++    }
++
++    int server_ret = SSL_do_handshake(server);
++    int server_err = SSL_get_error(server, server_ret);
++    if (server_err != SSL_ERROR_NONE &&
++        server_err != SSL_ERROR_WANT_READ &&
++        server_err != SSL_ERROR_WANT_WRITE &&
++#ifdef SSL_ERROR_PENDING_TICKET
++        server_err != SSL_ERROR_PENDING_TICKET) {
++#else
++        true) {
++#endif
++      fprintf(stderr, "Server error: %s\n", SSL_error_description(server_err));
++      return false;
++    }
++
++    if (client_ret == 1 && server_ret == 1) {
++      break;
++    }
++  }
+ 
+-//   return true;
+-// }
++  return true;
++}
+ 
+ // static bool FlushNewSessionTickets(SSL *client, SSL *server) {
+ //   // NewSessionTickets are deferred on the server to |SSL_write|, and clients do
+@@ -1473,74 +1490,90 @@
+ // CreateClientAndServer creates a client and server |SSL| objects whose |BIO|s
+ // are paired with each other. It does not run the handshake. The caller is
+ // expected to configure the objects and drive the handshake as needed.
+-// static bool CreateClientAndServer(bssl::UniquePtr<SSL> *out_client,
+-//                                   bssl::UniquePtr<SSL> *out_server,
+-//                                   SSL_CTX *client_ctx, SSL_CTX *server_ctx) {
+-//   bssl::UniquePtr<SSL> client(SSL_new(client_ctx)), server(SSL_new(server_ctx));
+-//   if (!client || !server) {
+-//     return false;
+-//   }
+-//   SSL_set_connect_state(client.get());
+-//   SSL_set_accept_state(server.get());
+-
+-//   BIO *bio1, *bio2;
+-//   if (!BIO_new_bio_pair(&bio1, 0, &bio2, 0)) {
+-//     return false;
+-//   }
+-//   // SSL_set_bio takes ownership.
+-//   SSL_set_bio(client.get(), bio1, bio1);
+-//   SSL_set_bio(server.get(), bio2, bio2);
+-
+-//   *out_client = std::move(client);
+-//   *out_server = std::move(server);
+-//   return true;
+-// }
+-
+-// struct ClientConfig {
+-//   SSL_SESSION *session = nullptr;
+-//   std::string servername;
+-//   std::string verify_hostname;
+-//   unsigned hostflags = 0;
+-//   bool early_data = false;
+-// };
+-
+-// static bool ConnectClientAndServer(bssl::UniquePtr<SSL> *out_client,
+-//                                    bssl::UniquePtr<SSL> *out_server,
+-//                                    SSL_CTX *client_ctx, SSL_CTX *server_ctx,
+-//                                    const ClientConfig &config = ClientConfig(),
+-//                                    bool shed_handshake_config = true) {
+-//   bssl::UniquePtr<SSL> client, server;
+-//   if (!CreateClientAndServer(&client, &server, client_ctx, server_ctx)) {
+-//     return false;
+-//   }
+-//   if (config.early_data) {
+-//     SSL_set_early_data_enabled(client.get(), 1);
+-//   }
+-//   if (config.session) {
+-//     SSL_set_session(client.get(), config.session);
+-//   }
+-//   if (!config.servername.empty() &&
+-//       !SSL_set_tlsext_host_name(client.get(), config.servername.c_str())) {
+-//     return false;
+-//   }
+-//   if (!config.verify_hostname.empty()) {
+-//     if (!SSL_set1_host(client.get(), config.verify_hostname.c_str())) {
+-//       return false;
+-//     }
+-//     SSL_set_hostflags(client.get(), config.hostflags);
+-//   }
+-
+-//   SSL_set_shed_handshake_config(client.get(), shed_handshake_config);
+-//   SSL_set_shed_handshake_config(server.get(), shed_handshake_config);
+-
+-//   if (!CompleteHandshakes(client.get(), server.get())) {
+-//     return false;
+-//   }
+-
+-//   *out_client = std::move(client);
+-//   *out_server = std::move(server);
+-//   return true;
+-// }
++static bool CreateClientAndServer(bssl::UniquePtr<SSL> *out_client,
++                                  bssl::UniquePtr<SSL> *out_server,
++                                  SSL_CTX *client_ctx, SSL_CTX *server_ctx) {
++  bssl::UniquePtr<SSL> client(SSL_new(client_ctx)), server(SSL_new(server_ctx));
++  if (!client || !server) {
++    return false;
++  }
++  SSL_set_connect_state(client.get());
++  SSL_set_accept_state(server.get());
++
++  BIO *bio1, *bio2;
++  if (!BIO_new_bio_pair(&bio1, 0, &bio2, 0)) {
++    return false;
++  }
++  // SSL_set_bio takes ownership.
++  SSL_set_bio(client.get(), bio1, bio1);
++  SSL_set_bio(server.get(), bio2, bio2);
++
++  *out_client = std::move(client);
++  *out_server = std::move(server);
++  return true;
++}
++
++struct ClientConfig {
++  SSL_SESSION *session = nullptr;
++  std::string servername;
++  std::string verify_hostname;
++  unsigned hostflags = 0;
++  bool early_data = false;
++};
++
++static bool ConnectClientAndServer(bssl::UniquePtr<SSL> *out_client,
++                                   bssl::UniquePtr<SSL> *out_server,
++                                   SSL_CTX *client_ctx, SSL_CTX *server_ctx,
++                                   const ClientConfig &config = ClientConfig(),
++                                   bool shed_handshake_config = true) {
++  bssl::UniquePtr<SSL> client, server;
++  if (!CreateClientAndServer(&client, &server, client_ctx, server_ctx)) {
++    return false;
++  }
++  if (config.early_data) {
++#ifndef BSSL_COMPAT
++    SSL_set_early_data_enabled(client.get(), 1);
++#else
++    std::cout << __FILE__ << ":" << __LINE__ << " Skipped SSL_set_early_data_enabled()" << std::endl;
++    return false;
++#endif
++  }
++  if (config.session) {
++    SSL_set_session(client.get(), config.session);
++  }
++  if (!config.servername.empty() &&
++      !SSL_set_tlsext_host_name(client.get(), config.servername.c_str())) {
++    return false;
++  }
++  if (!config.verify_hostname.empty()) {
++#ifndef BSSL_COMPAT
++    if (!SSL_set1_host(client.get(), config.verify_hostname.c_str())) {
++      return false;
++    }
++    SSL_set_hostflags(client.get(), config.hostflags);
++#else
++    std::cout << "WARNING: Skipped SSL_set1_host() & SSL_set_hostflags()" << std::endl;
++    return false;
++#endif
++  }
++
++#ifndef BSSL_COMPAT
++  SSL_set_shed_handshake_config(client.get(), shed_handshake_config);
++  SSL_set_shed_handshake_config(server.get(), shed_handshake_config);
++#else
++  if(shed_handshake_config) {
++    std::cout << "WARNING: Skipped SSL_set_shed_handshake_config()" << std::endl;
++  }
++#endif
++
++  if (!CompleteHandshakes(client.get(), server.get())) {
++    return false;
++  }
++
++  *out_client = std::move(client);
++  *out_server = std::move(server);
++  return true;
++}
+ 
+ // static bssl::UniquePtr<SSL_SESSION> g_last_session;
+ 
+@@ -2495,62 +2528,71 @@
+ // SSLVersionTest executes its test cases under all available protocol versions.
+ // Test cases call |Connect| to create a connection using context objects with
+ // the protocol version fixed to the current version under test.
+-// class SSLVersionTest : public ::testing::TestWithParam<VersionParam> {
+-//  protected:
+-//   SSLVersionTest() : cert_(GetTestCertificate()), key_(GetTestKey()) {}
+-
+-//   void SetUp() { ResetContexts(); }
+-
+-//   bssl::UniquePtr<SSL_CTX> CreateContext() const {
+-//     const SSL_METHOD *method = is_dtls() ? DTLS_method() : TLS_method();
+-//     bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(method));
+-//     if (!ctx || !SSL_CTX_set_min_proto_version(ctx.get(), version()) ||
+-//         !SSL_CTX_set_max_proto_version(ctx.get(), version())) {
+-//       return nullptr;
+-//     }
+-//     return ctx;
+-//   }
+-
+-//   void ResetContexts() {
+-//     ASSERT_TRUE(cert_);
+-//     ASSERT_TRUE(key_);
+-//     client_ctx_ = CreateContext();
+-//     ASSERT_TRUE(client_ctx_);
+-//     server_ctx_ = CreateContext();
+-//     ASSERT_TRUE(server_ctx_);
+-//     // Set up a server cert. Client certs can be set up explicitly.
+-//     ASSERT_TRUE(UseCertAndKey(server_ctx_.get()));
+-//   }
+-
+-//   bool UseCertAndKey(SSL_CTX *ctx) const {
+-//     return SSL_CTX_use_certificate(ctx, cert_.get()) &&
+-//            SSL_CTX_use_PrivateKey(ctx, key_.get());
+-//   }
+-
+-//   bool Connect(const ClientConfig &config = ClientConfig()) {
+-//     return ConnectClientAndServer(&client_, &server_, client_ctx_.get(),
+-//                                   server_ctx_.get(), config,
+-//                                   shed_handshake_config_);
+-//   }
+-
+-//   uint16_t version() const { return GetParam().version; }
+-
+-//   bool is_dtls() const {
+-//     return GetParam().ssl_method == VersionParam::is_dtls;
+-//   }
+-
+-//   bool shed_handshake_config_ = true;
+-//   bssl::UniquePtr<SSL> client_, server_;
+-//   bssl::UniquePtr<SSL_CTX> server_ctx_, client_ctx_;
+-//   bssl::UniquePtr<X509> cert_;
+-//   bssl::UniquePtr<EVP_PKEY> key_;
+-// };
+-
+-// INSTANTIATE_TEST_SUITE_P(WithVersion, SSLVersionTest,
+-//                          testing::ValuesIn(kAllVersions),
+-//                          [](const testing::TestParamInfo<VersionParam> &i) {
+-//                            return i.param.name;
+-//                          });
++class SSLVersionTest : public ::testing::TestWithParam<VersionParam> {
++ protected:
++  SSLVersionTest() : cert_(GetTestCertificate()), key_(GetTestKey()) {}
++
++  void SetUp() { ResetContexts(); }
++
++  bssl::UniquePtr<SSL_CTX> CreateContext() const {
++    const SSL_METHOD *method = is_dtls() ? DTLS_method() : TLS_method();
++    bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(method));
++    if (!ctx || !SSL_CTX_set_min_proto_version(ctx.get(), version()) ||
++        !SSL_CTX_set_max_proto_version(ctx.get(), version())) {
++      return nullptr;
++    }
++    return ctx;
++  }
++
++  void ResetContexts() {
++    ASSERT_TRUE(cert_);
++    ASSERT_TRUE(key_);
++    client_ctx_ = CreateContext();
++    ASSERT_TRUE(client_ctx_);
++    server_ctx_ = CreateContext();
++    ASSERT_TRUE(server_ctx_);
++    // Set up a server cert. Client certs can be set up explicitly.
++    ASSERT_TRUE(UseCertAndKey(server_ctx_.get())) << ERR_error_string(ERR_get_error(), nullptr);
++  }
++
++  bool UseCertAndKey(SSL_CTX *ctx) const {
++#ifdef BSSL_COMPAT
++    // By default, OpenSSL 3 doesn't like keys less than 2048 bits, so we
++    // have to drop the security level to 1 so that it will accept them.
++    bssl::UniquePtr<EVP_PKEY> pkey {X509_get_pubkey(cert_.get())};
++    if(ossl_EVP_PKEY_bits(pkey.get()) < 2048) {
++      std::cerr << "WARNING: ossl_SSL_CTX_set_security_level(server_ctx_.get(), 1)" << std::endl;
++      ossl_SSL_CTX_set_security_level(ctx, 1);
++    }
++#endif
++    return SSL_CTX_use_certificate(ctx, cert_.get()) &&
++           SSL_CTX_use_PrivateKey(ctx, key_.get());
++  }
++
++  bool Connect(const ClientConfig &config = ClientConfig()) {
++    return ConnectClientAndServer(&client_, &server_, client_ctx_.get(),
++                                  server_ctx_.get(), config,
++                                  shed_handshake_config_);
++  }
++
++  uint16_t version() const { return GetParam().version; }
++
++  bool is_dtls() const {
++    return GetParam().ssl_method == VersionParam::is_dtls;
++  }
++
++  bool shed_handshake_config_ = true;
++  bssl::UniquePtr<SSL> client_, server_;
++  bssl::UniquePtr<SSL_CTX> server_ctx_, client_ctx_;
++  bssl::UniquePtr<X509> cert_;
++  bssl::UniquePtr<EVP_PKEY> key_;
++};
++
++INSTANTIATE_TEST_SUITE_P(WithVersion, SSLVersionTest,
++                         testing::ValuesIn(kAllVersions),
++                         [](const testing::TestParamInfo<VersionParam> &i) {
++                           return i.param.name;
++                         });
+ 
+ // TEST_P(SSLVersionTest, SequenceNumber) {
+ //   ASSERT_TRUE(Connect());
+@@ -2591,110 +2633,110 @@
+ //   EXPECT_EQ(server_read_seq + 1, SSL_get_read_sequence(server_.get()));
+ // }
+ 
+-// TEST_P(SSLVersionTest, OneSidedShutdown) {
+-//   // SSL_shutdown is a no-op in DTLS.
+-//   if (is_dtls()) {
+-//     return;
+-//   }
+-//   ASSERT_TRUE(Connect());
+-
+-//   // Shut down half the connection. |SSL_shutdown| will return 0 to signal only
+-//   // one side has shut down.
+-//   ASSERT_EQ(SSL_shutdown(client_.get()), 0);
+-
+-//   // Reading from the server should consume the EOF.
+-//   uint8_t byte;
+-//   ASSERT_EQ(SSL_read(server_.get(), &byte, 1), 0);
+-//   ASSERT_EQ(SSL_get_error(server_.get(), 0), SSL_ERROR_ZERO_RETURN);
+-
+-//   // However, the server may continue to write data and then shut down the
+-//   // connection.
+-//   byte = 42;
+-//   ASSERT_EQ(SSL_write(server_.get(), &byte, 1), 1);
+-//   ASSERT_EQ(SSL_read(client_.get(), &byte, 1), 1);
+-//   ASSERT_EQ(byte, 42);
+-
+-//   // The server may then shutdown the connection.
+-//   EXPECT_EQ(SSL_shutdown(server_.get()), 1);
+-//   EXPECT_EQ(SSL_shutdown(client_.get()), 1);
+-// }
++TEST_P(SSLVersionTest, OneSidedShutdown) {
++  // SSL_shutdown is a no-op in DTLS.
++  if (is_dtls()) {
++    return;
++  }
++  ASSERT_TRUE(Connect());
++
++  // Shut down half the connection. |SSL_shutdown| will return 0 to signal only
++  // one side has shut down.
++  ASSERT_EQ(SSL_shutdown(client_.get()), 0);
++
++  // Reading from the server should consume the EOF.
++  uint8_t byte;
++  ASSERT_EQ(SSL_read(server_.get(), &byte, 1), 0);
++  ASSERT_EQ(SSL_get_error(server_.get(), 0), SSL_ERROR_ZERO_RETURN);
++
++  // However, the server may continue to write data and then shut down the
++  // connection.
++  byte = 42;
++  ASSERT_EQ(SSL_write(server_.get(), &byte, 1), 1);
++  ASSERT_EQ(SSL_read(client_.get(), &byte, 1), 1);
++  ASSERT_EQ(byte, 42);
++
++  // The server may then shutdown the connection.
++  EXPECT_EQ(SSL_shutdown(server_.get()), 1);
++  EXPECT_EQ(SSL_shutdown(client_.get()), 1);
++}
+ 
+ // Test that, after calling |SSL_shutdown|, |SSL_write| fails.
+-// TEST_P(SSLVersionTest, WriteAfterShutdown) {
+-//   ASSERT_TRUE(Connect());
+-
+-//   for (SSL *ssl : {client_.get(), server_.get()}) {
+-//     SCOPED_TRACE(SSL_is_server(ssl) ? "server" : "client");
+-
+-//     bssl::UniquePtr<BIO> mem(BIO_new(BIO_s_mem()));
+-//     ASSERT_TRUE(mem);
+-//     SSL_set0_wbio(ssl, bssl::UpRef(mem).release());
+-
+-//     // Shut down half the connection. |SSL_shutdown| will return 0 to signal
+-//     // only one side has shut down.
+-//     ASSERT_EQ(SSL_shutdown(ssl), 0);
++TEST_P(SSLVersionTest, WriteAfterShutdown) {
++  ASSERT_TRUE(Connect());
+ 
+-//     // |ssl| should have written an alert to the transport.
+-//     const uint8_t *unused;
+-//     size_t len;
+-//     ASSERT_TRUE(BIO_mem_contents(mem.get(), &unused, &len));
+-//     EXPECT_NE(0u, len);
+-//     EXPECT_TRUE(BIO_reset(mem.get()));
++  for (SSL *ssl : {client_.get(), server_.get()}) {
++    SCOPED_TRACE(SSL_is_server(ssl) ? "server" : "client");
+ 
+-//     // Writing should fail.
+-//     EXPECT_EQ(-1, SSL_write(ssl, "a", 1));
+-
+-//     // Nothing should be written to the transport.
+-//     ASSERT_TRUE(BIO_mem_contents(mem.get(), &unused, &len));
+-//     EXPECT_EQ(0u, len);
+-//   }
+-// }
++    bssl::UniquePtr<BIO> mem(BIO_new(BIO_s_mem()));
++    ASSERT_TRUE(mem);
++    SSL_set0_wbio(ssl, bssl::UpRef(mem).release());
++
++    // Shut down half the connection. |SSL_shutdown| will return 0 to signal
++    // only one side has shut down.
++    ASSERT_EQ(SSL_shutdown(ssl), 0);
++
++    // |ssl| should have written an alert to the transport.
++    const uint8_t *unused;
++    size_t len;
++    ASSERT_TRUE(BIO_mem_contents(mem.get(), &unused, &len));
++    EXPECT_NE(0u, len);
++    EXPECT_TRUE(BIO_reset(mem.get()));
++
++    // Writing should fail.
++    EXPECT_EQ(-1, SSL_write(ssl, "a", 1));
++
++    // Nothing should be written to the transport.
++    ASSERT_TRUE(BIO_mem_contents(mem.get(), &unused, &len));
++    EXPECT_EQ(0u, len);
++  }
++}
+ 
+ // Test that, after sending a fatal alert in a failed |SSL_read|, |SSL_write|
+ // fails.
+-// TEST_P(SSLVersionTest, WriteAfterReadSentFatalAlert) {
+-//   // Decryption failures are not fatal in DTLS.
+-//   if (is_dtls()) {
+-//     return;
+-//   }
+-
+-//   ASSERT_TRUE(Connect());
+-
+-//   // Save the write |BIO|s as the test will overwrite them.
+-//   bssl::UniquePtr<BIO> client_wbio = bssl::UpRef(SSL_get_wbio(client_.get()));
+-//   bssl::UniquePtr<BIO> server_wbio = bssl::UpRef(SSL_get_wbio(server_.get()));
+-
+-//   for (bool test_server : {false, true}) {
+-//     SCOPED_TRACE(test_server ? "server" : "client");
+-//     SSL *ssl = test_server ? server_.get() : client_.get();
+-//     BIO *other_wbio = test_server ? client_wbio.get() : server_wbio.get();
+-
+-//     bssl::UniquePtr<BIO> mem(BIO_new(BIO_s_mem()));
+-//     ASSERT_TRUE(mem);
+-//     SSL_set0_wbio(ssl, bssl::UpRef(mem).release());
+-
+-//     // Read an invalid record from the peer.
+-//     static const uint8_t kInvalidRecord[] = "invalid record";
+-//     EXPECT_EQ(int{sizeof(kInvalidRecord)},
+-//               BIO_write(other_wbio, kInvalidRecord, sizeof(kInvalidRecord)));
+-//     char buf[256];
+-//     EXPECT_EQ(-1, SSL_read(ssl, buf, sizeof(buf)));
+-
+-//     // |ssl| should have written an alert to the transport.
+-//     const uint8_t *unused;
+-//     size_t len;
+-//     ASSERT_TRUE(BIO_mem_contents(mem.get(), &unused, &len));
+-//     EXPECT_NE(0u, len);
+-//     EXPECT_TRUE(BIO_reset(mem.get()));
+-
+-//     // Writing should fail.
+-//     EXPECT_EQ(-1, SSL_write(ssl, "a", 1));
+-
+-//     // Nothing should be written to the transport.
+-//     ASSERT_TRUE(BIO_mem_contents(mem.get(), &unused, &len));
+-//     EXPECT_EQ(0u, len);
+-//   }
+-// }
++TEST_P(SSLVersionTest, WriteAfterReadSentFatalAlert) {
++  // Decryption failures are not fatal in DTLS.
++  if (is_dtls()) {
++    return;
++  }
++
++  ASSERT_TRUE(Connect());
++
++  // Save the write |BIO|s as the test will overwrite them.
++  bssl::UniquePtr<BIO> client_wbio = bssl::UpRef(SSL_get_wbio(client_.get()));
++  bssl::UniquePtr<BIO> server_wbio = bssl::UpRef(SSL_get_wbio(server_.get()));
++
++  for (bool test_server : {false, true}) {
++    SCOPED_TRACE(test_server ? "server" : "client");
++    SSL *ssl = test_server ? server_.get() : client_.get();
++    BIO *other_wbio = test_server ? client_wbio.get() : server_wbio.get();
++
++    bssl::UniquePtr<BIO> mem(BIO_new(BIO_s_mem()));
++    ASSERT_TRUE(mem);
++    SSL_set0_wbio(ssl, bssl::UpRef(mem).release());
++
++    // Read an invalid record from the peer.
++    static const uint8_t kInvalidRecord[] = "invalid record";
++    EXPECT_EQ(int{sizeof(kInvalidRecord)},
++              BIO_write(other_wbio, kInvalidRecord, sizeof(kInvalidRecord)));
++    char buf[256];
++    EXPECT_EQ(-1, SSL_read(ssl, buf, sizeof(buf)));
++
++    // |ssl| should have written an alert to the transport.
++    const uint8_t *unused;
++    size_t len;
++    ASSERT_TRUE(BIO_mem_contents(mem.get(), &unused, &len));
++    EXPECT_NE(0u, len);
++    EXPECT_TRUE(BIO_reset(mem.get()));
++
++    // Writing should fail.
++    EXPECT_EQ(-1, SSL_write(ssl, "a", 1));
++
++    // Nothing should be written to the transport.
++    ASSERT_TRUE(BIO_mem_contents(mem.get(), &unused, &len));
++    EXPECT_EQ(0u, len);
++  }
++}
+ 
+ // Test that, after sending a fatal alert from the handshake, |SSL_write| fails.
+ // TEST_P(SSLVersionTest, WriteAfterHandshakeSentFatalAlert) {
+@@ -2935,97 +2977,101 @@
+ //   // is correct.
+ // }
+ 
+-// TEST(SSLTest, SetBIO) {
+-//   bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+-//   ASSERT_TRUE(ctx);
+-
+-//   bssl::UniquePtr<SSL> ssl(SSL_new(ctx.get()));
+-//   bssl::UniquePtr<BIO> bio1(BIO_new(BIO_s_mem())), bio2(BIO_new(BIO_s_mem())),
+-//       bio3(BIO_new(BIO_s_mem()));
+-//   ASSERT_TRUE(ssl);
+-//   ASSERT_TRUE(bio1);
+-//   ASSERT_TRUE(bio2);
+-//   ASSERT_TRUE(bio3);
+-
+-//   // SSL_set_bio takes one reference when the parameters are the same.
+-//   BIO_up_ref(bio1.get());
+-//   SSL_set_bio(ssl.get(), bio1.get(), bio1.get());
+-
+-//   // Repeating the call does nothing.
+-//   SSL_set_bio(ssl.get(), bio1.get(), bio1.get());
+-
+-//   // It takes one reference each when the parameters are different.
+-//   BIO_up_ref(bio2.get());
+-//   BIO_up_ref(bio3.get());
+-//   SSL_set_bio(ssl.get(), bio2.get(), bio3.get());
+-
+-//   // Repeating the call does nothing.
+-//   SSL_set_bio(ssl.get(), bio2.get(), bio3.get());
+-
+-//   // It takes one reference when changing only wbio.
+-//   BIO_up_ref(bio1.get());
+-//   SSL_set_bio(ssl.get(), bio2.get(), bio1.get());
+-
+-//   // It takes one reference when changing only rbio and the two are different.
+-//   BIO_up_ref(bio3.get());
+-//   SSL_set_bio(ssl.get(), bio3.get(), bio1.get());
+-
+-//   // If setting wbio to rbio, it takes no additional references.
+-//   SSL_set_bio(ssl.get(), bio3.get(), bio3.get());
+-
+-//   // From there, wbio may be switched to something else.
+-//   BIO_up_ref(bio1.get());
+-//   SSL_set_bio(ssl.get(), bio3.get(), bio1.get());
+-
+-//   // If setting rbio to wbio, it takes no additional references.
+-//   SSL_set_bio(ssl.get(), bio1.get(), bio1.get());
+-
+-//   // From there, rbio may be switched to something else, but, for historical
+-//   // reasons, it takes a reference to both parameters.
+-//   BIO_up_ref(bio1.get());
+-//   BIO_up_ref(bio2.get());
+-//   SSL_set_bio(ssl.get(), bio2.get(), bio1.get());
+-
+-//   // ASAN builds will implicitly test that the internal |BIO| reference-counting
+-//   // is correct.
+-// }
+-
+-// static int VerifySucceed(X509_STORE_CTX *store_ctx, void *arg) { return 1; }
+-
+-// TEST_P(SSLVersionTest, GetPeerCertificate) {
+-//   ASSERT_TRUE(UseCertAndKey(client_ctx_.get()));
+-
+-//   // Configure both client and server to accept any certificate.
+-//   SSL_CTX_set_verify(client_ctx_.get(),
+-//                      SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
+-//                      nullptr);
+-//   SSL_CTX_set_cert_verify_callback(client_ctx_.get(), VerifySucceed, NULL);
+-//   SSL_CTX_set_verify(server_ctx_.get(),
+-//                      SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
+-//                      nullptr);
+-//   SSL_CTX_set_cert_verify_callback(server_ctx_.get(), VerifySucceed, NULL);
+-
+-//   ASSERT_TRUE(Connect());
+-
+-//   // Client and server should both see the leaf certificate.
+-//   bssl::UniquePtr<X509> peer(SSL_get_peer_certificate(server_.get()));
+-//   ASSERT_TRUE(peer);
+-//   ASSERT_EQ(X509_cmp(cert_.get(), peer.get()), 0);
+-
+-//   peer.reset(SSL_get_peer_certificate(client_.get()));
+-//   ASSERT_TRUE(peer);
+-//   ASSERT_EQ(X509_cmp(cert_.get(), peer.get()), 0);
+-
+-//   // However, for historical reasons, the X509 chain includes the leaf on the
+-//   // client, but does not on the server.
+-//   EXPECT_EQ(sk_X509_num(SSL_get_peer_cert_chain(client_.get())), 1u);
+-//   EXPECT_EQ(sk_CRYPTO_BUFFER_num(SSL_get0_peer_certificates(client_.get())),
+-//             1u);
+-
+-//   EXPECT_EQ(sk_X509_num(SSL_get_peer_cert_chain(server_.get())), 0u);
+-//   EXPECT_EQ(sk_CRYPTO_BUFFER_num(SSL_get0_peer_certificates(server_.get())),
+-//             1u);
+-// }
++TEST(SSLTest, SetBIO) {
++  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
++  ASSERT_TRUE(ctx);
++
++  bssl::UniquePtr<SSL> ssl(SSL_new(ctx.get()));
++  bssl::UniquePtr<BIO> bio1(BIO_new(BIO_s_mem())), bio2(BIO_new(BIO_s_mem())),
++      bio3(BIO_new(BIO_s_mem()));
++  ASSERT_TRUE(ssl);
++  ASSERT_TRUE(bio1);
++  ASSERT_TRUE(bio2);
++  ASSERT_TRUE(bio3);
++
++  // SSL_set_bio takes one reference when the parameters are the same.
++  BIO_up_ref(bio1.get());
++  SSL_set_bio(ssl.get(), bio1.get(), bio1.get());
++
++  // Repeating the call does nothing.
++  SSL_set_bio(ssl.get(), bio1.get(), bio1.get());
++
++  // It takes one reference each when the parameters are different.
++  BIO_up_ref(bio2.get());
++  BIO_up_ref(bio3.get());
++  SSL_set_bio(ssl.get(), bio2.get(), bio3.get());
++
++  // Repeating the call does nothing.
++  SSL_set_bio(ssl.get(), bio2.get(), bio3.get());
++
++  // It takes one reference when changing only wbio.
++  BIO_up_ref(bio1.get());
++  SSL_set_bio(ssl.get(), bio2.get(), bio1.get());
++
++  // It takes one reference when changing only rbio and the two are different.
++  BIO_up_ref(bio3.get());
++  SSL_set_bio(ssl.get(), bio3.get(), bio1.get());
++
++  // If setting wbio to rbio, it takes no additional references.
++  SSL_set_bio(ssl.get(), bio3.get(), bio3.get());
++
++  // From there, wbio may be switched to something else.
++  BIO_up_ref(bio1.get());
++  SSL_set_bio(ssl.get(), bio3.get(), bio1.get());
++
++  // If setting rbio to wbio, it takes no additional references.
++  SSL_set_bio(ssl.get(), bio1.get(), bio1.get());
++
++  // From there, rbio may be switched to something else, but, for historical
++  // reasons, it takes a reference to both parameters.
++  BIO_up_ref(bio1.get());
++  BIO_up_ref(bio2.get());
++  SSL_set_bio(ssl.get(), bio2.get(), bio1.get());
++
++  // ASAN builds will implicitly test that the internal |BIO| reference-counting
++  // is correct.
++}
++
++static int VerifySucceed(X509_STORE_CTX *store_ctx, void *arg) { return 1; }
++
++TEST_P(SSLVersionTest, GetPeerCertificate) {
++  ASSERT_TRUE(UseCertAndKey(client_ctx_.get()));
++
++  // Configure both client and server to accept any certificate.
++  SSL_CTX_set_verify(client_ctx_.get(),
++                     SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
++                     nullptr);
++  SSL_CTX_set_cert_verify_callback(client_ctx_.get(), VerifySucceed, NULL);
++  SSL_CTX_set_verify(server_ctx_.get(),
++                     SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT,
++                     nullptr);
++  SSL_CTX_set_cert_verify_callback(server_ctx_.get(), VerifySucceed, NULL);
++
++  ASSERT_TRUE(Connect());
++
++  // Client and server should both see the leaf certificate.
++  bssl::UniquePtr<X509> peer(SSL_get_peer_certificate(server_.get()));
++  ASSERT_TRUE(peer);
++  ASSERT_EQ(X509_cmp(cert_.get(), peer.get()), 0);
++
++  peer.reset(SSL_get_peer_certificate(client_.get()));
++  ASSERT_TRUE(peer);
++  ASSERT_EQ(X509_cmp(cert_.get(), peer.get()), 0);
++
++  // However, for historical reasons, the X509 chain includes the leaf on the
++  // client, but does not on the server.
++  EXPECT_EQ(sk_X509_num(SSL_get_peer_cert_chain(client_.get())), 1u);
++#ifndef BSSL_COMPAT // Envoy doesn't need SSL_get0_peer_certificates() so skip this
++  EXPECT_EQ(sk_CRYPTO_BUFFER_num(SSL_get0_peer_certificates(client_.get())),
++            1u);
++#endif
++
++  EXPECT_EQ(sk_X509_num(SSL_get_peer_cert_chain(server_.get())), 0u);
++#ifndef BSSL_COMPAT // Envoy doesn't need SSL_get0_peer_certificates() so skip this
++  EXPECT_EQ(sk_CRYPTO_BUFFER_num(SSL_get0_peer_certificates(server_.get())),
++            1u);
++#endif
++}
+ 
+ // TEST_P(SSLVersionTest, NoPeerCertificate) {
+ //   SSL_CTX_set_verify(server_ctx_.get(), SSL_VERIFY_PEER, nullptr);
+@@ -4214,43 +4260,46 @@
  //   X509_cmp(cert, cert);
  // }
  
@@ -254,7 +1110,7 @@
  
  // TEST(SSLTest, SetChainAndKeyMismatch) {
  //   bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_with_buffers_method()));
-@@ -4920,33 +4927,37 @@
+@@ -4920,33 +4969,37 @@
  // }
  
  // The client should gracefully handle no suitable ciphers being enabled.
@@ -319,7 +1175,7 @@
  
  // TEST_P(SSLVersionTest, SessionVersion) {
  //   SSL_CTX_set_session_cache_mode(client_ctx_.get(), SSL_SESS_CACHE_BOTH);
-@@ -5721,25 +5732,28 @@
+@@ -5721,25 +5774,28 @@
  // }
  
  // SSL_CTX_get0_certificate needs to lock internally. Test this works.
@@ -367,7 +1223,7 @@
  
  // Functions which access properties on the negotiated session are thread-safe
  // where needed. Prior to TLS 1.3, clients resuming sessions and servers
-@@ -8260,5 +8274,5 @@
+@@ -8260,5 +8316,5 @@
  //   }
  // }
  

--- a/bssl-compat/source/BIO_up_ref.cc
+++ b/bssl-compat/source/BIO_up_ref.cc
@@ -1,0 +1,12 @@
+#include <openssl/bio.h>
+#include <ossl/openssl/bio.h>
+
+
+/*
+ * OSSL: https://www.openssl.org/docs/man1.1.1/man3/BIO_up_ref.html
+ * BSSL: https://github.com/google/boringssl/blob/cacb5526268191ab52e3a8b2d71f686115776646/src/include/openssl/bio.h#L101
+ */
+extern "C" int BIO_up_ref(BIO *bio) {
+  return ossl_BIO_up_ref(bio);
+}
+

--- a/bssl-compat/source/DTLS_method.cc
+++ b/bssl-compat/source/DTLS_method.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+extern "C" const SSL_METHOD *DTLS_method(void) {
+  return ossl_DTLS_method();
+}

--- a/bssl-compat/source/PEM_read_bio_PrivateKey.cc
+++ b/bssl-compat/source/PEM_read_bio_PrivateKey.cc
@@ -1,0 +1,7 @@
+#include <openssl/pem.h>
+#include <ossl.h>
+
+
+extern "C" EVP_PKEY *PEM_read_bio_PrivateKey(BIO *bp, EVP_PKEY **x, pem_password_cb *cb, void *u) {
+  return ossl.ossl_PEM_read_bio_PrivateKey(bp, x, cb, u);
+}

--- a/bssl-compat/source/SSL_CTX_set_cert_verify_callback.cc
+++ b/bssl-compat/source/SSL_CTX_set_cert_verify_callback.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+extern "C" void SSL_CTX_set_cert_verify_callback(SSL_CTX *ctx, int (*callback)(X509_STORE_CTX *store_ctx, void *arg), void *arg) {
+  ossl_SSL_CTX_set_cert_verify_callback(ctx, callback, arg);
+}

--- a/bssl-compat/source/SSL_CTX_use_PrivateKey.cc
+++ b/bssl-compat/source/SSL_CTX_use_PrivateKey.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/ssl.h#L867
+ * https://www.openssl.org/docs/man3.0/man3/SSL_CTX_use_PrivateKey.html
+ */
+extern "C" int SSL_CTX_use_PrivateKey(SSL_CTX *ctx, EVP_PKEY *pkey) {
+  return (ossl_SSL_CTX_use_PrivateKey(ctx, pkey) == 1) ? 1 : 0;
+}

--- a/bssl-compat/source/SSL_get_peer_cert_chain.cc
+++ b/bssl-compat/source/SSL_get_peer_cert_chain.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+extern "C" STACK_OF(X509) *SSL_get_peer_cert_chain(const SSL *ssl) {
+  return (STACK_OF(X509)*)ossl_SSL_get_peer_cert_chain(ssl);
+}

--- a/bssl-compat/source/SSL_get_peer_certificate.cc
+++ b/bssl-compat/source/SSL_get_peer_certificate.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+extern "C" X509 *SSL_get_peer_certificate(const SSL *ssl) {
+  return ossl_SSL_get_peer_certificate(ssl);
+}

--- a/bssl-compat/source/SSL_get_wbio.cc
+++ b/bssl-compat/source/SSL_get_wbio.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+extern "C" BIO *SSL_get_wbio(const SSL *ssl) {
+  return ossl_SSL_get_wbio(ssl);
+}

--- a/bssl-compat/source/SSL_set_accept_state.cc
+++ b/bssl-compat/source/SSL_set_accept_state.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+extern "C" void SSL_set_accept_state(SSL *ssl) {
+  ossl_SSL_set_accept_state(ssl);
+}

--- a/bssl-compat/source/SSL_set_bio.cc
+++ b/bssl-compat/source/SSL_set_bio.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+extern "C" void SSL_set_bio(SSL *ssl, BIO *rbio, BIO *wbio) {
+  ossl_SSL_set_bio(ssl, rbio, wbio);
+}

--- a/bssl-compat/source/SSL_set_connect_state.cc
+++ b/bssl-compat/source/SSL_set_connect_state.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+extern "C" void SSL_set_connect_state(SSL *ssl) {
+  ossl_SSL_set_connect_state(ssl);
+}

--- a/bssl-compat/source/SSL_set_session.cc
+++ b/bssl-compat/source/SSL_set_session.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+extern "C" int SSL_set_session(SSL *ssl, SSL_SESSION *session) {
+  return ossl_SSL_set_session(ssl, session);
+}

--- a/bssl-compat/source/SSL_version.cc
+++ b/bssl-compat/source/SSL_version.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+extern "C" int SSL_version(const SSL *ssl) {
+  return ossl_SSL_version(ssl);
+}

--- a/bssl-compat/source/SSL_write.cc
+++ b/bssl-compat/source/SSL_write.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+int SSL_write(SSL *ssl, const void *buf, int num) {
+  return ossl_SSL_write(ssl, buf, num);
+}

--- a/bssl-compat/source/TLS_method.cc
+++ b/bssl-compat/source/TLS_method.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+const SSL_METHOD *TLS_method(void) {
+  return ossl_TLS_method();
+}

--- a/bssl-compat/source/X509_get_pubkey.cc
+++ b/bssl-compat/source/X509_get_pubkey.cc
@@ -1,0 +1,7 @@
+#include <openssl/x509.h>
+#include <ossl/openssl/x509.h>
+
+
+extern "C" EVP_PKEY *X509_get_pubkey(X509 *x509) {
+  return ossl_X509_get_pubkey(x509);
+}

--- a/bssl-compat/source/bio.cpp
+++ b/bssl-compat/source/bio.cpp
@@ -251,14 +251,6 @@ const BIO_METHOD *BIO_s_socket() {
 }
 
 /*
- * OSSL: https://www.openssl.org/docs/man1.1.1/man3/BIO_up_ref.html
- * BSSL: https://github.com/google/boringssl/blob/cacb5526268191ab52e3a8b2d71f686115776646/src/include/openssl/bio.h#L101
- */
-int BIO_up_ref(BIO *bio) {
-  return ossl_BIO_up_ref(bio);
-}
-
-/*
  * OSSL: https://www.openssl.org/docs/man1.1.1/man3/BIO_vfree.html
  * BSSL: https://github.com/google/boringssl/blob/cacb5526268191ab52e3a8b2d71f686115776646/src/include/openssl/bio.h#L98
  */

--- a/bssl-compat/source/extra/ssl_extra.ld
+++ b/bssl-compat/source/extra/ssl_extra.ld
@@ -18,7 +18,6 @@ PROVIDE(SSL_set_fd = ossl_SSL_set_fd);
 PROVIDE(SSL_shutdown = ossl_SSL_shutdown);
 PROVIDE(SSL_read = ossl_SSL_read);
 PROVIDE(SSL_write = ossl_SSL_write);
-PROVIDE(TLS_method = ossl_TLS_method);
 PROVIDE(SSL_SESSION_set_protocol_version = ossl_SSL_SESSION_set_protocol_version);
 PROVIDE(SSL_SESSION_free = ossl_SSL_SESSION_free);
 PROVIDE(SSL_is_server = ossl_SSL_is_server);

--- a/bssl-compat/source/extra/ssl_extra.ld
+++ b/bssl-compat/source/extra/ssl_extra.ld
@@ -17,7 +17,6 @@ PROVIDE(SSL_new = ossl_SSL_new);
 PROVIDE(SSL_set_fd = ossl_SSL_set_fd);
 PROVIDE(SSL_shutdown = ossl_SSL_shutdown);
 PROVIDE(SSL_read = ossl_SSL_read);
-PROVIDE(SSL_write = ossl_SSL_write);
 PROVIDE(SSL_SESSION_set_protocol_version = ossl_SSL_SESSION_set_protocol_version);
 PROVIDE(SSL_SESSION_free = ossl_SSL_SESSION_free);
 PROVIDE(SSL_is_server = ossl_SSL_is_server);

--- a/bssl-compat/source/ssl.c
+++ b/bssl-compat/source/ssl.c
@@ -177,10 +177,6 @@ void SSL_set0_wbio(SSL *ssl, BIO *wbio) {
   ossl_SSL_set0_wbio(ssl, wbio);
 }
 
-void SSL_set_connect_state(SSL *ssl) {
-  ossl_SSL_set_connect_state(ssl);
-}
-
 SSL_CTX *SSL_set_SSL_CTX(SSL *ssl, SSL_CTX *ctx) {
   return ossl_SSL_set_SSL_CTX(ssl, ctx);
 }

--- a/bssl-compat/source/ssl_ctx.c
+++ b/bssl-compat/source/ssl_ctx.c
@@ -99,14 +99,6 @@ int SSL_CTX_use_certificate(SSL_CTX *ctx, X509 *x509) {
   return (ret == 1) ? 1 : 0;
 }
 
-/*
- * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/ssl.h#L867
- * https://www.openssl.org/docs/man3.0/man3/SSL_CTX_use_PrivateKey.html
- */
-int SSL_CTX_use_PrivateKey(SSL_CTX *ctx, EVP_PKEY *pkey) {
-  return (ossl_SSL_CTX_use_PrivateKey(ctx, pkey) == 1) ? 1 : 0;
-}
-
 int SSL_CTX_set_cipher_list(SSL_CTX *ctx, const char *str) {
   return ossl_SSL_CTX_set_cipher_list(ctx, str);
 }


### PR DESCRIPTION
Added:

- TLS_method()
- SSL_write()
- SSL_version()
- SSL_set_accept_state()
- SSL_set_connect_state()
- SSL_set_bio()
- SSL_set_session()
- DTLS_method()
- SSL_CTX_use_PrivateKey()
- PEM_read_bio_PrivateKey()
- X509_get_pubkey()
- BIO_up_ref()
- SSL_get_wbio()
- SSL_CTX_set_cert_verify_callback()
- SSL_get_peer_certificate()
- SSL_get_peer_cert_chain()

Also, enabled the following BoringSSL unit tests:

- WithVersion/SSLVersionTest.OneSidedShutdown/*
- WithVersion/SSLVersionTest.WriteAfterShutdown/*
- WithVersion/SSLVersionTest.WriteAfterReadSentFatalAlert/*
- WithVersion/SSLVersionTest.GetPeerCertificate/*
- SSLTest.SetBIO
