### PR TITLE
OSSM-3364 Added more <openssl/ssl.h> functions

### DIFF
--- a/bssl-compat/.gitignore
+++ b/bssl-compat/.gitignore
@@ -96,4 +96,5 @@ source/crypto/test/test_util.h
 source/ossl.c
 source/ssl/
 source/ssl/internal.h
+source/ssl/ssl_c_test.c
 source/ssl/ssl_test.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -78,6 +78,7 @@ add_library(bssl-compat STATIC
   source/SSL_CTX_set_session_id_context.cc
   source/SSL_CTX_set_tlsext_servername_callback.cc
   source/SSL_CTX_set_tlsext_status_cb.c
+  source/SSL_CTX_set_tlsext_ticket_keys.cc
   source/SSL_CTX_set1_curves_list.c
   source/SSL_CTX_set1_sigalgs_list.c
   source/SSL_CTX_use_PrivateKey.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -97,6 +97,7 @@ add_library(bssl-compat STATIC
   source/SSL_SESSION_from_bytes.c
   source/SSL_SESSION_get_id.c
   source/SSL_SESSION_is_resumable.c
+  source/SSL_session_reused.cc
   source/SSL_SESSION_to_bytes.c
   source/SSL_set_accept_state.cc
   source/SSL_set_bio.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -76,6 +76,7 @@ add_library(bssl-compat STATIC
   source/SSL_CTX_set_cert_verify_callback.cc
   source/SSL_CTX_set_session_cache_mode.cc
   source/SSL_CTX_set_session_id_context.cc
+  source/SSL_CTX_set_tlsext_servername_callback.cc
   source/SSL_CTX_set_tlsext_status_cb.c
   source/SSL_CTX_set1_curves_list.c
   source/SSL_CTX_set1_sigalgs_list.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -110,6 +110,7 @@ add_library(bssl-compat STATIC
   source/SSL_set_session_id_context.cc
   source/SSL_set_session.cc
   source/SSL_set_tlsext_host_name.c
+  source/SSL_shutdown.cc
   source/SSL_version.cc
   source/SSL_write.cc
   source/ssl.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(bssl-compat STATIC
   source/ssl_cipher.c
   source/SSL_CTX_sess_set_new_cb.cc
   source/SSL_CTX_set_cert_verify_callback.cc
+  source/SSL_CTX_set_session_cache_mode.cc
   source/SSL_CTX_set_session_id_context.cc
   source/SSL_CTX_set_tlsext_status_cb.c
   source/SSL_CTX_set1_curves_list.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -72,6 +72,7 @@ add_library(bssl-compat STATIC
   source/rand.c
   source/RSA_free.c
   source/ssl_cipher.c
+  source/SSL_CTX_sess_set_new_cb.cc
   source/SSL_CTX_set_cert_verify_callback.cc
   source/SSL_CTX_set_tlsext_status_cb.c
   source/SSL_CTX_set1_curves_list.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -72,6 +72,8 @@ add_library(bssl-compat STATIC
   source/rand.c
   source/RSA_free.c
   source/ssl_cipher.c
+  source/SSL_CTX_get_min_proto_version.cc
+  source/SSL_CTX_get_max_proto_version.cc
   source/SSL_CTX_sess_set_new_cb.cc
   source/SSL_CTX_set_cert_verify_callback.cc
   source/SSL_CTX_set_session_cache_mode.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -74,6 +74,7 @@ add_library(bssl-compat STATIC
   source/ssl_cipher.c
   source/SSL_CTX_sess_set_new_cb.cc
   source/SSL_CTX_set_cert_verify_callback.cc
+  source/SSL_CTX_set_session_id_context.cc
   source/SSL_CTX_set_tlsext_status_cb.c
   source/SSL_CTX_set1_curves_list.c
   source/SSL_CTX_set1_sigalgs_list.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -103,6 +103,7 @@ add_library(bssl-compat STATIC
   source/SSL_set_bio.cc
   source/SSL_set_chain_and_key.cc
   source/SSL_set_connect_state.cc
+  source/SSL_set_session_id_context.cc
   source/SSL_set_session.cc
   source/SSL_set_tlsext_host_name.c
   source/SSL_version.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -236,8 +236,9 @@ set(utests-bssl-source-list
   source/crypto/err/err_test.cc
   source/crypto/rand_extra/rand_test.cc
   source/crypto/stack/stack_test.cc
-  source/crypto/test/test_util.h
   source/crypto/test/test_util.cc
+  source/crypto/test/test_util.h
+  source/ssl/ssl_c_test.c
   source/ssl/ssl_test.cc
 )
 

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -794,6 +794,17 @@
  
  // SSL_get_servername, for a server, returns the hostname supplied by the
  // client or NULL if there was none. The |type| argument must be
+@@ -2858,8 +2859,8 @@
+ // |SSL_TLSEXT_ERR_ALERT_FATAL|, then |*out_alert| is the alert to send,
+ // defaulting to |SSL_AD_UNRECOGNIZED_NAME|. |SSL_TLSEXT_ERR_ALERT_WARNING| is
+ // ignored and treated as |SSL_TLSEXT_ERR_OK|.
+-// OPENSSL_EXPORT int SSL_CTX_set_tlsext_servername_callback(
+-//     SSL_CTX *ctx, int (*callback)(SSL *ssl, int *out_alert, void *arg));
++OPENSSL_EXPORT int SSL_CTX_set_tlsext_servername_callback(
++    SSL_CTX *ctx, int (*callback)(SSL *ssl, int *out_alert, void *arg));
+ 
+ // SSL_CTX_set_tlsext_servername_arg sets the argument to the servername
+ // callback and returns one. See |SSL_CTX_set_tlsext_servername_callback|.
 @@ -2878,7 +2879,6 @@
  #ifdef ossl_SSL_TLSEXT_ERR_NOACK
  #define SSL_TLSEXT_ERR_NOACK ossl_SSL_TLSEXT_ERR_NOACK

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -388,6 +388,23 @@
  
  // SSL_CTX_set_default_passwd_cb sets the password callback for PEM-based
  // convenience functions called on |ctx|.
+@@ -1302,11 +1303,11 @@
+ 
+ // Custom private keys.
+ 
+-// enum ssl_private_key_result_t BORINGSSL_ENUM_INT {
+-//   ssl_private_key_success,
+-//   ssl_private_key_retry,
+-//   ssl_private_key_failure,
+-// };
++enum ssl_private_key_result_t BORINGSSL_ENUM_INT {
++  ssl_private_key_success,
++  ssl_private_key_retry,
++  ssl_private_key_failure,
++};
+ 
+ // ssl_private_key_method_st (aka |SSL_PRIVATE_KEY_METHOD|) describes private
+ // key hooks. This is used to off-load signing operations to a custom,
 @@ -1391,12 +1392,12 @@
  //
  // |SSL_CIPHER| objects represent cipher suites.

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -587,6 +587,19 @@
  
  // SSL_DEFAULT_SESSION_TIMEOUT is the default lifetime, in seconds, of a
  // session in TLS 1.2 or earlier. This is how long we are willing to use the
+@@ -2088,9 +2089,9 @@
+ //
+ // For a server, if |SSL_VERIFY_PEER| is enabled, it is an error to not set a
+ // session ID context.
+-// OPENSSL_EXPORT int SSL_CTX_set_session_id_context(SSL_CTX *ctx,
+-//                                                   const uint8_t *sid_ctx,
+-//                                                   size_t sid_ctx_len);
++OPENSSL_EXPORT int SSL_CTX_set_session_id_context(SSL_CTX *ctx,
++                                                  const uint8_t *sid_ctx,
++                                                  size_t sid_ctx_len);
+ 
+ // SSL_set_session_id_context sets |ssl|'s session ID context to |sid_ctx|. It
+ // returns one on success and zero on error. See also
 @@ -2151,8 +2152,8 @@
  // |SSL_do_handshake| or |SSL_connect| completes if False Start is enabled. Thus
  // it's recommended to use this callback over calling |SSL_get_session| on

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -605,7 +605,7 @@
  
  // SSL_DEFAULT_SESSION_TIMEOUT is the default lifetime, in seconds, of a
  // session in TLS 1.2 or earlier. This is how long we are willing to use the
-@@ -2104,9 +2105,9 @@
+@@ -2104,15 +2105,15 @@
  //
  // For a server, if |SSL_VERIFY_PEER| is enabled, it is an error to not set a
  // session ID context.
@@ -618,6 +618,14 @@
  
  // SSL_set_session_id_context sets |ssl|'s session ID context to |sid_ctx|. It
  // returns one on success and zero on error. See also
+ // |SSL_CTX_set_session_id_context|.
+-// OPENSSL_EXPORT int SSL_set_session_id_context(SSL *ssl, const uint8_t *sid_ctx,
+-//                                               size_t sid_ctx_len);
++OPENSSL_EXPORT int SSL_set_session_id_context(SSL *ssl, const uint8_t *sid_ctx,
++                                              size_t sid_ctx_len);
+ 
+ // SSL_get0_session_id_context returns a pointer to |ssl|'s session ID context
+ // and sets |*out_len| to its length.  It returns NULL on error.
 @@ -2167,8 +2168,8 @@
  // |SSL_do_handshake| or |SSL_connect| completes if False Start is enabled. Thus
  // it's recommended to use this callback over calling |SSL_get_session| on

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -233,7 +233,7 @@
  
  // SSL_set_mtu sets the |ssl|'s MTU in DTLS to |mtu|. It returns one on success
  // and zero on failure.
-@@ -716,14 +717,14 @@
+@@ -716,20 +717,20 @@
  // SSL_CTX_set_min_proto_version sets the minimum protocol version for |ctx| to
  // |version|. If |version| is zero, the default minimum version is used. It
  // returns one on success and zero if |version| is invalid.
@@ -251,7 +251,15 @@
 +                                                 uint16_t version);
  
  // SSL_CTX_get_min_proto_version returns the minimum protocol version for |ctx|
- // OPENSSL_EXPORT uint16_t SSL_CTX_get_min_proto_version(const SSL_CTX *ctx);
+-// OPENSSL_EXPORT uint16_t SSL_CTX_get_min_proto_version(const SSL_CTX *ctx);
++OPENSSL_EXPORT uint16_t SSL_CTX_get_min_proto_version(const SSL_CTX *ctx);
+ 
+ // SSL_CTX_get_max_proto_version returns the maximum protocol version for |ctx|
+-// OPENSSL_EXPORT uint16_t SSL_CTX_get_max_proto_version(const SSL_CTX *ctx);
++OPENSSL_EXPORT uint16_t SSL_CTX_get_max_proto_version(const SSL_CTX *ctx);
+ 
+ // SSL_set_min_proto_version sets the minimum protocol version for |ssl| to
+ // |version|. If |version| is zero, the default minimum version is used. It
 @@ -752,7 +753,7 @@
  // SSL_version returns the TLS or DTLS protocol version used by |ssl|, which is
  // one of the |*_VERSION| values. (E.g. |TLS1_2_VERSION|.) Before the version

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -502,6 +502,15 @@
  
  // SSL_get_tls_unique writes at most |max_out| bytes of the tls-unique value
  // for |ssl| to |out| and sets |*out_len| to the number of bytes written. It
+@@ -1719,7 +1720,7 @@
+ //
+ // TODO(davidben): Hammer down the semantics of this API while a handshake,
+ // initial or renego, is in progress.
+-// OPENSSL_EXPORT int SSL_session_reused(const SSL *ssl);
++OPENSSL_EXPORT int SSL_session_reused(const SSL *ssl);
+ 
+ // SSL_get_secure_renegotiation_support returns one if the peer supports secure
+ // renegotiation (RFC 5746) or TLS 1.3. Otherwise, it returns zero.
 @@ -1753,7 +1754,7 @@
  // SSL_SESSION_new returns a newly-allocated blank |SSL_SESSION| or NULL on
  // error. This may be useful when writing tests but should otherwise not be

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -578,7 +578,16 @@
  
  // SSL_SESSION_has_ticket returns one if |session| has a ticket and zero
  // otherwise.
-@@ -2048,7 +2049,7 @@
+@@ -2049,7 +2050,7 @@
+ 
+ // SSL_CTX_set_session_cache_mode sets the session cache mode bits for |ctx| to
+ // |mode|. It returns the previous value.
+-// OPENSSL_EXPORT int SSL_CTX_set_session_cache_mode(SSL_CTX *ctx, int mode);
++OPENSSL_EXPORT int SSL_CTX_set_session_cache_mode(SSL_CTX *ctx, int mode);
+ 
+ // SSL_CTX_get_session_cache_mode returns the session cache mode bits for
+ // |ctx|
+@@ -2064,7 +2065,7 @@
  // |SSL_SESSION_get0_ocsp_response|.
  //
  // It is an error to call this function after the handshake has begun.
@@ -587,7 +596,7 @@
  
  // SSL_DEFAULT_SESSION_TIMEOUT is the default lifetime, in seconds, of a
  // session in TLS 1.2 or earlier. This is how long we are willing to use the
-@@ -2088,9 +2089,9 @@
+@@ -2104,9 +2105,9 @@
  //
  // For a server, if |SSL_VERIFY_PEER| is enabled, it is an error to not set a
  // session ID context.
@@ -600,7 +609,7 @@
  
  // SSL_set_session_id_context sets |ssl|'s session ID context to |sid_ctx|. It
  // returns one on success and zero on error. See also
-@@ -2151,8 +2152,8 @@
+@@ -2167,8 +2168,8 @@
  // |SSL_do_handshake| or |SSL_connect| completes if False Start is enabled. Thus
  // it's recommended to use this callback over calling |SSL_get_session| on
  // handshake completion.
@@ -611,7 +620,7 @@
  
  // SSL_CTX_sess_get_new_cb returns the callback set by
  // |SSL_CTX_sess_set_new_cb|.
-@@ -2393,7 +2394,7 @@
+@@ -2409,7 +2410,7 @@
  // colon-separated list |curves|. Each element of |curves| should be a curve
  // name (e.g. P-256, X25519, ...). It returns one on success and zero on
  // failure.
@@ -620,7 +629,7 @@
  
  // SSL_set1_curves_list sets the preferred curves for |ssl| to be the
  // colon-separated list |curves|. Each element of |curves| should be a curve
-@@ -2402,11 +2403,11 @@
+@@ -2418,11 +2419,11 @@
  // OPENSSL_EXPORT int SSL_set1_curves_list(SSL *ssl, const char *curves);
  
  // SSL_CURVE_* define TLS curve IDs.
@@ -637,7 +646,7 @@
  // #define SSL_CURVE_CECPQ2 16696
  
  // SSL_get_curve_id returns the ID of the curve used by |ssl|'s most recently
-@@ -2414,11 +2415,11 @@
+@@ -2430,11 +2431,11 @@
  //
  // TODO(davidben): This API currently does not work correctly if there is a
  // renegotiation in progress. Fix this.
@@ -651,7 +660,7 @@
  
  
  // Certificate verification.
-@@ -2449,18 +2450,18 @@
+@@ -2465,18 +2466,18 @@
  // SSL_VERIFY_NONE, on a client, verifies the server certificate but does not
  // make errors fatal. The result may be checked with |SSL_get_verify_result|. On
  // a server it does not request a client certificate. This is the default.
@@ -673,7 +682,7 @@
  
  // SSL_VERIFY_PEER_IF_NO_OBC configures a server to request a client certificate
  // if and only if Channel ID is not negotiated.
-@@ -2473,8 +2474,8 @@
+@@ -2489,8 +2490,8 @@
  //
  // The callback may use |SSL_get_ex_data_X509_STORE_CTX_idx| with
  // |X509_STORE_CTX_get_ex_data| to look up the |SSL| from |store_ctx|.
@@ -684,7 +693,7 @@
  
  // SSL_set_verify configures certificate verification behavior. |mode| is one of
  // the |SSL_VERIFY_*| values defined above. |callback|, if not NULL, is used to
-@@ -2624,9 +2625,9 @@
+@@ -2640,9 +2641,9 @@
  // See
  // https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_load_verify_locations.html
  // for documentation on the directory format.
@@ -697,7 +706,7 @@
  
  // SSL_get_verify_result returns the result of certificate verification. It is
  // either |X509_V_OK| or a |X509_V_ERR_*| value.
-@@ -2649,9 +2650,9 @@
+@@ -2665,9 +2666,9 @@
  //
  // The callback may use |SSL_get_ex_data_X509_STORE_CTX_idx| to recover the
  // |SSL| object from |store_ctx|.
@@ -710,7 +719,7 @@
  
  // SSL_enable_signed_cert_timestamps causes |ssl| (which must be the client end
  // of a connection) to request SCTs from the server. See
-@@ -2673,7 +2674,7 @@
+@@ -2689,7 +2690,7 @@
  //
  // Call |SSL_get0_ocsp_response| to recover the OCSP response after the
  // handshake.
@@ -719,7 +728,7 @@
  
  // SSL_CTX_enable_ocsp_stapling enables OCSP stapling on all client SSL objects
  // created from |ctx|.
-@@ -2708,9 +2709,9 @@
+@@ -2724,9 +2725,9 @@
  // preference list when verifying signatures from the peer's long-term key. It
  // returns one on zero on error. |prefs| should not include the internal-only
  // value |SSL_SIGN_RSA_PKCS1_MD5_SHA1|.
@@ -732,7 +741,7 @@
  
  // SSL_set_verify_algorithm_prefs configures |ssl| to use |prefs| as the
  // preference list when verifying signatures from the peer's long-term key. It
-@@ -2739,8 +2740,8 @@
+@@ -2755,8 +2756,8 @@
  
  // SSL_CTX_set_client_CA_list sets |ctx|'s client certificate CA list to
  // |name_list|. It takes ownership of |name_list|.
@@ -743,7 +752,7 @@
  
  // SSL_set0_client_CAs sets |ssl|'s client certificate CA list to |name_list|,
  // which should contain DER-encoded distinguished names (RFC 5280). It takes
-@@ -2800,8 +2801,8 @@
+@@ -2816,8 +2817,8 @@
  // SSL_add_file_cert_subjects_to_stack behaves like |SSL_load_client_CA_file|
  // but appends the result to |out|. It returns one on success or zero on
  // error.
@@ -754,7 +763,7 @@
  
  // SSL_add_bio_cert_subjects_to_stack behaves like
  // |SSL_add_file_cert_subjects_to_stack| but reads from |bio|.
-@@ -2816,11 +2817,11 @@
+@@ -2832,11 +2833,11 @@
  // deployments to select one of a several certificates on a single IP. Only the
  // host_name name type is supported.
  
@@ -768,7 +777,7 @@
  
  // SSL_get_servername, for a server, returns the hostname supplied by the
  // client or NULL if there was none. The |type| argument must be
-@@ -2862,7 +2863,6 @@
+@@ -2878,7 +2879,6 @@
  #ifdef ossl_SSL_TLSEXT_ERR_NOACK
  #define SSL_TLSEXT_ERR_NOACK ossl_SSL_TLSEXT_ERR_NOACK
  #endif
@@ -776,7 +785,7 @@
  // SSL_set_SSL_CTX changes |ssl|'s |SSL_CTX|. |ssl| will use the
  // certificate-related settings from |ctx|, and |SSL_get_SSL_CTX| will report
  // |ctx|. This function may be used during the callbacks registered by
-@@ -2876,7 +2876,7 @@
+@@ -2892,7 +2892,7 @@
  // the session cache between different domains.
  //
  // TODO(davidben): Should other settings change after this call?
@@ -785,7 +794,7 @@
  
  
  // Application-layer protocol negotiation.
-@@ -4045,8 +4045,8 @@
+@@ -4061,8 +4061,8 @@
  //                                                 CRYPTO_EX_dup *dup_unused,
  //                                                 CRYPTO_EX_free *free_func);
  
@@ -796,7 +805,7 @@
  // OPENSSL_EXPORT int SSL_CTX_get_ex_new_index(long argl, void *argp,
  //                                             CRYPTO_EX_unused *unused,
  //                                             CRYPTO_EX_dup *dup_unused,
-@@ -4270,13 +4270,13 @@
+@@ -4286,13 +4286,13 @@
  // such as HTTP/1.1, and not others, such as HTTP/2.
  // OPENSSL_EXPORT void SSL_set_shed_handshake_config(SSL *ssl, int enable);
  
@@ -817,7 +826,7 @@
  
  // SSL_set_renegotiate_mode configures how |ssl|, a client, reacts to
  // renegotiation attempts by a server. If |ssl| is a server, peer-initiated
-@@ -4305,8 +4305,8 @@
+@@ -4321,8 +4321,8 @@
  //
  // There is no support in BoringSSL for initiating renegotiations as a client
  // or server.
@@ -828,7 +837,7 @@
  
  // SSL_renegotiate starts a deferred renegotiation on |ssl| if it was configured
  // with |ssl_renegotiate_explicit| and has a pending HelloRequest. It returns
-@@ -4367,45 +4367,45 @@
+@@ -4383,45 +4383,45 @@
  // callbacks that are called very early on during the server handshake. At this
  // point, much of the SSL* hasn't been filled out and only the ClientHello can
  // be depended on.
@@ -904,7 +913,7 @@
  
  // SSL_CTX_set_select_certificate_cb sets a callback that is called before most
  // ClientHello processing and before the decision whether to resume a session
-@@ -4421,9 +4421,9 @@
+@@ -4437,9 +4437,9 @@
  //
  // Note: The |SSL_CLIENT_HELLO| is only valid for the duration of the callback
  // and is not valid while the handshake is paused.
@@ -917,7 +926,7 @@
  
  // SSL_CTX_set_dos_protection_cb sets a callback that is called once the
  // resumption decision for a ClientHello has been made. It can return one to
-@@ -4539,7 +4539,7 @@
+@@ -4555,7 +4555,7 @@
  
  // SSL_get_peer_signature_algorithm returns the signature algorithm used by the
  // peer. If not applicable, it returns zero.
@@ -926,7 +935,7 @@
  
  // SSL_get_client_random writes up to |max_out| bytes of the most recent
  // handshake's client_random to |out| and returns the number of bytes written.
-@@ -4673,8 +4673,8 @@
+@@ -4689,8 +4689,8 @@
  
  // These client- and server-specific methods call their corresponding generic
  // methods.
@@ -937,7 +946,7 @@
  // OPENSSL_EXPORT const SSL_METHOD *SSLv23_server_method(void);
  // OPENSSL_EXPORT const SSL_METHOD *SSLv23_client_method(void);
  // OPENSSL_EXPORT const SSL_METHOD *TLSv1_server_method(void);
-@@ -4789,14 +4789,14 @@
+@@ -4805,14 +4805,14 @@
  // i2d_SSL_SESSION serializes |in|, as described in |i2d_SAMPLE|.
  //
  // Use |SSL_SESSION_to_bytes| instead.
@@ -955,7 +964,7 @@
  
  // i2d_SSL_SESSION_bio serializes |session| and writes the result to |bio|. It
  // returns the number of bytes written on success and <= 0 on error.
-@@ -4885,7 +4885,7 @@
+@@ -4901,7 +4901,7 @@
  // This API is compatible with OpenSSL. However, BoringSSL-specific code should
  // prefer |SSL_CTX_set_signing_algorithm_prefs| because it's clearer and it's
  // more convenient to codesearch for specific algorithm values.
@@ -964,7 +973,7 @@
  
  // SSL_set1_sigalgs_list takes a textual specification of a set of signature
  // algorithms and configures them on |ssl|. It returns one on success and zero
-@@ -5170,7 +5170,7 @@
+@@ -5186,7 +5186,7 @@
  
  // SSL_get1_session acts like |SSL_get_session| but returns a new reference to
  // the session.
@@ -973,7 +982,7 @@
  
  // #define OPENSSL_INIT_NO_LOAD_SSL_STRINGS 0
  // #define OPENSSL_INIT_LOAD_SSL_STRINGS 0
-@@ -5238,9 +5238,9 @@
+@@ -5254,9 +5254,9 @@
  // OCSP responses like other server credentials, such as certificates or SCT
  // lists. Configure, store, and refresh them eagerly. This avoids downtime if
  // the CA's OCSP responder is briefly offline.
@@ -986,7 +995,7 @@
  
  // SSL_CTX_set_tlsext_status_arg sets additional data for
  // |SSL_CTX_set_tlsext_status_cb|'s callback and returns one.
-@@ -5470,21 +5470,21 @@
+@@ -5486,21 +5486,21 @@
  // #endif // !defined(BORINGSSL_PREFIX)
  
  
@@ -1016,7 +1025,7 @@
  // BORINGSSL_MAKE_UP_REF(SSL_SESSION, SSL_SESSION_up_ref)
  
  // enum class OpenRecordResult {
-@@ -5601,13 +5601,13 @@
+@@ -5617,13 +5617,13 @@
  //     Span<const uint8_t> *out_write_traffic_secret);
  
  
@@ -1034,7 +1043,7 @@
  
  #ifdef ossl_SSL_R_APP_DATA_IN_HANDSHAKE
  #define SSL_R_APP_DATA_IN_HANDSHAKE ossl_SSL_R_APP_DATA_IN_HANDSHAKE
-@@ -6375,4 +6375,4 @@
+@@ -6391,4 +6391,4 @@
  #define SSL_R_TLSV1_ALERT_ECH_REQUIRED ossl_SSL_R_TLSV1_ALERT_ECH_REQUIRED
  #endif
  

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -587,6 +587,17 @@
  
  // SSL_DEFAULT_SESSION_TIMEOUT is the default lifetime, in seconds, of a
  // session in TLS 1.2 or earlier. This is how long we are willing to use the
+@@ -2151,8 +2152,8 @@
+ // |SSL_do_handshake| or |SSL_connect| completes if False Start is enabled. Thus
+ // it's recommended to use this callback over calling |SSL_get_session| on
+ // handshake completion.
+-// OPENSSL_EXPORT void SSL_CTX_sess_set_new_cb(
+-//     SSL_CTX *ctx, int (*new_session_cb)(SSL *ssl, SSL_SESSION *session));
++OPENSSL_EXPORT void SSL_CTX_sess_set_new_cb(
++    SSL_CTX *ctx, int (*new_session_cb)(SSL *ssl, SSL_SESSION *session));
+ 
+ // SSL_CTX_sess_get_new_cb returns the callback set by
+ // |SSL_CTX_sess_set_new_cb|.
 @@ -2393,7 +2394,7 @@
  // colon-separated list |curves|. Each element of |curves| should be a curve
  // name (e.g. P-256, X25519, ...). It returns one on success and zero on

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -654,6 +654,17 @@
  
  // SSL_CTX_sess_get_new_cb returns the callback set by
  // |SSL_CTX_sess_set_new_cb|.
+@@ -2271,8 +2272,8 @@
+ // SSL_CTX_set_tlsext_ticket_keys sets |ctx|'s session ticket key material to
+ // |len| bytes of |in|. It returns one on success and zero if |len| is not
+ // 48. If |in| is NULL, it returns 48 instead.
+-// OPENSSL_EXPORT int SSL_CTX_set_tlsext_ticket_keys(SSL_CTX *ctx, const void *in,
+-//                                                   size_t len);
++OPENSSL_EXPORT int SSL_CTX_set_tlsext_ticket_keys(SSL_CTX *ctx, const void *in,
++                                                  size_t len);
+ 
+ // SSL_TICKET_KEY_NAME_LEN is the length of the key name prefix of a session
+ // ticket.
 @@ -2409,7 +2410,7 @@
  // colon-separated list |curves|. Each element of |curves| should be a curve
  // name (e.g. P-256, X25519, ...). It returns one on success and zero on

--- a/bssl-compat/patch/include/openssl/ssl.h.sh
+++ b/bssl-compat/patch/include/openssl/ssl.h.sh
@@ -14,6 +14,7 @@ SUBSTITUTIONS+=('DTLS1_VERSION')
 SUBSTITUTIONS+=('DTLS1_2_VERSION')
 SUBSTITUTIONS+=('SSL_R_[a-zA-Z0-9_]*')
 SUBSTITUTIONS+=('SSL_TLSEXT_ERR_[A-Z_]*')
+SUBSTITUTIONS+=('SSL_SESS_CACHE_[A-Z_]*')
 
 EXPRE='s|^//[ \t]#[ \t]*define[ \t]*[^a-zA-Z0-9_]\('
 EXPOST='\)[^a-zA-Z0-9_].*$|#ifdef ossl_\1\n#define \1 ossl_\1\n#endif|'

--- a/bssl-compat/patch/source/ssl/ssl_c_test.c.patch
+++ b/bssl-compat/patch/source/ssl/ssl_c_test.c.patch
@@ -1,0 +1,30 @@
+--- a/source/ssl/ssl_c_test.c
++++ b/source/ssl/ssl_c_test.c
+@@ -1,15 +1,15 @@
+-// #include <openssl/ssl.h>
++#include <openssl/ssl.h>
+ 
+-// int BORINGSSL_enum_c_type_test(void);
++int BORINGSSL_enum_c_type_test(void);
+ 
+-// int BORINGSSL_enum_c_type_test(void) {
+-// #if defined(__cplusplus)
+-// #error "This is testing the behaviour of the C compiler."
+-// #error "It's pointless to build it in C++ mode."
+-// #endif
++int BORINGSSL_enum_c_type_test(void) {
++#if defined(__cplusplus)
++#error "This is testing the behaviour of the C compiler."
++#error "It's pointless to build it in C++ mode."
++#endif
+ 
+-//   // In C++, the enums in ssl.h are explicitly typed as ints to allow them to
+-//   // be predeclared. This function confirms that the C compiler believes them
+-//   // to be the same size as ints. They may differ in signedness, however.
+-//   return sizeof(enum ssl_private_key_result_t) == sizeof(int);
+-// }
++  // In C++, the enums in ssl.h are explicitly typed as ints to allow them to
++  // be predeclared. This function confirms that the C compiler believes them
++  // to be the same size as ints. They may differ in signedness, however.
++  return sizeof(enum ssl_private_key_result_t) == sizeof(int);
++}

--- a/bssl-compat/patch/source/ssl/ssl_test.cc.patch
+++ b/bssl-compat/patch/source/ssl/ssl_test.cc.patch
@@ -1,6 +1,6 @@
 --- a/source/ssl/ssl_test.cc
 +++ b/source/ssl/ssl_test.cc
-@@ -12,56 +12,61 @@
+@@ -12,82 +12,91 @@
   * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
   * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
  
@@ -67,51 +67,68 @@
 +#include "../crypto/test/test_util.h"
  
 -// #if defined(OPENSSL_WINDOWS)
-+#ifdef BSSL_COMPAT
-+#include <ossl/openssl/ssl.h>
-+#include <ossl/openssl/provider.h>
-+#endif
-+
-+#if defined(OPENSSL_WINDOWS)
- // Windows defines struct timeval in winsock2.h.
+-// Windows defines struct timeval in winsock2.h.
 -// OPENSSL_MSVC_PRAGMA(warning(push, 3))
 -// #include <winsock2.h>
 -// OPENSSL_MSVC_PRAGMA(warning(pop))
 -// #else
 -// #include <sys/time.h>
 -// #endif
+-
+-// #if defined(OPENSSL_THREADS)
+-// #include <thread>
+-// #endif
+-
+-
+-// BSSL_NAMESPACE_BEGIN
++#ifdef BSSL_COMPAT
++#include <ossl/openssl/ssl.h>
++#include <ossl/openssl/provider.h>
++#endif
+ 
+-// namespace {
+-
+-// #define TRACED_CALL(code)                     \
+-//   do {                                        \
+-//     SCOPED_TRACE("<- called from here");      \
+-//     code;                                     \
+-//     if (::testing::Test::HasFatalFailure()) { \
+-//       return;                                 \
+-//     }                                         \
+-//   } while (false)
+-
+-// struct VersionParam {
+-//   uint16_t version;
+-//   enum { is_tls, is_dtls } ssl_method;
+-//   const char name[8];
+-// };
++#if defined(OPENSSL_WINDOWS)
++// Windows defines struct timeval in winsock2.h.
 +OPENSSL_MSVC_PRAGMA(warning(push, 3))
 +#include <winsock2.h>
 +OPENSSL_MSVC_PRAGMA(warning(pop))
 +#else
 +#include <sys/time.h>
 +#endif
- 
--// #if defined(OPENSSL_THREADS)
--// #include <thread>
--// #endif
++
 +#if defined(OPENSSL_THREADS)
 +#include <thread>
 +#endif
- 
- 
--// BSSL_NAMESPACE_BEGIN
++
++
 +BSSL_NAMESPACE_BEGIN
- 
--// namespace {
++
 +namespace {
- 
- // #define TRACED_CALL(code)                     \
- //   do {                                        \
-@@ -72,22 +77,26 @@
- //     }                                         \
- //   } while (false)
- 
--// struct VersionParam {
--//   uint16_t version;
--//   enum { is_tls, is_dtls } ssl_method;
--//   const char name[8];
--// };
++
++#define TRACED_CALL(code)                     \
++  do {                                        \
++    SCOPED_TRACE("<- called from here");      \
++    code;                                     \
++    if (::testing::Test::HasFatalFailure()) { \
++      return;                                 \
++    }                                         \
++  } while (false)
++
 +struct VersionParam {
 +  uint16_t version;
 +  enum { is_tls, is_dtls } ssl_method;
@@ -264,7 +281,7 @@
  
  // static bssl::UniquePtr<SSL_CTX> CreateContextWithTestCertificate(
  //     const SSL_METHOD *method) {
-@@ -1408,36 +1417,44 @@
+@@ -1408,171 +1417,195 @@
  //   return KeyFromPEM(kKeyPEM);
  // }
  
@@ -295,6 +312,40 @@
 -//       break;
 -//     }
 -//   }
+-
+-//   return true;
+-// }
+-
+-// static bool FlushNewSessionTickets(SSL *client, SSL *server) {
+-//   // NewSessionTickets are deferred on the server to |SSL_write|, and clients do
+-//   // not pick them up until |SSL_read|.
+-//   for (;;) {
+-//     int server_ret = SSL_write(server, nullptr, 0);
+-//     int server_err = SSL_get_error(server, server_ret);
+-//     // The server may either succeed (|server_ret| is zero) or block on write
+-//     // (|server_ret| is -1 and |server_err| is |SSL_ERROR_WANT_WRITE|).
+-//     if (server_ret > 0 ||
+-//         (server_ret < 0 && server_err != SSL_ERROR_WANT_WRITE)) {
+-//       fprintf(stderr, "Unexpected server result: %d %d\n", server_ret,
+-//               server_err);
+-//       return false;
+-//     }
+-
+-//     int client_ret = SSL_read(client, nullptr, 0);
+-//     int client_err = SSL_get_error(client, client_ret);
+-//     // The client must always block on read.
+-//     if (client_ret != -1 || client_err != SSL_ERROR_WANT_READ) {
+-//       fprintf(stderr, "Unexpected client result: %d %d\n", client_ret,
+-//               client_err);
+-//       return false;
+-//     }
+-
+-//     // The server flushed everything it had to write.
+-//     if (server_ret == 0) {
+-//       return true;
+-//     }
+-//   }
+-// }
 +static bool CompleteHandshakes(SSL *client, SSL *server) {
 +  // Drive both their handshakes to completion.
 +  for (;;) {
@@ -330,15 +381,41 @@
 +      break;
 +    }
 +  }
- 
--//   return true;
--// }
++
 +  return true;
 +}
++
++static bool FlushNewSessionTickets(SSL *client, SSL *server) {
++  // NewSessionTickets are deferred on the server to |SSL_write|, and clients do
++  // not pick them up until |SSL_read|.
++  for (;;) {
++    int server_ret = SSL_write(server, nullptr, 0);
++    int server_err = SSL_get_error(server, server_ret);
++    // The server may either succeed (|server_ret| is zero) or block on write
++    // (|server_ret| is -1 and |server_err| is |SSL_ERROR_WANT_WRITE|).
++    if (server_ret > 0 ||
++        (server_ret < 0 && server_err != SSL_ERROR_WANT_WRITE)) {
++      fprintf(stderr, "Unexpected server result: %d %d\n", server_ret,
++              server_err);
++      return false;
++    }
++
++    int client_ret = SSL_read(client, nullptr, 0);
++    int client_err = SSL_get_error(client, client_ret);
++    // The client must always block on read.
++    if (client_ret != -1 || client_err != SSL_ERROR_WANT_READ) {
++      fprintf(stderr, "Unexpected client result: %d %d\n", client_ret,
++              client_err);
++      return false;
++    }
++
++    // The server flushed everything it had to write.
++    if (server_ret == 0) {
++      return true;
++    }
++  }
++}
  
- // static bool FlushNewSessionTickets(SSL *client, SSL *server) {
- //   // NewSessionTickets are deferred on the server to |SSL_write|, and clients do
-@@ -1473,74 +1490,90 @@
  // CreateClientAndServer creates a client and server |SSL| objects whose |BIO|s
  // are paired with each other. It does not run the handshake. The caller is
  // expected to configure the objects and drive the handshake as needed.
@@ -410,6 +487,38 @@
 -//   *out_server = std::move(server);
 -//   return true;
 -// }
+-
+-// static bssl::UniquePtr<SSL_SESSION> g_last_session;
+-
+-// static int SaveLastSession(SSL *ssl, SSL_SESSION *session) {
+-//   // Save the most recent session.
+-//   g_last_session.reset(session);
+-//   return 1;
+-// }
+-
+-// static bssl::UniquePtr<SSL_SESSION> CreateClientSession(
+-//     SSL_CTX *client_ctx, SSL_CTX *server_ctx,
+-//     const ClientConfig &config = ClientConfig()) {
+-//   g_last_session = nullptr;
+-//   SSL_CTX_sess_set_new_cb(client_ctx, SaveLastSession);
+-
+-//   // Connect client and server to get a session.
+-//   bssl::UniquePtr<SSL> client, server;
+-//   if (!ConnectClientAndServer(&client, &server, client_ctx, server_ctx,
+-//                               config) ||
+-//       !FlushNewSessionTickets(client.get(), server.get())) {
+-//     fprintf(stderr, "Failed to connect client and server.\n");
+-//     return nullptr;
+-//   }
+-
+-//   SSL_CTX_sess_set_new_cb(client_ctx, nullptr);
+-
+-//   if (!g_last_session) {
+-//     fprintf(stderr, "Client did not receive a session.\n");
+-//     return nullptr;
+-//   }
+-//   return std::move(g_last_session);
+-// }
 +static bool CreateClientAndServer(bssl::UniquePtr<SSL> *out_client,
 +                                  bssl::UniquePtr<SSL> *out_server,
 +                                  SSL_CTX *client_ctx, SSL_CTX *server_ctx) {
@@ -454,7 +563,7 @@
 +#ifndef BSSL_COMPAT
 +    SSL_set_early_data_enabled(client.get(), 1);
 +#else
-+    std::cout << __FILE__ << ":" << __LINE__ << " Skipped SSL_set_early_data_enabled()" << std::endl;
++    std::cout << "WARNING: Skipped SSL_set_early_data_enabled()" << std::endl;
 +    return false;
 +#endif
 +  }
@@ -494,9 +603,41 @@
 +  *out_server = std::move(server);
 +  return true;
 +}
++
++static bssl::UniquePtr<SSL_SESSION> g_last_session;
++
++static int SaveLastSession(SSL *ssl, SSL_SESSION *session) {
++  // Save the most recent session.
++  g_last_session.reset(session);
++  return 1;
++}
++
++static bssl::UniquePtr<SSL_SESSION> CreateClientSession(
++    SSL_CTX *client_ctx, SSL_CTX *server_ctx,
++    const ClientConfig &config = ClientConfig()) {
++  g_last_session = nullptr;
++  SSL_CTX_sess_set_new_cb(client_ctx, SaveLastSession);
++
++  // Connect client and server to get a session.
++  bssl::UniquePtr<SSL> client, server;
++  if (!ConnectClientAndServer(&client, &server, client_ctx, server_ctx,
++                              config) ||
++      !FlushNewSessionTickets(client.get(), server.get())) {
++    fprintf(stderr, "Failed to connect client and server.\n");
++    return nullptr;
++  }
++
++  SSL_CTX_sess_set_new_cb(client_ctx, nullptr);
++
++  if (!g_last_session) {
++    fprintf(stderr, "Client did not receive a session.\n");
++    return nullptr;
++  }
++  return std::move(g_last_session);
++}
  
- // static bssl::UniquePtr<SSL_SESSION> g_last_session;
- 
+ // Test that |SSL_get_client_CA_list| echoes back the configured parameter even
+ // before configuring as a server.
 @@ -2495,62 +2528,71 @@
  // SSLVersionTest executes its test cases under all available protocol versions.
  // Test cases call |Connect| to create a connection using context objects with
@@ -687,10 +828,14 @@
  // Test that, after calling |SSL_shutdown|, |SSL_write| fails.
 -// TEST_P(SSLVersionTest, WriteAfterShutdown) {
 -//   ASSERT_TRUE(Connect());
--
++TEST_P(SSLVersionTest, WriteAfterShutdown) {
++  ASSERT_TRUE(Connect());
+ 
 -//   for (SSL *ssl : {client_.get(), server_.get()}) {
 -//     SCOPED_TRACE(SSL_is_server(ssl) ? "server" : "client");
--
++  for (SSL *ssl : {client_.get(), server_.get()}) {
++    SCOPED_TRACE(SSL_is_server(ssl) ? "server" : "client");
+ 
 -//     bssl::UniquePtr<BIO> mem(BIO_new(BIO_s_mem()));
 -//     ASSERT_TRUE(mem);
 -//     SSL_set0_wbio(ssl, bssl::UpRef(mem).release());
@@ -698,18 +843,14 @@
 -//     // Shut down half the connection. |SSL_shutdown| will return 0 to signal
 -//     // only one side has shut down.
 -//     ASSERT_EQ(SSL_shutdown(ssl), 0);
-+TEST_P(SSLVersionTest, WriteAfterShutdown) {
-+  ASSERT_TRUE(Connect());
- 
+-
 -//     // |ssl| should have written an alert to the transport.
 -//     const uint8_t *unused;
 -//     size_t len;
 -//     ASSERT_TRUE(BIO_mem_contents(mem.get(), &unused, &len));
 -//     EXPECT_NE(0u, len);
 -//     EXPECT_TRUE(BIO_reset(mem.get()));
-+  for (SSL *ssl : {client_.get(), server_.get()}) {
-+    SCOPED_TRACE(SSL_is_server(ssl) ? "server" : "client");
- 
+-
 -//     // Writing should fail.
 -//     EXPECT_EQ(-1, SSL_write(ssl, "a", 1));
 -
@@ -833,7 +974,7 @@
  
  // Test that, after sending a fatal alert from the handshake, |SSL_write| fails.
  // TEST_P(SSLVersionTest, WriteAfterHandshakeSentFatalAlert) {
-@@ -2935,97 +2977,101 @@
+@@ -2935,110 +2977,116 @@
  //   // is correct.
  // }
  
@@ -927,6 +1068,19 @@
 -//   EXPECT_EQ(sk_X509_num(SSL_get_peer_cert_chain(server_.get())), 0u);
 -//   EXPECT_EQ(sk_CRYPTO_BUFFER_num(SSL_get0_peer_certificates(server_.get())),
 -//             1u);
+-// }
+-
+-// TEST_P(SSLVersionTest, NoPeerCertificate) {
+-//   SSL_CTX_set_verify(server_ctx_.get(), SSL_VERIFY_PEER, nullptr);
+-//   SSL_CTX_set_cert_verify_callback(server_ctx_.get(), VerifySucceed, NULL);
+-//   SSL_CTX_set_cert_verify_callback(client_ctx_.get(), VerifySucceed, NULL);
+-
+-//   ASSERT_TRUE(Connect());
+-
+-//   // Server should not see a peer certificate.
+-//   bssl::UniquePtr<X509> peer(SSL_get_peer_certificate(server_.get()));
+-//   ASSERT_FALSE(peer);
+-//   ASSERT_FALSE(SSL_get0_peer_certificates(server_.get()));
 -// }
 +TEST(SSLTest, SetBIO) {
 +  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
@@ -1023,10 +1177,201 @@
 +            1u);
 +#endif
 +}
++
++TEST_P(SSLVersionTest, NoPeerCertificate) {
++  SSL_CTX_set_verify(server_ctx_.get(), SSL_VERIFY_PEER, nullptr);
++  SSL_CTX_set_cert_verify_callback(server_ctx_.get(), VerifySucceed, NULL);
++  SSL_CTX_set_cert_verify_callback(client_ctx_.get(), VerifySucceed, NULL);
++
++  ASSERT_TRUE(Connect());
++
++  // Server should not see a peer certificate.
++  bssl::UniquePtr<X509> peer(SSL_get_peer_certificate(server_.get()));
++  ASSERT_FALSE(peer);
++#ifndef BSSL_COMPAT // Envoy doesn't need SSL_get0_peer_certificates() so skip this
++  ASSERT_FALSE(SSL_get0_peer_certificates(server_.get()));
++#endif
++}
  
- // TEST_P(SSLVersionTest, NoPeerCertificate) {
- //   SSL_CTX_set_verify(server_ctx_.get(), SSL_VERIFY_PEER, nullptr);
-@@ -4214,43 +4260,46 @@
+ // TEST_P(SSLVersionTest, RetainOnlySHA256OfCerts) {
+ //   uint8_t *cert_der = NULL;
+@@ -3167,19 +3215,19 @@
+ //   }
+ // }
+ 
+-// static void ExpectSessionReused(SSL_CTX *client_ctx, SSL_CTX *server_ctx,
+-//                                 SSL_SESSION *session, bool want_reused) {
+-//   bssl::UniquePtr<SSL> client, server;
+-//   ClientConfig config;
+-//   config.session = session;
+-//   EXPECT_TRUE(
+-//       ConnectClientAndServer(&client, &server, client_ctx, server_ctx, config));
+-
+-//   EXPECT_EQ(SSL_session_reused(client.get()), SSL_session_reused(server.get()));
+-
+-//   bool was_reused = !!SSL_session_reused(client.get());
+-//   EXPECT_EQ(was_reused, want_reused);
+-// }
++static void ExpectSessionReused(SSL_CTX *client_ctx, SSL_CTX *server_ctx,
++                                SSL_SESSION *session, bool want_reused) {
++  bssl::UniquePtr<SSL> client, server;
++  ClientConfig config;
++  config.session = session;
++  EXPECT_TRUE(
++      ConnectClientAndServer(&client, &server, client_ctx, server_ctx, config));
++
++  EXPECT_EQ(SSL_session_reused(client.get()), SSL_session_reused(server.get()));
++
++  bool was_reused = !!SSL_session_reused(client.get());
++  EXPECT_EQ(was_reused, want_reused);
++}
+ 
+ // static bssl::UniquePtr<SSL_SESSION> ExpectSessionRenewed(SSL_CTX *client_ctx,
+ //                                                          SSL_CTX *server_ctx,
+@@ -3229,73 +3277,76 @@
+ //   OPENSSL_memcpy(inout_key, new_key, kTicketKeyLen);
+ // }
+ 
+-// static int SwitchSessionIDContextSNI(SSL *ssl, int *out_alert, void *arg) {
+-//   static const uint8_t kContext[] = {3};
+-
+-//   if (!SSL_set_session_id_context(ssl, kContext, sizeof(kContext))) {
+-//     return SSL_TLSEXT_ERR_ALERT_FATAL;
+-//   }
+-
+-//   return SSL_TLSEXT_ERR_OK;
+-// }
+-
+-// TEST_P(SSLVersionTest, SessionIDContext) {
+-//   static const uint8_t kContext1[] = {1};
+-//   static const uint8_t kContext2[] = {2};
+-
+-//   ASSERT_TRUE(SSL_CTX_set_session_id_context(server_ctx_.get(), kContext1,
+-//                                              sizeof(kContext1)));
+-
+-//   SSL_CTX_set_session_cache_mode(client_ctx_.get(), SSL_SESS_CACHE_BOTH);
+-//   SSL_CTX_set_session_cache_mode(server_ctx_.get(), SSL_SESS_CACHE_BOTH);
+-
+-//   bssl::UniquePtr<SSL_SESSION> session =
+-//       CreateClientSession(client_ctx_.get(), server_ctx_.get());
+-//   ASSERT_TRUE(session);
+-
+-//   TRACED_CALL(ExpectSessionReused(client_ctx_.get(), server_ctx_.get(),
+-//                                   session.get(),
+-//                                   true /* expect session reused */));
+-
+-//   // Change the session ID context.
+-//   ASSERT_TRUE(SSL_CTX_set_session_id_context(server_ctx_.get(), kContext2,
+-//                                              sizeof(kContext2)));
+-
+-//   TRACED_CALL(ExpectSessionReused(client_ctx_.get(), server_ctx_.get(),
+-//                                   session.get(),
+-//                                   false /* expect session not reused */));
+-
+-//   // Change the session ID context back and install an SNI callback to switch
+-//   // it.
+-//   ASSERT_TRUE(SSL_CTX_set_session_id_context(server_ctx_.get(), kContext1,
+-//                                              sizeof(kContext1)));
+-
+-//   SSL_CTX_set_tlsext_servername_callback(server_ctx_.get(),
+-//                                          SwitchSessionIDContextSNI);
+-
+-//   TRACED_CALL(ExpectSessionReused(client_ctx_.get(), server_ctx_.get(),
+-//                                   session.get(),
+-//                                   false /* expect session not reused */));
+-
+-//   // Switch the session ID context with the early callback instead.
+-//   SSL_CTX_set_tlsext_servername_callback(server_ctx_.get(), nullptr);
+-//   SSL_CTX_set_select_certificate_cb(
+-//       server_ctx_.get(),
+-//       [](const SSL_CLIENT_HELLO *client_hello) -> ssl_select_cert_result_t {
+-//         static const uint8_t kContext[] = {3};
+-
+-//         if (!SSL_set_session_id_context(client_hello->ssl, kContext,
+-//                                         sizeof(kContext))) {
+-//           return ssl_select_cert_error;
+-//         }
+-
+-//         return ssl_select_cert_success;
+-//       });
++static int SwitchSessionIDContextSNI(SSL *ssl, int *out_alert, void *arg) {
++  static const uint8_t kContext[] = {3};
+ 
+-//   TRACED_CALL(ExpectSessionReused(client_ctx_.get(), server_ctx_.get(),
+-//                                   session.get(),
+-//                                   false /* expect session not reused */));
+-// }
++  if (!SSL_set_session_id_context(ssl, kContext, sizeof(kContext))) {
++    return SSL_TLSEXT_ERR_ALERT_FATAL;
++  }
++
++  return SSL_TLSEXT_ERR_OK;
++}
++
++TEST_P(SSLVersionTest, SessionIDContext) {
++#ifdef BSSL_COMPAT
++  GTEST_SKIP(); // TODO: Investigate failures on BSSL_COMPAT
++#endif
++  static const uint8_t kContext1[] = {1};
++  static const uint8_t kContext2[] = {2};
++
++  ASSERT_TRUE(SSL_CTX_set_session_id_context(server_ctx_.get(), kContext1,
++                                             sizeof(kContext1)));
++
++  SSL_CTX_set_session_cache_mode(client_ctx_.get(), SSL_SESS_CACHE_BOTH);
++  SSL_CTX_set_session_cache_mode(server_ctx_.get(), SSL_SESS_CACHE_BOTH);
++
++  bssl::UniquePtr<SSL_SESSION> session =
++      CreateClientSession(client_ctx_.get(), server_ctx_.get());
++  ASSERT_TRUE(session);
++
++  TRACED_CALL(ExpectSessionReused(client_ctx_.get(), server_ctx_.get(),
++                                  session.get(),
++                                  true /* expect session reused */));
++
++  // Change the session ID context.
++  ASSERT_TRUE(SSL_CTX_set_session_id_context(server_ctx_.get(), kContext2,
++                                             sizeof(kContext2)));
++
++  TRACED_CALL(ExpectSessionReused(client_ctx_.get(), server_ctx_.get(),
++                                  session.get(),
++                                  false /* expect session not reused */));
++
++  // Change the session ID context back and install an SNI callback to switch
++  // it.
++  ASSERT_TRUE(SSL_CTX_set_session_id_context(server_ctx_.get(), kContext1,
++                                             sizeof(kContext1)));
++
++  SSL_CTX_set_tlsext_servername_callback(server_ctx_.get(),
++                                         SwitchSessionIDContextSNI);
++
++  TRACED_CALL(ExpectSessionReused(client_ctx_.get(), server_ctx_.get(),
++                                  session.get(),
++                                  false /* expect session not reused */));
++
++  // Switch the session ID context with the early callback instead.
++  SSL_CTX_set_tlsext_servername_callback(server_ctx_.get(), nullptr);
++  SSL_CTX_set_select_certificate_cb(
++      server_ctx_.get(),
++      [](const SSL_CLIENT_HELLO *client_hello) -> ssl_select_cert_result_t {
++        static const uint8_t kContext[] = {3};
++
++        if (!SSL_set_session_id_context(client_hello->ssl, kContext,
++                                        sizeof(kContext))) {
++          return ssl_select_cert_error;
++        }
++
++        return ssl_select_cert_success;
++      });
++
++  TRACED_CALL(ExpectSessionReused(client_ctx_.get(), server_ctx_.get(),
++                                  session.get(),
++                                  false /* expect session not reused */));
++}
+ 
+ // static timeval g_current_time;
+ 
+@@ -4214,43 +4265,46 @@
  //   X509_cmp(cert, cert);
  // }
  
@@ -1110,7 +1455,7 @@
  
  // TEST(SSLTest, SetChainAndKeyMismatch) {
  //   bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_with_buffers_method()));
-@@ -4920,33 +4969,37 @@
+@@ -4920,33 +4974,37 @@
  // }
  
  // The client should gracefully handle no suitable ciphers being enabled.
@@ -1175,7 +1520,7 @@
  
  // TEST_P(SSLVersionTest, SessionVersion) {
  //   SSL_CTX_set_session_cache_mode(client_ctx_.get(), SSL_SESS_CACHE_BOTH);
-@@ -5721,25 +5774,28 @@
+@@ -5721,25 +5779,28 @@
  // }
  
  // SSL_CTX_get0_certificate needs to lock internally. Test this works.
@@ -1223,7 +1568,30 @@
  
  // Functions which access properties on the negotiated session are thread-safe
  // where needed. Prior to TLS 1.3, clients resuming sessions and servers
-@@ -8260,5 +8316,5 @@
+@@ -7167,14 +7228,14 @@
+ //   ASSERT_TRUE(CompleteHandshakesForQUIC());
+ // }
+ 
+-// extern "C" {
+-// int BORINGSSL_enum_c_type_test(void);
+-// }
+-
+-// TEST(SSLTest, EnumTypes) {
+-//   EXPECT_EQ(sizeof(int), sizeof(ssl_private_key_result_t));
+-//   EXPECT_EQ(1, BORINGSSL_enum_c_type_test());
+-// }
++extern "C" {
++int BORINGSSL_enum_c_type_test(void);
++}
++
++TEST(SSLTest, EnumTypes) {
++  EXPECT_EQ(sizeof(int), sizeof(ssl_private_key_result_t));
++  EXPECT_EQ(1, BORINGSSL_enum_c_type_test());
++}
+ 
+ // TEST_P(SSLVersionTest, DoubleSSLError) {
+ //   // Connect the inner SSL connections.
+@@ -8260,5 +8321,5 @@
  //   }
  // }
  

--- a/bssl-compat/source/SSL_CTX_get_max_proto_version.cc
+++ b/bssl-compat/source/SSL_CTX_get_max_proto_version.cc
@@ -1,0 +1,8 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+extern "C" uint16_t SSL_CTX_get_max_proto_version(const SSL_CTX *ctx) {
+  return ossl_SSL_CTX_get_max_proto_version((SSL_CTX*)ctx);
+}
+

--- a/bssl-compat/source/SSL_CTX_get_min_proto_version.cc
+++ b/bssl-compat/source/SSL_CTX_get_min_proto_version.cc
@@ -1,0 +1,8 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+extern "C" uint16_t SSL_CTX_get_min_proto_version(const SSL_CTX *ctx) {
+  return ossl_SSL_CTX_get_min_proto_version((SSL_CTX*)ctx);
+}
+

--- a/bssl-compat/source/SSL_CTX_sess_set_new_cb.cc
+++ b/bssl-compat/source/SSL_CTX_sess_set_new_cb.cc
@@ -1,0 +1,8 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+extern "C" void SSL_CTX_sess_set_new_cb(SSL_CTX *ctx, int (*new_session_cb)(SSL *ssl, SSL_SESSION *session)) {
+  ossl_SSL_CTX_sess_set_new_cb(ctx, new_session_cb);
+}
+

--- a/bssl-compat/source/SSL_CTX_set_session_cache_mode.cc
+++ b/bssl-compat/source/SSL_CTX_set_session_cache_mode.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/ssl.h#L1964
+ * https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set_session_cache_mode.html
+ */
+extern "C" int SSL_CTX_set_session_cache_mode(SSL_CTX *ctx, int mode) {
+  return ossl_SSL_CTX_set_session_cache_mode(ctx, mode);
+}

--- a/bssl-compat/source/SSL_CTX_set_session_id_context.cc
+++ b/bssl-compat/source/SSL_CTX_set_session_id_context.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/ssl.h#L2019
+ * https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set_session_id_context.html
+ */
+extern "C" int SSL_CTX_set_session_id_context(SSL_CTX *ctx, const uint8_t *sid_ctx, size_t sid_ctx_len) {
+  return ossl_SSL_CTX_set_session_id_context(ctx, sid_ctx, sid_ctx_len);
+}

--- a/bssl-compat/source/SSL_CTX_set_tlsext_servername_callback.cc
+++ b/bssl-compat/source/SSL_CTX_set_tlsext_servername_callback.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/ssl.h#LL2773C20-L2773C58
+ * https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set_tlsext_servername_callback.html
+ */
+extern "C" int SSL_CTX_set_tlsext_servername_callback(SSL_CTX *ctx, int (*callback)(SSL *ssl, int *out_alert, void *arg)) {
+  return ossl_SSL_CTX_set_tlsext_servername_callback(ctx, callback);
+}

--- a/bssl-compat/source/SSL_CTX_set_tlsext_ticket_keys.cc
+++ b/bssl-compat/source/SSL_CTX_set_tlsext_ticket_keys.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+extern "C" int SSL_CTX_set_tlsext_ticket_keys(SSL_CTX *ctx, const void *in, size_t len) {
+  return ossl_SSL_CTX_set_tlsext_ticket_keys(ctx, (void*)in, len);
+}

--- a/bssl-compat/source/SSL_session_reused.cc
+++ b/bssl-compat/source/SSL_session_reused.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/ssl.h#L1650
+ * https://www.openssl.org/docs/man3.0/man3/SSL_session_reused.html
+ */
+extern "C" int SSL_session_reused(const SSL *ssl) {
+  return ossl_SSL_session_reused(ssl);
+}

--- a/bssl-compat/source/SSL_set_session_id_context.cc
+++ b/bssl-compat/source/SSL_set_session_id_context.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl/openssl/ssl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/ssl.h#L2026
+ * https://www.openssl.org/docs/man3.0/man3/SSL_set_session_id_context.html
+ */
+extern "C" int SSL_set_session_id_context(SSL *ssl, const uint8_t *sid_ctx, size_t sid_ctx_len) {
+  return ossl_SSL_set_session_id_context(ssl, sid_ctx, sid_ctx_len);
+}

--- a/bssl-compat/source/SSL_shutdown.cc
+++ b/bssl-compat/source/SSL_shutdown.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/ssl.h#L455
+ * https://www.openssl.org/docs/man3.0/man3/SSL_shutdown.html
+ */
+int SSL_shutdown(SSL *ssl) {
+  return ossl.ossl_SSL_shutdown(ssl);
+}

--- a/bssl-compat/source/extra/ssl_extra.ld
+++ b/bssl-compat/source/extra/ssl_extra.ld
@@ -15,7 +15,6 @@ PROVIDE(SSL_get_ciphers = ossl_SSL_get_ciphers);
 PROVIDE(SSL_get_SSL_CTX = ossl_SSL_get_SSL_CTX);
 PROVIDE(SSL_new = ossl_SSL_new);
 PROVIDE(SSL_set_fd = ossl_SSL_set_fd);
-PROVIDE(SSL_shutdown = ossl_SSL_shutdown);
 PROVIDE(SSL_read = ossl_SSL_read);
 PROVIDE(SSL_SESSION_set_protocol_version = ossl_SSL_SESSION_set_protocol_version);
 PROVIDE(SSL_SESSION_free = ossl_SSL_SESSION_free);


### PR DESCRIPTION
Added:

- SSL_shutdown()
- SSL_CTX_get_min/max_proto_version()
- SSL_CTX_set_tlsext_ticket_keys()
- SSL_CTX_set_tlsext_servername_callback()
- SSL_set_session_id_context()
- SSL_session_reused()
- SSL_CTX_set_session_cache_mode()
- SSL_CTX_set_session_id_context()
- SSL_CTX_sess_set_new_cb()

Also, enabled the following BoringSSL unit tests:

- WithVersion/SSLVersionTest.WriteAfterShutdown/*
- WithVersion/SSLVersionTest.NoPeerCertificate*
- WithVersion/SSLVersionTest.SessionIDContext/*
- SSLTest.EnumTypes

Signed-off-by: Ted Poole <tpoole@redhat.com>