### PR TITLE
OSSM-3364 Added more <openssl/ssl.h> functions

### DIFF
--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -99,6 +99,7 @@ add_library(bssl-compat STATIC
   source/SSL_get_peer_signature_algorithm.c
   source/SSL_get_signature_algorithm_name.c
   source/SSL_get_wbio.cc
+  source/SSL_get0_alpn_selected.cc
   source/SSL_get0_ocsp_response.c
   source/SSL_get1_session.c
   source/SSL_select_next_proto.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -107,6 +107,7 @@ add_library(bssl-compat STATIC
   source/SSL_set_bio.cc
   source/SSL_set_chain_and_key.cc
   source/SSL_set_connect_state.cc
+  source/SSL_set_ex_data.cc
   source/SSL_set_fd.cc
   source/SSL_set_quiet_shutdown.cc
   source/SSL_set_session_id_context.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -102,6 +102,7 @@ add_library(bssl-compat STATIC
   source/SSL_get_peer_cert_chain.cc
   source/SSL_get_peer_certificate.cc
   source/SSL_get_peer_signature_algorithm.c
+  source/SSL_get_servername.cc
   source/SSL_get_session.cc
   source/SSL_get_signature_algorithm_name.c
   source/SSL_get_SSL_CTX.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -91,6 +91,7 @@ add_library(bssl-compat STATIC
   source/SSL_get_cipher_by_value.c
   source/SSL_get_curve_id.c
   source/SSL_get_curve_name.c
+  source/SSL_get_ex_new_index.cc
   source/SSL_get_peer_cert_chain.cc
   source/SSL_get_peer_certificate.cc
   source/SSL_get_peer_signature_algorithm.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -102,6 +102,7 @@ add_library(bssl-compat STATIC
   source/SSL_get0_alpn_selected.cc
   source/SSL_get0_ocsp_response.c
   source/SSL_get1_session.c
+  source/SSL_read.cc
   source/SSL_select_next_proto.cc
   source/SSL_SESSION_free.cc
   source/SSL_SESSION_from_bytes.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -106,6 +106,7 @@ add_library(bssl-compat STATIC
   source/SSL_session_reused.cc
   source/SSL_SESSION_to_bytes.c
   source/SSL_set_accept_state.cc
+  source/SSL_set_alpn_protos.cc
   source/SSL_set_bio.cc
   source/SSL_set_cert_cb.cc
   source/SSL_set_chain_and_key.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -75,6 +75,7 @@ add_library(bssl-compat STATIC
   source/SSL_CTX_get_max_proto_version.cc
   source/SSL_CTX_get_min_proto_version.cc
   source/SSL_CTX_sess_set_new_cb.cc
+  source/SSL_CTX_set_alpn_select_cb.cc
   source/SSL_CTX_set_cert_verify_callback.cc
   source/SSL_CTX_set_session_cache_mode.cc
   source/SSL_CTX_set_session_id_context.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -89,6 +89,7 @@ add_library(bssl-compat STATIC
   source/SSL_CTX_set_tlsext_servername_callback.cc
   source/SSL_CTX_set_tlsext_status_cb.c
   source/SSL_CTX_set_tlsext_ticket_keys.cc
+  source/SSL_CTX_set_verify_depth.cc
   source/SSL_CTX_use_certificate_file.cc
   source/SSL_CTX_use_PrivateKey.cc
   source/SSL_CTX_use_PrivateKey_file.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -45,36 +45,41 @@ add_custom_target(ossl-gen DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/include/ossl.h)
 
 add_library(bssl-compat STATIC
   source/asn1.c
-  source/BIO_up_ref.cc
   source/bio.cpp
+  source/BIO_up_ref.cc
   source/bn.c
   source/cipher.c
   source/CRYPTO_BUFFER_free.c
-  source/CRYPTO_BUFFER_new.c
   source/CRYPTO_BUFFER.h
+  source/CRYPTO_BUFFER_new.c
   source/crypto.c
   source/d2i_SSL_SESSION.c
   source/digest.c
   source/DTLS_method.cc
   source/err.c
+  source/evp.c
   source/EVP_DecodeBase64.c
   source/EVP_DecodedLength.c
-  source/evp.c
   source/i2d_SSL_SESSION.c
   source/log.c
   source/log.h
   source/mem.c
-  source/ossl_ERR_set_error.c
   source/ossl.c
+  source/ossl_ERR_set_error.c
   source/PEM_bytes_read_bio.c
   source/PEM_read_bio_PrivateKey.cc
   source/PEM_read_bio_RSAPrivateKey.c
   source/rand.c
   source/RSA_free.c
+  source/ssl.c
   source/ssl_cipher.c
+  source/ssl_ctx.c
+  source/ssl_ctx.cc
   source/SSL_CTX_get_max_proto_version.cc
   source/SSL_CTX_get_min_proto_version.cc
   source/SSL_CTX_sess_set_new_cb.cc
+  source/SSL_CTX_set1_curves_list.c
+  source/SSL_CTX_set1_sigalgs_list.c
   source/SSL_CTX_set_alpn_select_cb.cc
   source/SSL_CTX_set_cert_verify_callback.cc
   source/SSL_CTX_set_session_cache_mode.cc
@@ -82,13 +87,12 @@ add_library(bssl-compat STATIC
   source/SSL_CTX_set_tlsext_servername_callback.cc
   source/SSL_CTX_set_tlsext_status_cb.c
   source/SSL_CTX_set_tlsext_ticket_keys.cc
-  source/SSL_CTX_set1_curves_list.c
-  source/SSL_CTX_set1_sigalgs_list.c
   source/SSL_CTX_use_PrivateKey.cc
-  source/ssl_ctx.c
-  source/ssl_ctx.cc
   source/SSL_early_callback_ctx_extension_get.c
   source/ssl_ext.c
+  source/SSL_get0_alpn_selected.cc
+  source/SSL_get0_ocsp_response.c
+  source/SSL_get1_session.c
   source/SSL_get_cipher_by_value.c
   source/SSL_get_curve_id.c
   source/SSL_get_curve_name.c
@@ -98,10 +102,8 @@ add_library(bssl-compat STATIC
   source/SSL_get_peer_certificate.cc
   source/SSL_get_peer_signature_algorithm.c
   source/SSL_get_signature_algorithm_name.c
+  source/SSL_get_version.cc
   source/SSL_get_wbio.cc
-  source/SSL_get0_alpn_selected.cc
-  source/SSL_get0_ocsp_response.c
-  source/SSL_get1_session.c
   source/SSL_new.cc
   source/SSL_read.cc
   source/SSL_select_next_proto.cc
@@ -112,6 +114,7 @@ add_library(bssl-compat STATIC
   source/SSL_SESSION_is_resumable.c
   source/SSL_session_reused.cc
   source/SSL_SESSION_to_bytes.c
+  source/SSL_set1_curves_list.cc
   source/SSL_set_accept_state.cc
   source/SSL_set_alpn_protos.cc
   source/SSL_set_bio.cc
@@ -122,15 +125,13 @@ add_library(bssl-compat STATIC
   source/SSL_set_ex_data.cc
   source/SSL_set_fd.cc
   source/SSL_set_quiet_shutdown.cc
-  source/SSL_set_session_id_context.cc
   source/SSL_set_session.cc
+  source/SSL_set_session_id_context.cc
   source/SSL_set_tlsext_host_name.c
   source/SSL_set_verify.cc
-  source/SSL_set1_curves_list.cc
   source/SSL_shutdown.cc
   source/SSL_version.cc
   source/SSL_write.cc
-  source/ssl.c
   source/stack.c
   source/TLS_method.cc
   source/X509_get_pubkey.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -148,6 +148,7 @@ add_library(bssl-compat STATIC
   source/X509_get_pubkey.cc
   source/X509_NAME_cmp.cc
   source/X509_NAME_dup.cc
+  source/X509_NAME_free.cc
   source/X509_NAME_new.cc
 )
 

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -83,6 +83,7 @@ add_library(bssl-compat STATIC
   source/SSL_CTX_set1_sigalgs_list.c
   source/SSL_CTX_set_alpn_select_cb.cc
   source/SSL_CTX_set_cert_verify_callback.cc
+  source/SSL_CTX_set_options.cc
   source/SSL_CTX_set_session_cache_mode.cc
   source/SSL_CTX_set_session_id_context.cc
   source/SSL_CTX_set_timeout.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -146,6 +146,7 @@ add_library(bssl-compat STATIC
   source/TLS_method.cc
   source/TLS_VERSION_to_string.cc
   source/X509_get_pubkey.cc
+  source/X509_NAME_dup.cc
   source/X509_NAME_new.cc
 )
 

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -107,6 +107,7 @@ add_library(bssl-compat STATIC
   source/SSL_set_bio.cc
   source/SSL_set_chain_and_key.cc
   source/SSL_set_connect_state.cc
+  source/SSL_set_fd.cc
   source/SSL_set_quiet_shutdown.cc
   source/SSL_set_session_id_context.cc
   source/SSL_set_session.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -72,8 +72,8 @@ add_library(bssl-compat STATIC
   source/rand.c
   source/RSA_free.c
   source/ssl_cipher.c
-  source/SSL_CTX_get_min_proto_version.cc
   source/SSL_CTX_get_max_proto_version.cc
+  source/SSL_CTX_get_min_proto_version.cc
   source/SSL_CTX_sess_set_new_cb.cc
   source/SSL_CTX_set_cert_verify_callback.cc
   source/SSL_CTX_set_session_cache_mode.cc
@@ -91,6 +91,7 @@ add_library(bssl-compat STATIC
   source/SSL_get_cipher_by_value.c
   source/SSL_get_curve_id.c
   source/SSL_get_curve_name.c
+  source/SSL_get_ex_data.cc
   source/SSL_get_ex_new_index.cc
   source/SSL_get_peer_cert_chain.cc
   source/SSL_get_peer_certificate.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -96,6 +96,7 @@ add_library(bssl-compat STATIC
   source/SSL_get0_ocsp_response.c
   source/SSL_get1_session.c
   source/SSL_get_cipher_by_value.c
+  source/SSL_get_current_cipher.cc
   source/SSL_get_curve_id.c
   source/SSL_get_curve_name.c
   source/SSL_get_ex_data.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -146,6 +146,7 @@ add_library(bssl-compat STATIC
   source/TLS_method.cc
   source/TLS_VERSION_to_string.cc
   source/X509_get_pubkey.cc
+  source/X509_NAME_new.cc
 )
 
 target_add_bssl_source(bssl-compat

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -101,6 +101,7 @@ add_library(bssl-compat STATIC
   source/SSL_get_wbio.cc
   source/SSL_get0_ocsp_response.c
   source/SSL_get1_session.c
+  source/SSL_select_next_proto.cc
   source/SSL_SESSION_free.cc
   source/SSL_SESSION_from_bytes.c
   source/SSL_SESSION_get_id.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -146,6 +146,7 @@ add_library(bssl-compat STATIC
   source/TLS_method.cc
   source/TLS_VERSION_to_string.cc
   source/X509_get_pubkey.cc
+  source/X509_NAME_cmp.cc
   source/X509_NAME_dup.cc
   source/X509_NAME_new.cc
 )

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -104,6 +104,7 @@ add_library(bssl-compat STATIC
   source/SSL_get_peer_signature_algorithm.c
   source/SSL_get_session.cc
   source/SSL_get_signature_algorithm_name.c
+  source/SSL_get_SSL_CTX.cc
   source/SSL_get_version.cc
   source/SSL_get_wbio.cc
   source/SSL_new.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -102,6 +102,7 @@ add_library(bssl-compat STATIC
   source/SSL_get0_alpn_selected.cc
   source/SSL_get0_ocsp_response.c
   source/SSL_get1_session.c
+  source/SSL_new.cc
   source/SSL_read.cc
   source/SSL_select_next_proto.cc
   source/SSL_SESSION_free.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -90,6 +90,7 @@ add_library(bssl-compat STATIC
   source/SSL_CTX_set_tlsext_status_cb.c
   source/SSL_CTX_set_tlsext_ticket_keys.cc
   source/SSL_CTX_use_PrivateKey.cc
+  source/SSL_CTX_use_PrivateKey_file.cc
   source/SSL_early_callback_ctx_extension_get.c
   source/ssl_ext.c
   source/SSL_get0_alpn_selected.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -107,6 +107,7 @@ add_library(bssl-compat STATIC
   source/SSL_SESSION_to_bytes.c
   source/SSL_set_accept_state.cc
   source/SSL_set_bio.cc
+  source/SSL_set_cert_cb.cc
   source/SSL_set_chain_and_key.cc
   source/SSL_set_cipher_list.cc
   source/SSL_set_connect_state.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -107,6 +107,7 @@ add_library(bssl-compat STATIC
   source/SSL_set_bio.cc
   source/SSL_set_chain_and_key.cc
   source/SSL_set_connect_state.cc
+  source/SSL_set_quiet_shutdown.cc
   source/SSL_set_session_id_context.cc
   source/SSL_set_session.cc
   source/SSL_set_tlsext_host_name.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -89,6 +89,7 @@ add_library(bssl-compat STATIC
   source/SSL_CTX_set_tlsext_servername_callback.cc
   source/SSL_CTX_set_tlsext_status_cb.c
   source/SSL_CTX_set_tlsext_ticket_keys.cc
+  source/SSL_CTX_use_certificate_file.cc
   source/SSL_CTX_use_PrivateKey.cc
   source/SSL_CTX_use_PrivateKey_file.cc
   source/SSL_early_callback_ctx_extension_get.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -103,6 +103,7 @@ add_library(bssl-compat STATIC
   source/SSL_get1_session.c
   source/SSL_SESSION_from_bytes.c
   source/SSL_SESSION_get_id.c
+  source/SSL_SESSION_get_ticket_lifetime_hint.cc
   source/SSL_SESSION_is_resumable.c
   source/SSL_session_reused.cc
   source/SSL_SESSION_to_bytes.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -101,6 +101,7 @@ add_library(bssl-compat STATIC
   source/SSL_get_wbio.cc
   source/SSL_get0_ocsp_response.c
   source/SSL_get1_session.c
+  source/SSL_SESSION_free.cc
   source/SSL_SESSION_from_bytes.c
   source/SSL_SESSION_get_id.c
   source/SSL_SESSION_get_ticket_lifetime_hint.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -130,6 +130,7 @@ add_library(bssl-compat STATIC
   source/SSL_set_cert_cb.cc
   source/SSL_set_chain_and_key.cc
   source/SSL_set_cipher_list.cc
+  source/SSL_set_client_CA_list.cc
   source/SSL_set_connect_state.cc
   source/SSL_set_ex_data.cc
   source/SSL_set_fd.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -99,6 +99,7 @@ add_library(bssl-compat STATIC
   source/SSL_get_curve_id.c
   source/SSL_get_curve_name.c
   source/SSL_get_ex_data.cc
+  source/SSL_get_ex_data_X509_STORE_CTX_idx.cc
   source/SSL_get_ex_new_index.cc
   source/SSL_get_peer_cert_chain.cc
   source/SSL_get_peer_certificate.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -101,6 +101,7 @@ add_library(bssl-compat STATIC
   source/SSL_get_peer_cert_chain.cc
   source/SSL_get_peer_certificate.cc
   source/SSL_get_peer_signature_algorithm.c
+  source/SSL_get_session.cc
   source/SSL_get_signature_algorithm_name.c
   source/SSL_get_version.cc
   source/SSL_get_wbio.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -96,6 +96,7 @@ add_library(bssl-compat STATIC
   source/SSL_get0_ocsp_response.c
   source/SSL_get1_session.c
   source/SSL_get_cipher_by_value.c
+  source/SSL_get_client_CA_list.cc
   source/SSL_get_current_cipher.cc
   source/SSL_get_curve_id.c
   source/SSL_get_curve_name.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(bssl-compat STATIC
   source/EVP_DecodeBase64.c
   source/EVP_DecodedLength.c
   source/i2d_SSL_SESSION.c
+  source/internal.h
   source/log.c
   source/log.h
   source/mem.c
@@ -112,6 +113,7 @@ add_library(bssl-compat STATIC
   source/SSL_SESSION_from_bytes.c
   source/SSL_SESSION_get_id.c
   source/SSL_SESSION_get_ticket_lifetime_hint.cc
+  source/SSL_SESSION_get_version.cc
   source/SSL_SESSION_is_resumable.c
   source/SSL_session_reused.cc
   source/SSL_SESSION_to_bytes.c
@@ -135,6 +137,7 @@ add_library(bssl-compat STATIC
   source/SSL_write.cc
   source/stack.c
   source/TLS_method.cc
+  source/TLS_VERSION_to_string.cc
   source/X509_get_pubkey.cc
 )
 

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -85,6 +85,7 @@ add_library(bssl-compat STATIC
   source/SSL_CTX_set_cert_verify_callback.cc
   source/SSL_CTX_set_session_cache_mode.cc
   source/SSL_CTX_set_session_id_context.cc
+  source/SSL_CTX_set_timeout.cc
   source/SSL_CTX_set_tlsext_servername_arg.cc
   source/SSL_CTX_set_tlsext_servername_callback.cc
   source/SSL_CTX_set_tlsext_status_cb.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -85,6 +85,7 @@ add_library(bssl-compat STATIC
   source/SSL_CTX_set_cert_verify_callback.cc
   source/SSL_CTX_set_session_cache_mode.cc
   source/SSL_CTX_set_session_id_context.cc
+  source/SSL_CTX_set_tlsext_servername_arg.cc
   source/SSL_CTX_set_tlsext_servername_callback.cc
   source/SSL_CTX_set_tlsext_status_cb.c
   source/SSL_CTX_set_tlsext_ticket_keys.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -108,6 +108,7 @@ add_library(bssl-compat STATIC
   source/SSL_set_accept_state.cc
   source/SSL_set_bio.cc
   source/SSL_set_chain_and_key.cc
+  source/SSL_set_cipher_list.cc
   source/SSL_set_connect_state.cc
   source/SSL_set_ex_data.cc
   source/SSL_set_fd.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -88,6 +88,7 @@ add_library(bssl-compat STATIC
   source/SSL_CTX_set_tlsext_servername_arg.cc
   source/SSL_CTX_set_tlsext_servername_callback.cc
   source/SSL_CTX_set_tlsext_status_cb.c
+  source/SSL_CTX_set_tlsext_ticket_key_cb.cc
   source/SSL_CTX_set_tlsext_ticket_keys.cc
   source/SSL_CTX_set_verify_depth.cc
   source/SSL_CTX_use_certificate_file.cc

--- a/bssl-compat/patch/include/openssl/base.h.patch
+++ b/bssl-compat/patch/include/openssl/base.h.patch
@@ -526,7 +526,7 @@
  // typedef struct evp_encode_ctx_st EVP_ENCODE_CTX;
  // typedef struct evp_hpke_aead_st EVP_HPKE_AEAD;
  // typedef struct evp_hpke_ctx_st EVP_HPKE_CTX;
-@@ -410,9 +414,9 @@
+@@ -410,10 +414,10 @@
  // typedef struct evp_hpke_kem_st EVP_HPKE_KEM;
  // typedef struct evp_hpke_key_st EVP_HPKE_KEY;
  // typedef struct evp_pkey_asn1_method_st EVP_PKEY_ASN1_METHOD;
@@ -534,10 +534,12 @@
 +typedef ossl_EVP_PKEY_CTX EVP_PKEY_CTX;
  // typedef struct evp_pkey_method_st EVP_PKEY_METHOD;
 -// typedef struct evp_pkey_st EVP_PKEY;
+-// typedef struct hmac_ctx_st HMAC_CTX;
 +typedef ossl_EVP_PKEY EVP_PKEY;
- // typedef struct hmac_ctx_st HMAC_CTX;
++typedef ossl_HMAC_CTX HMAC_CTX;
  // typedef struct md4_state_st MD4_CTX;
  // typedef struct md5_state_st MD5_CTX;
+ // typedef struct ossl_init_settings_st OPENSSL_INIT_SETTINGS;
 @@ -424,21 +428,21 @@
  // typedef struct rc4_key_st RC4_KEY;
  // typedef struct rsa_meth_st RSA_METHOD;

--- a/bssl-compat/patch/include/openssl/ex_data.h.patch
+++ b/bssl-compat/patch/include/openssl/ex_data.h.patch
@@ -1,0 +1,77 @@
+--- a/include/openssl/ex_data.h
++++ b/include/openssl/ex_data.h
+@@ -106,16 +106,16 @@
+  * (eay@cryptsoft.com).  This product includes software written by Tim
+  * Hudson (tjh@cryptsoft.com). */
+ 
+-// #ifndef OPENSSL_HEADER_EX_DATA_H
+-// #define OPENSSL_HEADER_EX_DATA_H
++#ifndef OPENSSL_HEADER_EX_DATA_H
++#define OPENSSL_HEADER_EX_DATA_H
+ 
+-// #include <openssl/base.h>
++#include <openssl/base.h>
+ 
+-// #include <openssl/stack.h>
++#include <openssl/stack.h>
+ 
+-// #if defined(__cplusplus)
+-// extern "C" {
+-// #endif
++#if defined(__cplusplus)
++extern "C" {
++#endif
+ 
+ 
+ // ex_data is a mechanism for associating arbitrary extra data with objects.
+@@ -125,7 +125,7 @@
+ // duplicated.
+ 
+ 
+-// typedef struct crypto_ex_data_st CRYPTO_EX_DATA;
++typedef ossl_CRYPTO_EX_DATA CRYPTO_EX_DATA;
+ 
+ 
+ // Type-specific functions.
+@@ -171,8 +171,8 @@
+ // This callback may be called with a NULL value for |ptr| if |parent| has no
+ // value set for this index. However, the callbacks may also be skipped entirely
+ // if no extra data pointers are set on |parent| at all.
+-// typedef void CRYPTO_EX_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
+-//                             int index, long argl, void *argp);
++typedef void CRYPTO_EX_free(void *parent, void *ptr, CRYPTO_EX_DATA *ad,
++                            int index, long argl, void *argp);
+ 
+ 
+ // Deprecated functions.
+@@ -181,23 +181,23 @@
+ // OPENSSL_EXPORT void CRYPTO_cleanup_all_ex_data(void);
+ 
+ // CRYPTO_EX_dup is a legacy callback function type which is ignored.
+-// typedef int CRYPTO_EX_dup(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
+-//                           void **from_d, int index, long argl, void *argp);
++typedef int CRYPTO_EX_dup(CRYPTO_EX_DATA *to, const CRYPTO_EX_DATA *from,
++                          void **from_d, int index, long argl, void *argp);
+ 
+ 
+ // Private structures.
+ 
+ // CRYPTO_EX_unused is a placeholder for an unused callback. It is aliased to
+ // int to ensure non-NULL callers fail to compile rather than fail silently.
+-// typedef int CRYPTO_EX_unused;
++typedef int CRYPTO_EX_unused;
+ 
+ // struct crypto_ex_data_st {
+ //   STACK_OF(void) *sk;
+ // };
+ 
+ 
+-// #if defined(__cplusplus)
+-// }  // extern C
+-// #endif
++#if defined(__cplusplus)
++}  // extern C
++#endif
+ 
+-// #endif  // OPENSSL_HEADER_EX_DATA_H
++#endif  // OPENSSL_HEADER_EX_DATA_H

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -935,7 +935,22 @@
  
  // SSL_get0_alpn_selected gets the selected ALPN protocol (if any) from |ssl|.
  // On return it sets |*out_data| to point to |*out_len| bytes of protocol name
-@@ -4045,12 +4045,12 @@
+@@ -3126,10 +3126,10 @@
+ // and returns |OPENSSL_NPN_NEGOTIATED|. Otherwise, it returns
+ // |OPENSSL_NPN_NO_OVERLAP| and sets |*out| and |*out_len| to the first
+ // supported protocol.
+-// OPENSSL_EXPORT int SSL_select_next_proto(uint8_t **out, uint8_t *out_len,
+-//                                          const uint8_t *peer, unsigned peer_len,
+-//                                          const uint8_t *supported,
+-//                                          unsigned supported_len);
++OPENSSL_EXPORT int SSL_select_next_proto(uint8_t **out, uint8_t *out_len,
++                                         const uint8_t *peer, unsigned peer_len,
++                                         const uint8_t *supported,
++                                         unsigned supported_len);
+ 
+ #ifdef ossl_OPENSSL_NPN_UNSUPPORTED
+ #define OPENSSL_NPN_UNSUPPORTED ossl_OPENSSL_NPN_UNSUPPORTED
+@@ -4051,12 +4051,12 @@
  //
  // See |ex_data.h| for details.
  
@@ -954,7 +969,7 @@
  
  // OPENSSL_EXPORT int SSL_SESSION_set_ex_data(SSL_SESSION *session, int idx,
  //                                            void *data);
-@@ -4061,8 +4061,8 @@
+@@ -4067,8 +4067,8 @@
  //                                                 CRYPTO_EX_dup *dup_unused,
  //                                                 CRYPTO_EX_free *free_func);
  
@@ -965,7 +980,7 @@
  // OPENSSL_EXPORT int SSL_CTX_get_ex_new_index(long argl, void *argp,
  //                                             CRYPTO_EX_unused *unused,
  //                                             CRYPTO_EX_dup *dup_unused,
-@@ -4286,13 +4286,13 @@
+@@ -4292,13 +4292,13 @@
  // such as HTTP/1.1, and not others, such as HTTP/2.
  // OPENSSL_EXPORT void SSL_set_shed_handshake_config(SSL *ssl, int enable);
  
@@ -986,7 +1001,7 @@
  
  // SSL_set_renegotiate_mode configures how |ssl|, a client, reacts to
  // renegotiation attempts by a server. If |ssl| is a server, peer-initiated
-@@ -4321,8 +4321,8 @@
+@@ -4327,8 +4327,8 @@
  //
  // There is no support in BoringSSL for initiating renegotiations as a client
  // or server.
@@ -997,7 +1012,7 @@
  
  // SSL_renegotiate starts a deferred renegotiation on |ssl| if it was configured
  // with |ssl_renegotiate_explicit| and has a pending HelloRequest. It returns
-@@ -4383,45 +4383,45 @@
+@@ -4389,45 +4389,45 @@
  // callbacks that are called very early on during the server handshake. At this
  // point, much of the SSL* hasn't been filled out and only the ClientHello can
  // be depended on.
@@ -1073,7 +1088,7 @@
  
  // SSL_CTX_set_select_certificate_cb sets a callback that is called before most
  // ClientHello processing and before the decision whether to resume a session
-@@ -4437,9 +4437,9 @@
+@@ -4443,9 +4443,9 @@
  //
  // Note: The |SSL_CLIENT_HELLO| is only valid for the duration of the callback
  // and is not valid while the handshake is paused.
@@ -1086,7 +1101,7 @@
  
  // SSL_CTX_set_dos_protection_cb sets a callback that is called once the
  // resumption decision for a ClientHello has been made. It can return one to
-@@ -4555,7 +4555,7 @@
+@@ -4561,7 +4561,7 @@
  
  // SSL_get_peer_signature_algorithm returns the signature algorithm used by the
  // peer. If not applicable, it returns zero.
@@ -1095,7 +1110,7 @@
  
  // SSL_get_client_random writes up to |max_out| bytes of the most recent
  // handshake's client_random to |out| and returns the number of bytes written.
-@@ -4689,8 +4689,8 @@
+@@ -4695,8 +4695,8 @@
  
  // These client- and server-specific methods call their corresponding generic
  // methods.
@@ -1106,7 +1121,7 @@
  // OPENSSL_EXPORT const SSL_METHOD *SSLv23_server_method(void);
  // OPENSSL_EXPORT const SSL_METHOD *SSLv23_client_method(void);
  // OPENSSL_EXPORT const SSL_METHOD *TLSv1_server_method(void);
-@@ -4805,14 +4805,14 @@
+@@ -4811,14 +4811,14 @@
  // i2d_SSL_SESSION serializes |in|, as described in |i2d_SAMPLE|.
  //
  // Use |SSL_SESSION_to_bytes| instead.
@@ -1124,7 +1139,7 @@
  
  // i2d_SSL_SESSION_bio serializes |session| and writes the result to |bio|. It
  // returns the number of bytes written on success and <= 0 on error.
-@@ -4901,7 +4901,7 @@
+@@ -4907,7 +4907,7 @@
  // This API is compatible with OpenSSL. However, BoringSSL-specific code should
  // prefer |SSL_CTX_set_signing_algorithm_prefs| because it's clearer and it's
  // more convenient to codesearch for specific algorithm values.
@@ -1133,7 +1148,7 @@
  
  // SSL_set1_sigalgs_list takes a textual specification of a set of signature
  // algorithms and configures them on |ssl|. It returns one on success and zero
-@@ -4916,8 +4916,8 @@
+@@ -4922,8 +4922,8 @@
  // more convenient to codesearch for specific algorithm values.
  // OPENSSL_EXPORT int SSL_set1_sigalgs_list(SSL *ssl, const char *str);
  
@@ -1144,7 +1159,7 @@
  // #define SSL_SESSION_set_app_data(s, a) \
  //   (SSL_SESSION_set_ex_data(s, 0, (char *)(a)))
  // #define SSL_SESSION_get_app_data(s) (SSL_SESSION_get_ex_data(s, 0))
-@@ -5186,7 +5186,7 @@
+@@ -5192,7 +5192,7 @@
  
  // SSL_get1_session acts like |SSL_get_session| but returns a new reference to
  // the session.
@@ -1153,7 +1168,7 @@
  
  // #define OPENSSL_INIT_NO_LOAD_SSL_STRINGS 0
  // #define OPENSSL_INIT_LOAD_SSL_STRINGS 0
-@@ -5254,9 +5254,9 @@
+@@ -5260,9 +5260,9 @@
  // OCSP responses like other server credentials, such as certificates or SCT
  // lists. Configure, store, and refresh them eagerly. This avoids downtime if
  // the CA's OCSP responder is briefly offline.
@@ -1166,7 +1181,7 @@
  
  // SSL_CTX_set_tlsext_status_arg sets additional data for
  // |SSL_CTX_set_tlsext_status_cb|'s callback and returns one.
-@@ -5486,21 +5486,21 @@
+@@ -5492,21 +5492,21 @@
  // #endif // !defined(BORINGSSL_PREFIX)
  
  
@@ -1196,7 +1211,7 @@
  // BORINGSSL_MAKE_UP_REF(SSL_SESSION, SSL_SESSION_up_ref)
  
  // enum class OpenRecordResult {
-@@ -5617,13 +5617,13 @@
+@@ -5623,13 +5623,13 @@
  //     Span<const uint8_t> *out_write_traffic_secret);
  
  
@@ -1214,7 +1229,7 @@
  
  #ifdef ossl_SSL_R_APP_DATA_IN_HANDSHAKE
  #define SSL_R_APP_DATA_IN_HANDSHAKE ossl_SSL_R_APP_DATA_IN_HANDSHAKE
-@@ -6391,4 +6391,4 @@
+@@ -6397,4 +6397,4 @@
  #define SSL_R_TLSV1_ALERT_ECH_REQUIRED ossl_SSL_R_TLSV1_ALERT_ECH_REQUIRED
  #endif
  

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -887,12 +887,13 @@
  // See |ex_data.h| for details.
  
 -// OPENSSL_EXPORT int SSL_set_ex_data(SSL *ssl, int idx, void *data);
-+OPENSSL_EXPORT int SSL_set_ex_data(SSL *ssl, int idx, void *data);
- // OPENSSL_EXPORT void *SSL_get_ex_data(const SSL *ssl, int idx);
+-// OPENSSL_EXPORT void *SSL_get_ex_data(const SSL *ssl, int idx);
 -// OPENSSL_EXPORT int SSL_get_ex_new_index(long argl, void *argp,
 -//                                         CRYPTO_EX_unused *unused,
 -//                                         CRYPTO_EX_dup *dup_unused,
 -//                                         CRYPTO_EX_free *free_func);
++OPENSSL_EXPORT int SSL_set_ex_data(SSL *ssl, int idx, void *data);
++OPENSSL_EXPORT void *SSL_get_ex_data(const SSL *ssl, int idx);
 +OPENSSL_EXPORT int SSL_get_ex_new_index(long argl, void *argp,
 +                                        CRYPTO_EX_unused *unused,
 +                                        CRYPTO_EX_dup *dup_unused,

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -882,6 +882,15 @@
  
  
  // Application-layer protocol negotiation.
+@@ -4045,7 +4045,7 @@
+ //
+ // See |ex_data.h| for details.
+ 
+-// OPENSSL_EXPORT int SSL_set_ex_data(SSL *ssl, int idx, void *data);
++OPENSSL_EXPORT int SSL_set_ex_data(SSL *ssl, int idx, void *data);
+ // OPENSSL_EXPORT void *SSL_get_ex_data(const SSL *ssl, int idx);
+ // OPENSSL_EXPORT int SSL_get_ex_new_index(long argl, void *argp,
+ //                                         CRYPTO_EX_unused *unused,
 @@ -4061,8 +4061,8 @@
  //                                                 CRYPTO_EX_dup *dup_unused,
  //                                                 CRYPTO_EX_free *free_func);

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -552,7 +552,15 @@
  
  // SSL_get_tls_unique writes at most |max_out| bytes of the tls-unique value
  // for |ssl| to |out| and sets |*out_len| to the number of bytes written. It
-@@ -1719,7 +1720,7 @@
+@@ -1712,14 +1713,14 @@
+ 
+ // SSL_get_current_cipher returns cipher suite used by |ssl|, or NULL if it has
+ // not been negotiated yet.
+-// OPENSSL_EXPORT const SSL_CIPHER *SSL_get_current_cipher(const SSL *ssl);
++OPENSSL_EXPORT const SSL_CIPHER *SSL_get_current_cipher(const SSL *ssl);
+ 
+ // SSL_session_reused returns one if |ssl| performed an abbreviated handshake
+ // and zero otherwise.
  //
  // TODO(davidben): Hammer down the semantics of this API while a handshake,
  // initial or renego, is in progress.

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -1170,6 +1170,15 @@
  // #define SSL_SESSION_set_app_data(s, a) \
  //   (SSL_SESSION_set_ex_data(s, 0, (char *)(a)))
  // #define SSL_SESSION_get_app_data(s) (SSL_SESSION_get_ex_data(s, 0))
+@@ -5005,7 +5005,7 @@
+ 
+ // SSL_get_version returns a string describing the TLS version used by |ssl|.
+ // For example, "TLSv1.2" or "DTLSv1".
+-// OPENSSL_EXPORT const char *SSL_get_version(const SSL *ssl);
++OPENSSL_EXPORT const char *SSL_get_version(const SSL *ssl);
+ 
+ // SSL_get_cipher_list returns the name of the |n|th cipher in the output of
+ // |SSL_get_ciphers| or NULL if out of range. Use |SSL_get_ciphers| instead.
 @@ -5192,7 +5192,7 @@
  
  // SSL_get1_session acts like |SSL_get_session| but returns a new reference to

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -815,6 +815,15 @@
  
  // SSL_get_verify_result returns the result of certificate verification. It is
  // either |X509_V_OK| or a |X509_V_ERR_*| value.
+@@ -2655,7 +2656,7 @@
+ 
+ // SSL_get_ex_data_X509_STORE_CTX_idx returns the ex_data index used to look up
+ // the |SSL| associated with an |X509_STORE_CTX| in the verify callback.
+-// OPENSSL_EXPORT int SSL_get_ex_data_X509_STORE_CTX_idx(void);
++OPENSSL_EXPORT int SSL_get_ex_data_X509_STORE_CTX_idx(void);
+ 
+ // SSL_CTX_set_cert_verify_callback sets a custom callback to be called on
+ // certificate verification rather than |X509_verify_cert|. |store_ctx| contains
 @@ -2665,9 +2666,9 @@
  //
  // The callback may use |SSL_get_ex_data_X509_STORE_CTX_idx| to recover the

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -637,6 +637,17 @@
  
  // SSL_SESSION_has_ticket returns one if |session| has a ticket and zero
  // otherwise.
+@@ -1933,8 +1934,8 @@
+ 
+ // SSL_SESSION_get_ticket_lifetime_hint returns ticket lifetime hint of
+ // |session| in seconds or zero if none was set.
+-// OPENSSL_EXPORT uint32_t
+-// SSL_SESSION_get_ticket_lifetime_hint(const SSL_SESSION *session);
++OPENSSL_EXPORT uint32_t
++SSL_SESSION_get_ticket_lifetime_hint(const SSL_SESSION *session);
+ 
+ // SSL_SESSION_get0_cipher returns the cipher negotiated by the connection which
+ // established |session|.
 @@ -2049,7 +2050,7 @@
  
  // SSL_CTX_set_session_cache_mode sets the session cache mode bits for |ctx| to

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -898,6 +898,17 @@
  
  
  // Application-layer protocol negotiation.
+@@ -2920,8 +2920,8 @@
+ //
+ // WARNING: this function is dangerous because it breaks the usual return value
+ // convention.
+-// OPENSSL_EXPORT int SSL_set_alpn_protos(SSL *ssl, const uint8_t *protos,
+-//                                        unsigned protos_len);
++OPENSSL_EXPORT int SSL_set_alpn_protos(SSL *ssl, const uint8_t *protos,
++                                       unsigned protos_len);
+ 
+ // SSL_CTX_set_alpn_select_cb sets a callback function on |ctx| that is called
+ // during ClientHello processing in order to select an ALPN protocol from the
 @@ -4045,12 +4045,12 @@
  //
  // See |ex_data.h| for details.

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -686,6 +686,15 @@
  
  // SSL_DEFAULT_SESSION_TIMEOUT is the default lifetime, in seconds, of a
  // session in TLS 1.2 or earlier. This is how long we are willing to use the
+@@ -2083,7 +2084,7 @@
+ 
+ // SSL_CTX_set_timeout sets the lifetime, in seconds, of TLS 1.2 (or earlier)
+ // sessions created in |ctx| to |timeout|.
+-// OPENSSL_EXPORT uint32_t SSL_CTX_set_timeout(SSL_CTX *ctx, uint32_t timeout);
++OPENSSL_EXPORT uint32_t SSL_CTX_set_timeout(SSL_CTX *ctx, uint32_t timeout);
+ 
+ // SSL_CTX_set_session_psk_dhe_timeout sets the lifetime, in seconds, of TLS 1.3
+ // sessions created in |ctx| to |timeout|.
 @@ -2104,15 +2105,15 @@
  //
  // For a server, if |SSL_VERIFY_PEER| is enabled, it is an error to not set a

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -882,15 +882,24 @@
  
  
  // Application-layer protocol negotiation.
-@@ -4045,7 +4045,7 @@
+@@ -4045,12 +4045,12 @@
  //
  // See |ex_data.h| for details.
  
 -// OPENSSL_EXPORT int SSL_set_ex_data(SSL *ssl, int idx, void *data);
 +OPENSSL_EXPORT int SSL_set_ex_data(SSL *ssl, int idx, void *data);
  // OPENSSL_EXPORT void *SSL_get_ex_data(const SSL *ssl, int idx);
- // OPENSSL_EXPORT int SSL_get_ex_new_index(long argl, void *argp,
- //                                         CRYPTO_EX_unused *unused,
+-// OPENSSL_EXPORT int SSL_get_ex_new_index(long argl, void *argp,
+-//                                         CRYPTO_EX_unused *unused,
+-//                                         CRYPTO_EX_dup *dup_unused,
+-//                                         CRYPTO_EX_free *free_func);
++OPENSSL_EXPORT int SSL_get_ex_new_index(long argl, void *argp,
++                                        CRYPTO_EX_unused *unused,
++                                        CRYPTO_EX_dup *dup_unused,
++                                        CRYPTO_EX_free *free_func);
+ 
+ // OPENSSL_EXPORT int SSL_SESSION_set_ex_data(SSL_SESSION *session, int idx,
+ //                                            void *data);
 @@ -4061,8 +4061,8 @@
  //                                                 CRYPTO_EX_dup *dup_unused,
  //                                                 CRYPTO_EX_free *free_func);

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -817,6 +817,15 @@
  
  // enum ssl_verify_result_t BORINGSSL_ENUM_INT {
  //   ssl_verify_ok,
+@@ -2566,7 +2567,7 @@
+ // SSL_CTX_set_verify_depth sets the maximum depth of a certificate chain
+ // accepted in verification. This number does not include the leaf, so a depth
+ // of 1 allows the leaf and one CA certificate.
+-// OPENSSL_EXPORT void SSL_CTX_set_verify_depth(SSL_CTX *ctx, int depth);
++OPENSSL_EXPORT void SSL_CTX_set_verify_depth(SSL_CTX *ctx, int depth);
+ 
+ // SSL_set_verify_depth sets the maximum depth of a certificate chain accepted
+ // in verification. This number does not include the leaf, so a depth of 1
 @@ -2640,9 +2641,9 @@
  // See
  // https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_load_verify_locations.html

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -588,7 +588,7 @@
  
  // SSL_SESSION_to_bytes_for_ticket serializes |in|, but excludes the session
  // identification information, namely the session ID and ticket.
-@@ -1778,8 +1779,8 @@
+@@ -1778,12 +1779,12 @@
  
  // SSL_SESSION_from_bytes parses |in_len| bytes from |in| as an SSL_SESSION. It
  // returns a newly-allocated |SSL_SESSION| on success or NULL on error.
@@ -599,6 +599,11 @@
  
  // SSL_SESSION_get_version returns a string describing the TLS or DTLS version
  // |session| was established at. For example, "TLSv1.2" or "DTLSv1".
+-// OPENSSL_EXPORT const char *SSL_SESSION_get_version(const SSL_SESSION *session);
++OPENSSL_EXPORT const char *SSL_SESSION_get_version(const SSL_SESSION *session);
+ 
+ // SSL_SESSION_get_protocol_version returns the TLS or DTLS version |session|
+ // was established at.
 @@ -1793,8 +1794,8 @@
  // SSL_SESSION_set_protocol_version sets |session|'s TLS or DTLS version to
  // |version|. This may be useful when writing tests but should otherwise not be

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -892,7 +892,7 @@
  
  // SSL_get_servername_type, for a server, returns |TLSEXT_NAMETYPE_host_name|
  // if the client sent a hostname and -1 otherwise.
-@@ -2858,8 +2859,8 @@
+@@ -2858,12 +2859,12 @@
  // |SSL_TLSEXT_ERR_ALERT_FATAL|, then |*out_alert| is the alert to send,
  // defaulting to |SSL_AD_UNRECOGNIZED_NAME|. |SSL_TLSEXT_ERR_ALERT_WARNING| is
  // ignored and treated as |SSL_TLSEXT_ERR_OK|.
@@ -903,6 +903,11 @@
  
  // SSL_CTX_set_tlsext_servername_arg sets the argument to the servername
  // callback and returns one. See |SSL_CTX_set_tlsext_servername_callback|.
+-// OPENSSL_EXPORT int SSL_CTX_set_tlsext_servername_arg(SSL_CTX *ctx, void *arg);
++OPENSSL_EXPORT int SSL_CTX_set_tlsext_servername_arg(SSL_CTX *ctx, void *arg);
+ 
+ // SSL_TLSEXT_ERR_* are values returned by some extension-related callbacks.
+ #ifdef ossl_SSL_TLSEXT_ERR_OK
 @@ -2878,7 +2879,6 @@
  #ifdef ossl_SSL_TLSEXT_ERR_NOACK
  #define SSL_TLSEXT_ERR_NOACK ossl_SSL_TLSEXT_ERR_NOACK

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -1179,7 +1179,15 @@
  
  // SSL_get_cipher_list returns the name of the |n|th cipher in the output of
  // |SSL_get_ciphers| or NULL if out of range. Use |SSL_get_ciphers| instead.
-@@ -5192,7 +5192,7 @@
+@@ -5185,14 +5185,14 @@
+ // unresumable session which may be cached, but will never be resumed.
+ //
+ // If querying properties of the connection, use APIs on the |SSL| object.
+-// OPENSSL_EXPORT SSL_SESSION *SSL_get_session(const SSL *ssl);
++OPENSSL_EXPORT SSL_SESSION *SSL_get_session(const SSL *ssl);
+ 
+ // SSL_get0_session is an alias for |SSL_get_session|.
+ // #define SSL_get0_session SSL_get_session
  
  // SSL_get1_session acts like |SSL_get_session| but returns a new reference to
  // the session.

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -480,7 +480,12 @@
  
  // SSL_set_strict_cipher_list configures the cipher list for |ssl|, evaluating
  // |str| as a cipher string and returning error if |str| contains anything
-@@ -1601,7 +1602,7 @@
+@@ -1597,11 +1598,11 @@
+ //
+ // Prefer to use |SSL_set_strict_cipher_list|. This function tolerates garbage
+ // inputs, unless an empty cipher list results.
+-// OPENSSL_EXPORT int SSL_set_cipher_list(SSL *ssl, const char *str);
++OPENSSL_EXPORT int SSL_set_cipher_list(SSL *ssl, const char *str);
  
  // SSL_CTX_get_ciphers returns the cipher list for |ctx|, in order of
  // preference.

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -296,6 +296,17 @@
  
  // SSL_use_PrivateKey sets |ssl|'s private key to |pkey|. It returns one on
  // success and zero on failure.
+@@ -1022,8 +1023,8 @@
+ // On the server, the callback will be called after extensions have been
+ // processed, but before the resumption decision has been made. This differs
+ // from OpenSSL which handles resumption before selecting the certificate.
+-// OPENSSL_EXPORT void SSL_set_cert_cb(SSL *ssl, int (*cb)(SSL *ssl, void *arg),
+-//                                     void *arg);
++OPENSSL_EXPORT void SSL_set_cert_cb(SSL *ssl, int (*cb)(SSL *ssl, void *arg),
++                                    void *arg);
+ 
+ // SSL_get0_certificate_types, for a client, sets |*out_types| to an array
+ // containing the client certificate types requested by a server. It returns the
 @@ -1074,10 +1075,10 @@
  // OPENSSL_EXPORT int SSL_check_private_key(const SSL *ssl);
  

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -1219,6 +1219,17 @@
  // #define SSL_SESSION_set_app_data(s, a) \
  //   (SSL_SESSION_set_ex_data(s, 0, (char *)(a)))
  // #define SSL_SESSION_get_app_data(s) (SSL_SESSION_get_ex_data(s, 0))
+@@ -4939,8 +4939,8 @@
+ //     SSL_CIPHER_get_bits(SSL_get_current_cipher(ssl), out_alg_bits)
+ // #define SSL_get_cipher_version(ssl) \
+ //     SSL_CIPHER_get_version(SSL_get_current_cipher(ssl))
+-// #define SSL_get_cipher_name(ssl) \
+-//     SSL_CIPHER_get_name(SSL_get_current_cipher(ssl))
++#define SSL_get_cipher_name(ssl) \
++    SSL_CIPHER_get_name(SSL_get_current_cipher(ssl))
+ // #define SSL_get_time(session) SSL_SESSION_get_time(session)
+ // #define SSL_set_time(session, time) SSL_SESSION_set_time((session), (time))
+ // #define SSL_get_timeout(session) SSL_SESSION_get_timeout(session)
 @@ -5005,7 +5005,7 @@
  
  // SSL_get_version returns a string describing the TLS version used by |ssl|.

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -1096,6 +1096,17 @@
  
  // SSL_set1_sigalgs_list takes a textual specification of a set of signature
  // algorithms and configures them on |ssl|. It returns one on success and zero
+@@ -4916,8 +4916,8 @@
+ // more convenient to codesearch for specific algorithm values.
+ // OPENSSL_EXPORT int SSL_set1_sigalgs_list(SSL *ssl, const char *str);
+ 
+-// #define SSL_set_app_data(s, arg) (SSL_set_ex_data(s, 0, (char *)(arg)))
+-// #define SSL_get_app_data(s) (SSL_get_ex_data(s, 0))
++#define SSL_set_app_data(s, arg) (SSL_set_ex_data(s, 0, (char *)(arg)))
++#define SSL_get_app_data(s) (SSL_get_ex_data(s, 0))
+ // #define SSL_SESSION_set_app_data(s, a) \
+ //   (SSL_SESSION_set_ex_data(s, 0, (char *)(a)))
+ // #define SSL_SESSION_get_app_data(s) (SSL_SESSION_get_ex_data(s, 0))
 @@ -5186,7 +5186,7 @@
  
  // SSL_get1_session acts like |SSL_get_session| but returns a new reference to

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -394,7 +394,14 @@
  
  // OPENSSL_EXPORT int SSL_CTX_use_RSAPrivateKey_file(SSL_CTX *ctx,
  //                                                   const char *file,
-@@ -1268,8 +1269,8 @@
+@@ -1263,13 +1264,13 @@
+ // OPENSSL_EXPORT int SSL_use_RSAPrivateKey_file(SSL *ssl, const char *file,
+ //                                               int type);
+ 
+-// OPENSSL_EXPORT int SSL_CTX_use_certificate_file(SSL_CTX *ctx, const char *file,
+-//                                                 int type);
++OPENSSL_EXPORT int SSL_CTX_use_certificate_file(SSL_CTX *ctx, const char *file,
++                                                int type);
  // OPENSSL_EXPORT int SSL_use_certificate_file(SSL *ssl, const char *file,
  //                                             int type);
  

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -872,7 +872,7 @@
  
  // SSL_add_bio_cert_subjects_to_stack behaves like
  // |SSL_add_file_cert_subjects_to_stack| but reads from |bio|.
-@@ -2832,11 +2833,11 @@
+@@ -2832,16 +2833,16 @@
  // deployments to select one of a several certificates on a single IP. Only the
  // host_name name type is supported.
  
@@ -886,6 +886,12 @@
  
  // SSL_get_servername, for a server, returns the hostname supplied by the
  // client or NULL if there was none. The |type| argument must be
+ // |TLSEXT_NAMETYPE_host_name|.
+-// OPENSSL_EXPORT const char *SSL_get_servername(const SSL *ssl, const int type);
++OPENSSL_EXPORT const char *SSL_get_servername(const SSL *ssl, const int type);
+ 
+ // SSL_get_servername_type, for a server, returns |TLSEXT_NAMETYPE_host_name|
+ // if the client sent a hostname and -1 otherwise.
 @@ -2858,8 +2859,8 @@
  // |SSL_TLSEXT_ERR_ALERT_FATAL|, then |*out_alert| is the alert to send,
  // defaulting to |SSL_AD_UNRECOGNIZED_NAME|. |SSL_TLSEXT_ERR_ALERT_WARNING| is

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -729,6 +729,21 @@
  
  // SSL_TICKET_KEY_NAME_LEN is the length of the key name prefix of a session
  // ticket.
+@@ -2301,10 +2302,10 @@
+ //
+ // WARNING: |callback| wildly breaks the usual return value convention and is
+ // called in two different modes.
+-// OPENSSL_EXPORT int SSL_CTX_set_tlsext_ticket_key_cb(
+-//     SSL_CTX *ctx, int (*callback)(SSL *ssl, uint8_t *key_name, uint8_t *iv,
+-//                                   EVP_CIPHER_CTX *ctx, HMAC_CTX *hmac_ctx,
+-//                                   int encrypt));
++OPENSSL_EXPORT int SSL_CTX_set_tlsext_ticket_key_cb(
++    SSL_CTX *ctx, int (*callback)(SSL *ssl, uint8_t *key_name, uint8_t *iv,
++                                  EVP_CIPHER_CTX *ctx, HMAC_CTX *hmac_ctx,
++                                  int encrypt));
+ 
+ // ssl_ticket_aead_result_t enumerates the possible results from decrypting a
+ // ticket with an |SSL_TICKET_AEAD_METHOD|.
 @@ -2409,20 +2410,20 @@
  // colon-separated list |curves|. Each element of |curves| should be a curve
  // name (e.g. P-256, X25519, ...). It returns one on success and zero on

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -867,7 +867,14 @@
  
  // SSL_set_verify_algorithm_prefs configures |ssl| to use |prefs| as the
  // preference list when verifying signatures from the peer's long-term key. It
-@@ -2755,8 +2756,8 @@
+@@ -2750,13 +2751,13 @@
+ 
+ // SSL_set_client_CA_list sets |ssl|'s client certificate CA list to
+ // |name_list|. It takes ownership of |name_list|.
+-// OPENSSL_EXPORT void SSL_set_client_CA_list(SSL *ssl,
+-//                                            STACK_OF(X509_NAME) *name_list);
++OPENSSL_EXPORT void SSL_set_client_CA_list(SSL *ssl,
++                                           STACK_OF(X509_NAME) *name_list);
  
  // SSL_CTX_set_client_CA_list sets |ctx|'s client certificate CA list to
  // |name_list|. It takes ownership of |name_list|.

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -878,6 +878,15 @@
  
  // SSL_set0_client_CAs sets |ssl|'s client certificate CA list to |name_list|,
  // which should contain DER-encoded distinguished names (RFC 5280). It takes
+@@ -2778,7 +2779,7 @@
+ // the server. In this mode, the behavior is undefined except during the
+ // callbacks set by |SSL_CTX_set_cert_cb| and |SSL_CTX_set_client_cert_cb| or
+ // when the handshake is paused because of them.
+-// OPENSSL_EXPORT STACK_OF(X509_NAME) *SSL_get_client_CA_list(const SSL *ssl);
++OPENSSL_EXPORT STACK_OF(X509_NAME) *SSL_get_client_CA_list(const SSL *ssl);
+ 
+ // SSL_get0_server_requested_CAs returns the CAs sent by a server to guide a
+ // client in certificate selection. They are a series of DER-encoded X.509
 @@ -2816,8 +2817,8 @@
  // SSL_add_file_cert_subjects_to_stack behaves like |SSL_load_client_CA_file|
  // but appends the result to |out|. It returns one on success or zero on

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -278,7 +278,7 @@
  
  
  // Options.
-@@ -928,7 +929,7 @@
+@@ -946,7 +947,7 @@
  
  // SSL_CTX_use_certificate sets |ctx|'s leaf certificate to |x509|. It returns
  // one on success and zero on failure.
@@ -287,7 +287,7 @@
  
  // SSL_use_certificate sets |ssl|'s leaf certificate to |x509|. It returns one
  // on success and zero on failure.
-@@ -936,7 +937,7 @@
+@@ -954,7 +955,7 @@
  
  // SSL_CTX_use_PrivateKey sets |ctx|'s private key to |pkey|. It returns one on
  // success and zero on failure.
@@ -296,7 +296,7 @@
  
  // SSL_use_PrivateKey sets |ssl|'s private key to |pkey|. It returns one on
  // success and zero on failure.
-@@ -1022,8 +1023,8 @@
+@@ -1040,8 +1041,8 @@
  // On the server, the callback will be called after extensions have been
  // processed, but before the resumption decision has been made. This differs
  // from OpenSSL which handles resumption before selecting the certificate.
@@ -307,7 +307,7 @@
  
  // SSL_get0_certificate_types, for a client, sets |*out_types| to an array
  // containing the client certificate types requested by a server. It returns the
-@@ -1074,10 +1075,10 @@
+@@ -1092,10 +1093,10 @@
  // OPENSSL_EXPORT int SSL_check_private_key(const SSL *ssl);
  
  // SSL_CTX_get0_certificate returns |ctx|'s leaf certificate.
@@ -320,7 +320,7 @@
  
  // SSL_CTX_get0_privatekey returns |ctx|'s private key.
  // OPENSSL_EXPORT EVP_PKEY *SSL_CTX_get0_privatekey(const SSL_CTX *ctx);
-@@ -1129,23 +1130,23 @@
+@@ -1147,23 +1148,23 @@
  // SSL_set_ocsp_response sets the OCSP response that is sent to clients which
  // request it. It returns one on success and zero on error. The caller retains
  // ownership of |response|.
@@ -359,7 +359,7 @@
  
  // SSL_SIGN_RSA_PKCS1_MD5_SHA1 is an internal signature algorithm used to
  // specify raw RSASSA-PKCS1-v1_5 with an MD5/SHA-1 concatenation, as used in TLS
-@@ -1155,8 +1156,8 @@
+@@ -1173,8 +1174,8 @@
  // SSL_get_signature_algorithm_name returns a human-readable name for |sigalg|,
  // or NULL if unknown. If |include_curve| is one, the curve for ECDSA algorithms
  // is included as in TLS 1.3. Otherwise, it is excluded as in TLS 1.2.
@@ -370,7 +370,7 @@
  
  // SSL_get_signature_algorithm_key_type returns the key type associated with
  // |sigalg| as an |EVP_PKEY_*| constant or |EVP_PKEY_NONE| if unknown.
-@@ -1202,9 +1203,9 @@
+@@ -1220,9 +1221,9 @@
  // client or server. References to the given |CRYPTO_BUFFER| and |EVP_PKEY|
  // objects are added as needed. Exactly one of |privkey| or |privkey_method|
  // may be non-NULL. Returns one on success and zero on error.
@@ -383,7 +383,7 @@
  
  // SSL_CTX_get0_chain returns the list of |CRYPTO_BUFFER|s that were set by
  // |SSL_CTX_set_chain_and_key|. Reference counts are not incremented by this
-@@ -1254,8 +1255,8 @@
+@@ -1272,8 +1273,8 @@
  // |type| parameter is one of the |SSL_FILETYPE_*| values and determines whether
  // the file's contents are read as PEM or DER.
  
@@ -394,7 +394,7 @@
  
  // OPENSSL_EXPORT int SSL_CTX_use_RSAPrivateKey_file(SSL_CTX *ctx,
  //                                                   const char *file,
-@@ -1263,13 +1264,13 @@
+@@ -1281,13 +1282,13 @@
  // OPENSSL_EXPORT int SSL_use_RSAPrivateKey_file(SSL *ssl, const char *file,
  //                                               int type);
  
@@ -412,7 +412,7 @@
  // OPENSSL_EXPORT int SSL_use_PrivateKey_file(SSL *ssl, const char *file,
  //                                            int type);
  
-@@ -1277,8 +1278,8 @@
+@@ -1295,8 +1296,8 @@
  // reads the contents of |file| as a PEM-encoded leaf certificate followed
  // optionally by the certificate chain to send to the peer. It returns one on
  // success and zero on failure.
@@ -423,7 +423,7 @@
  
  // SSL_CTX_set_default_passwd_cb sets the password callback for PEM-based
  // convenience functions called on |ctx|.
-@@ -1302,11 +1303,11 @@
+@@ -1320,11 +1321,11 @@
  
  // Custom private keys.
  
@@ -440,7 +440,7 @@
  
  // ssl_private_key_method_st (aka |SSL_PRIVATE_KEY_METHOD|) describes private
  // key hooks. This is used to off-load signing operations to a custom,
-@@ -1391,12 +1392,12 @@
+@@ -1409,12 +1410,12 @@
  //
  // |SSL_CIPHER| objects represent cipher suites.
  
@@ -455,7 +455,7 @@
  
  // SSL_CIPHER_get_id returns |cipher|'s non-IANA id. This is not its
  // IANA-assigned number, which is called the "value" here, although it may be
-@@ -1445,7 +1446,7 @@
+@@ -1463,7 +1464,7 @@
  
  // SSL_CIPHER_get_min_version returns the minimum protocol version required
  // for |cipher|.
@@ -464,7 +464,7 @@
  
  // SSL_CIPHER_get_max_version returns the maximum protocol version that
  // supports |cipher|.
-@@ -1453,12 +1454,12 @@
+@@ -1471,12 +1472,12 @@
  
  // SSL_CIPHER_standard_name returns the standard IETF name for |cipher|. For
  // example, "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256".
@@ -479,7 +479,7 @@
  
  // SSL_CIPHER_get_kx_name returns a string that describes the key-exchange
  // method used by |cipher|. For example, "ECDHE_ECDSA". TLS 1.3 AEAD-only
-@@ -1577,15 +1578,15 @@
+@@ -1595,15 +1596,15 @@
  // SSL_CTX_set_strict_cipher_list configures the cipher list for |ctx|,
  // evaluating |str| as a cipher string and returning error if |str| contains
  // anything meaningless. It returns one on success and zero on failure.
@@ -498,7 +498,7 @@
  
  // SSL_set_strict_cipher_list configures the cipher list for |ssl|, evaluating
  // |str| as a cipher string and returning error if |str| contains anything
-@@ -1597,11 +1598,11 @@
+@@ -1615,11 +1616,11 @@
  //
  // Prefer to use |SSL_set_strict_cipher_list|. This function tolerates garbage
  // inputs, unless an empty cipher list results.
@@ -512,7 +512,7 @@
  
  // SSL_CTX_cipher_in_group returns one if the |i|th cipher (see
  // |SSL_CTX_get_ciphers|) is in the same equipreference group as the one
-@@ -1609,7 +1610,7 @@
+@@ -1627,7 +1628,7 @@
  // OPENSSL_EXPORT int SSL_CTX_cipher_in_group(const SSL_CTX *ctx, size_t i);
  
  // SSL_get_ciphers returns the cipher list for |ssl|, in order of preference.
@@ -521,7 +521,7 @@
  
  
  // Connection information.
-@@ -1633,7 +1634,7 @@
+@@ -1651,7 +1652,7 @@
  // SSL_get_peer_certificate returns the peer's leaf certificate or NULL if the
  // peer did not use certificates. The caller must call |X509_free| on the
  // result to release it.
@@ -530,7 +530,7 @@
  
  // SSL_get_peer_cert_chain returns the peer's certificate chain or NULL if
  // unavailable or the peer did not use certificates. This is the unverified list
-@@ -1643,7 +1644,7 @@
+@@ -1661,7 +1662,7 @@
  // WARNING: This function behaves differently between client and server. If
  // |ssl| is a server, the returned chain does not include the leaf certificate.
  // If a client, it does.
@@ -539,7 +539,7 @@
  
  // SSL_get_peer_full_cert_chain returns the peer's certificate chain, or NULL if
  // unavailable or the peer did not use certificates. This is the unverified list
-@@ -1655,7 +1656,7 @@
+@@ -1673,7 +1674,7 @@
  // (if any) will be the leaf certificate. In constrast,
  // |SSL_get_peer_cert_chain| returns only the intermediate certificates if the
  // |ssl| is a server.
@@ -548,7 +548,7 @@
  
  // SSL_get0_peer_certificates returns the peer's certificate chain, or NULL if
  // unavailable or the peer did not use certificates. This is the unverified list
-@@ -1683,8 +1684,8 @@
+@@ -1701,8 +1702,8 @@
  // OCSPResponse type as defined in RFC 2560.
  //
  // WARNING: the returned data is not guaranteed to be well formed.
@@ -559,7 +559,7 @@
  
  // SSL_get_tls_unique writes at most |max_out| bytes of the tls-unique value
  // for |ssl| to |out| and sets |*out_len| to the number of bytes written. It
-@@ -1712,14 +1713,14 @@
+@@ -1730,14 +1731,14 @@
  
  // SSL_get_current_cipher returns cipher suite used by |ssl|, or NULL if it has
  // not been negotiated yet.
@@ -576,7 +576,7 @@
  
  // SSL_get_secure_renegotiation_support returns one if the peer supports secure
  // renegotiation (RFC 5746) or TLS 1.3. Otherwise, it returns zero.
-@@ -1753,7 +1754,7 @@
+@@ -1771,7 +1772,7 @@
  // SSL_SESSION_new returns a newly-allocated blank |SSL_SESSION| or NULL on
  // error. This may be useful when writing tests but should otherwise not be
  // used.
@@ -585,7 +585,7 @@
  
  // SSL_SESSION_up_ref increments the reference count of |session| and returns
  // one.
-@@ -1761,14 +1762,14 @@
+@@ -1779,14 +1780,14 @@
  
  // SSL_SESSION_free decrements the reference count of |session|. If it reaches
  // zero, all data referenced by |session| and |session| itself are released.
@@ -603,7 +603,7 @@
  
  // SSL_SESSION_to_bytes_for_ticket serializes |in|, but excludes the session
  // identification information, namely the session ID and ticket.
-@@ -1778,12 +1779,12 @@
+@@ -1796,12 +1797,12 @@
  
  // SSL_SESSION_from_bytes parses |in_len| bytes from |in| as an SSL_SESSION. It
  // returns a newly-allocated |SSL_SESSION| on success or NULL on error.
@@ -619,7 +619,7 @@
  
  // SSL_SESSION_get_protocol_version returns the TLS or DTLS version |session|
  // was established at.
-@@ -1793,8 +1794,8 @@
+@@ -1811,8 +1812,8 @@
  // SSL_SESSION_set_protocol_version sets |session|'s TLS or DTLS version to
  // |version|. This may be useful when writing tests but should otherwise not be
  // used. It returns one on success and zero on error.
@@ -630,7 +630,7 @@
  
  // SSL_MAX_SSL_SESSION_ID_LENGTH is the maximum length of an SSL session ID.
  // #define SSL_MAX_SSL_SESSION_ID_LENGTH 32
-@@ -1814,8 +1815,8 @@
+@@ -1832,8 +1833,8 @@
  // As a workaround for some broken applications, BoringSSL sometimes synthesizes
  // arbitrary session IDs for non-ID-based sessions. This behavior may be
  // removed in the future.
@@ -641,7 +641,7 @@
  
  // SSL_SESSION_set1_id sets |session|'s session ID to |sid|, It returns one on
  // success and zero on error. This function may be useful in writing tests but
-@@ -1905,13 +1906,13 @@
+@@ -1923,13 +1924,13 @@
  // only once. This prevents passive observers from correlating connections with
  // tickets. See RFC 8446, appendix C.4. If it returns zero, |session| cannot be
  // used without leaking a correlator.
@@ -657,7 +657,7 @@
  
  // SSL_SESSION_has_ticket returns one if |session| has a ticket and zero
  // otherwise.
-@@ -1933,8 +1934,8 @@
+@@ -1951,8 +1952,8 @@
  
  // SSL_SESSION_get_ticket_lifetime_hint returns ticket lifetime hint of
  // |session| in seconds or zero if none was set.
@@ -668,7 +668,7 @@
  
  // SSL_SESSION_get0_cipher returns the cipher negotiated by the connection which
  // established |session|.
-@@ -2049,7 +2050,7 @@
+@@ -2067,7 +2068,7 @@
  
  // SSL_CTX_set_session_cache_mode sets the session cache mode bits for |ctx| to
  // |mode|. It returns the previous value.
@@ -677,7 +677,7 @@
  
  // SSL_CTX_get_session_cache_mode returns the session cache mode bits for
  // |ctx|
-@@ -2064,7 +2065,7 @@
+@@ -2082,7 +2083,7 @@
  // |SSL_SESSION_get0_ocsp_response|.
  //
  // It is an error to call this function after the handshake has begun.
@@ -686,7 +686,7 @@
  
  // SSL_DEFAULT_SESSION_TIMEOUT is the default lifetime, in seconds, of a
  // session in TLS 1.2 or earlier. This is how long we are willing to use the
-@@ -2083,7 +2084,7 @@
+@@ -2101,7 +2102,7 @@
  
  // SSL_CTX_set_timeout sets the lifetime, in seconds, of TLS 1.2 (or earlier)
  // sessions created in |ctx| to |timeout|.
@@ -695,7 +695,7 @@
  
  // SSL_CTX_set_session_psk_dhe_timeout sets the lifetime, in seconds, of TLS 1.3
  // sessions created in |ctx| to |timeout|.
-@@ -2104,15 +2105,15 @@
+@@ -2122,15 +2123,15 @@
  //
  // For a server, if |SSL_VERIFY_PEER| is enabled, it is an error to not set a
  // session ID context.
@@ -716,7 +716,7 @@
  
  // SSL_get0_session_id_context returns a pointer to |ssl|'s session ID context
  // and sets |*out_len| to its length.  It returns NULL on error.
-@@ -2167,8 +2168,8 @@
+@@ -2185,8 +2186,8 @@
  // |SSL_do_handshake| or |SSL_connect| completes if False Start is enabled. Thus
  // it's recommended to use this callback over calling |SSL_get_session| on
  // handshake completion.
@@ -727,7 +727,7 @@
  
  // SSL_CTX_sess_get_new_cb returns the callback set by
  // |SSL_CTX_sess_set_new_cb|.
-@@ -2271,8 +2272,8 @@
+@@ -2289,8 +2290,8 @@
  // SSL_CTX_set_tlsext_ticket_keys sets |ctx|'s session ticket key material to
  // |len| bytes of |in|. It returns one on success and zero if |len| is not
  // 48. If |in| is NULL, it returns 48 instead.
@@ -738,7 +738,7 @@
  
  // SSL_TICKET_KEY_NAME_LEN is the length of the key name prefix of a session
  // ticket.
-@@ -2301,10 +2302,10 @@
+@@ -2319,10 +2320,10 @@
  //
  // WARNING: |callback| wildly breaks the usual return value convention and is
  // called in two different modes.
@@ -753,7 +753,7 @@
  
  // ssl_ticket_aead_result_t enumerates the possible results from decrypting a
  // ticket with an |SSL_TICKET_AEAD_METHOD|.
-@@ -2409,20 +2410,20 @@
+@@ -2427,20 +2428,20 @@
  // colon-separated list |curves|. Each element of |curves| should be a curve
  // name (e.g. P-256, X25519, ...). It returns one on success and zero on
  // failure.
@@ -781,7 +781,7 @@
  // #define SSL_CURVE_CECPQ2 16696
  
  // SSL_get_curve_id returns the ID of the curve used by |ssl|'s most recently
-@@ -2430,11 +2431,11 @@
+@@ -2448,11 +2449,11 @@
  //
  // TODO(davidben): This API currently does not work correctly if there is a
  // renegotiation in progress. Fix this.
@@ -795,7 +795,7 @@
  
  
  // Certificate verification.
-@@ -2465,18 +2466,18 @@
+@@ -2483,18 +2484,18 @@
  // SSL_VERIFY_NONE, on a client, verifies the server certificate but does not
  // make errors fatal. The result may be checked with |SSL_get_verify_result|. On
  // a server it does not request a client certificate. This is the default.
@@ -817,7 +817,7 @@
  
  // SSL_VERIFY_PEER_IF_NO_OBC configures a server to request a client certificate
  // if and only if Channel ID is not negotiated.
-@@ -2489,8 +2490,8 @@
+@@ -2507,8 +2508,8 @@
  //
  // The callback may use |SSL_get_ex_data_X509_STORE_CTX_idx| with
  // |X509_STORE_CTX_get_ex_data| to look up the |SSL| from |store_ctx|.
@@ -828,7 +828,7 @@
  
  // SSL_set_verify configures certificate verification behavior. |mode| is one of
  // the |SSL_VERIFY_*| values defined above. |callback|, if not NULL, is used to
-@@ -2499,9 +2500,9 @@
+@@ -2517,9 +2518,9 @@
  //
  // The callback may use |SSL_get_ex_data_X509_STORE_CTX_idx| with
  // |X509_STORE_CTX_get_ex_data| to look up the |SSL| from |store_ctx|.
@@ -841,7 +841,7 @@
  
  // enum ssl_verify_result_t BORINGSSL_ENUM_INT {
  //   ssl_verify_ok,
-@@ -2566,7 +2567,7 @@
+@@ -2584,7 +2585,7 @@
  // SSL_CTX_set_verify_depth sets the maximum depth of a certificate chain
  // accepted in verification. This number does not include the leaf, so a depth
  // of 1 allows the leaf and one CA certificate.
@@ -850,7 +850,7 @@
  
  // SSL_set_verify_depth sets the maximum depth of a certificate chain accepted
  // in verification. This number does not include the leaf, so a depth of 1
-@@ -2640,9 +2641,9 @@
+@@ -2658,9 +2659,9 @@
  // See
  // https://www.openssl.org/docs/man1.1.0/man3/SSL_CTX_load_verify_locations.html
  // for documentation on the directory format.
@@ -863,7 +863,7 @@
  
  // SSL_get_verify_result returns the result of certificate verification. It is
  // either |X509_V_OK| or a |X509_V_ERR_*| value.
-@@ -2655,7 +2656,7 @@
+@@ -2673,7 +2674,7 @@
  
  // SSL_get_ex_data_X509_STORE_CTX_idx returns the ex_data index used to look up
  // the |SSL| associated with an |X509_STORE_CTX| in the verify callback.
@@ -872,7 +872,7 @@
  
  // SSL_CTX_set_cert_verify_callback sets a custom callback to be called on
  // certificate verification rather than |X509_verify_cert|. |store_ctx| contains
-@@ -2665,9 +2666,9 @@
+@@ -2683,9 +2684,9 @@
  //
  // The callback may use |SSL_get_ex_data_X509_STORE_CTX_idx| to recover the
  // |SSL| object from |store_ctx|.
@@ -885,7 +885,7 @@
  
  // SSL_enable_signed_cert_timestamps causes |ssl| (which must be the client end
  // of a connection) to request SCTs from the server. See
-@@ -2689,7 +2690,7 @@
+@@ -2707,7 +2708,7 @@
  //
  // Call |SSL_get0_ocsp_response| to recover the OCSP response after the
  // handshake.
@@ -894,7 +894,7 @@
  
  // SSL_CTX_enable_ocsp_stapling enables OCSP stapling on all client SSL objects
  // created from |ctx|.
-@@ -2724,9 +2725,9 @@
+@@ -2742,9 +2743,9 @@
  // preference list when verifying signatures from the peer's long-term key. It
  // returns one on zero on error. |prefs| should not include the internal-only
  // value |SSL_SIGN_RSA_PKCS1_MD5_SHA1|.
@@ -907,7 +907,7 @@
  
  // SSL_set_verify_algorithm_prefs configures |ssl| to use |prefs| as the
  // preference list when verifying signatures from the peer's long-term key. It
-@@ -2750,13 +2751,13 @@
+@@ -2768,13 +2769,13 @@
  
  // SSL_set_client_CA_list sets |ssl|'s client certificate CA list to
  // |name_list|. It takes ownership of |name_list|.
@@ -925,7 +925,7 @@
  
  // SSL_set0_client_CAs sets |ssl|'s client certificate CA list to |name_list|,
  // which should contain DER-encoded distinguished names (RFC 5280). It takes
-@@ -2778,7 +2779,7 @@
+@@ -2796,7 +2797,7 @@
  // the server. In this mode, the behavior is undefined except during the
  // callbacks set by |SSL_CTX_set_cert_cb| and |SSL_CTX_set_client_cert_cb| or
  // when the handshake is paused because of them.
@@ -934,7 +934,7 @@
  
  // SSL_get0_server_requested_CAs returns the CAs sent by a server to guide a
  // client in certificate selection. They are a series of DER-encoded X.509
-@@ -2816,8 +2817,8 @@
+@@ -2834,8 +2835,8 @@
  // SSL_add_file_cert_subjects_to_stack behaves like |SSL_load_client_CA_file|
  // but appends the result to |out|. It returns one on success or zero on
  // error.
@@ -945,7 +945,7 @@
  
  // SSL_add_bio_cert_subjects_to_stack behaves like
  // |SSL_add_file_cert_subjects_to_stack| but reads from |bio|.
-@@ -2832,16 +2833,16 @@
+@@ -2850,16 +2851,16 @@
  // deployments to select one of a several certificates on a single IP. Only the
  // host_name name type is supported.
  
@@ -965,7 +965,7 @@
  
  // SSL_get_servername_type, for a server, returns |TLSEXT_NAMETYPE_host_name|
  // if the client sent a hostname and -1 otherwise.
-@@ -2858,12 +2859,12 @@
+@@ -2876,12 +2877,12 @@
  // |SSL_TLSEXT_ERR_ALERT_FATAL|, then |*out_alert| is the alert to send,
  // defaulting to |SSL_AD_UNRECOGNIZED_NAME|. |SSL_TLSEXT_ERR_ALERT_WARNING| is
  // ignored and treated as |SSL_TLSEXT_ERR_OK|.
@@ -981,7 +981,7 @@
  
  // SSL_TLSEXT_ERR_* are values returned by some extension-related callbacks.
  #ifdef ossl_SSL_TLSEXT_ERR_OK
-@@ -2878,7 +2879,6 @@
+@@ -2896,7 +2897,6 @@
  #ifdef ossl_SSL_TLSEXT_ERR_NOACK
  #define SSL_TLSEXT_ERR_NOACK ossl_SSL_TLSEXT_ERR_NOACK
  #endif
@@ -989,7 +989,7 @@
  // SSL_set_SSL_CTX changes |ssl|'s |SSL_CTX|. |ssl| will use the
  // certificate-related settings from |ctx|, and |SSL_get_SSL_CTX| will report
  // |ctx|. This function may be used during the callbacks registered by
-@@ -2892,7 +2892,7 @@
+@@ -2910,7 +2910,7 @@
  // the session cache between different domains.
  //
  // TODO(davidben): Should other settings change after this call?
@@ -998,7 +998,7 @@
  
  
  // Application-layer protocol negotiation.
-@@ -2920,8 +2920,8 @@
+@@ -2938,8 +2938,8 @@
  //
  // WARNING: this function is dangerous because it breaks the usual return value
  // convention.
@@ -1009,7 +1009,7 @@
  
  // SSL_CTX_set_alpn_select_cb sets a callback function on |ctx| that is called
  // during ClientHello processing in order to select an ALPN protocol from the
-@@ -2953,18 +2953,18 @@
+@@ -2971,18 +2971,18 @@
  // The cipher suite is selected before negotiating ALPN. The callback may use
  // |SSL_get_pending_cipher| to query the cipher suite. This may be used to
  // implement HTTP/2's cipher suite constraints.
@@ -1035,7 +1035,7 @@
  
  // SSL_CTX_set_allow_unknown_alpn_protos configures client connections on |ctx|
  // to allow unknown ALPN protocols from the server. Otherwise, by default, the
-@@ -3126,10 +3126,10 @@
+@@ -3144,10 +3144,10 @@
  // and returns |OPENSSL_NPN_NEGOTIATED|. Otherwise, it returns
  // |OPENSSL_NPN_NO_OVERLAP| and sets |*out| and |*out_len| to the first
  // supported protocol.
@@ -1050,7 +1050,7 @@
  
  #ifdef ossl_OPENSSL_NPN_UNSUPPORTED
  #define OPENSSL_NPN_UNSUPPORTED ossl_OPENSSL_NPN_UNSUPPORTED
-@@ -4051,12 +4051,12 @@
+@@ -4069,12 +4069,12 @@
  //
  // See |ex_data.h| for details.
  
@@ -1069,7 +1069,7 @@
  
  // OPENSSL_EXPORT int SSL_SESSION_set_ex_data(SSL_SESSION *session, int idx,
  //                                            void *data);
-@@ -4067,8 +4067,8 @@
+@@ -4085,8 +4085,8 @@
  //                                                 CRYPTO_EX_dup *dup_unused,
  //                                                 CRYPTO_EX_free *free_func);
  
@@ -1080,7 +1080,7 @@
  // OPENSSL_EXPORT int SSL_CTX_get_ex_new_index(long argl, void *argp,
  //                                             CRYPTO_EX_unused *unused,
  //                                             CRYPTO_EX_dup *dup_unused,
-@@ -4292,13 +4292,13 @@
+@@ -4310,13 +4310,13 @@
  // such as HTTP/1.1, and not others, such as HTTP/2.
  // OPENSSL_EXPORT void SSL_set_shed_handshake_config(SSL *ssl, int enable);
  
@@ -1101,7 +1101,7 @@
  
  // SSL_set_renegotiate_mode configures how |ssl|, a client, reacts to
  // renegotiation attempts by a server. If |ssl| is a server, peer-initiated
-@@ -4327,8 +4327,8 @@
+@@ -4345,8 +4345,8 @@
  //
  // There is no support in BoringSSL for initiating renegotiations as a client
  // or server.
@@ -1112,7 +1112,7 @@
  
  // SSL_renegotiate starts a deferred renegotiation on |ssl| if it was configured
  // with |ssl_renegotiate_explicit| and has a pending HelloRequest. It returns
-@@ -4389,45 +4389,45 @@
+@@ -4407,45 +4407,45 @@
  // callbacks that are called very early on during the server handshake. At this
  // point, much of the SSL* hasn't been filled out and only the ClientHello can
  // be depended on.
@@ -1188,7 +1188,7 @@
  
  // SSL_CTX_set_select_certificate_cb sets a callback that is called before most
  // ClientHello processing and before the decision whether to resume a session
-@@ -4443,9 +4443,9 @@
+@@ -4461,9 +4461,9 @@
  //
  // Note: The |SSL_CLIENT_HELLO| is only valid for the duration of the callback
  // and is not valid while the handshake is paused.
@@ -1201,7 +1201,7 @@
  
  // SSL_CTX_set_dos_protection_cb sets a callback that is called once the
  // resumption decision for a ClientHello has been made. It can return one to
-@@ -4561,7 +4561,7 @@
+@@ -4579,7 +4579,7 @@
  
  // SSL_get_peer_signature_algorithm returns the signature algorithm used by the
  // peer. If not applicable, it returns zero.
@@ -1210,7 +1210,7 @@
  
  // SSL_get_client_random writes up to |max_out| bytes of the most recent
  // handshake's client_random to |out| and returns the number of bytes written.
-@@ -4695,8 +4695,8 @@
+@@ -4713,8 +4713,8 @@
  
  // These client- and server-specific methods call their corresponding generic
  // methods.
@@ -1221,7 +1221,7 @@
  // OPENSSL_EXPORT const SSL_METHOD *SSLv23_server_method(void);
  // OPENSSL_EXPORT const SSL_METHOD *SSLv23_client_method(void);
  // OPENSSL_EXPORT const SSL_METHOD *TLSv1_server_method(void);
-@@ -4811,14 +4811,14 @@
+@@ -4829,14 +4829,14 @@
  // i2d_SSL_SESSION serializes |in|, as described in |i2d_SAMPLE|.
  //
  // Use |SSL_SESSION_to_bytes| instead.
@@ -1239,7 +1239,7 @@
  
  // i2d_SSL_SESSION_bio serializes |session| and writes the result to |bio|. It
  // returns the number of bytes written on success and <= 0 on error.
-@@ -4907,7 +4907,7 @@
+@@ -4925,7 +4925,7 @@
  // This API is compatible with OpenSSL. However, BoringSSL-specific code should
  // prefer |SSL_CTX_set_signing_algorithm_prefs| because it's clearer and it's
  // more convenient to codesearch for specific algorithm values.
@@ -1248,7 +1248,7 @@
  
  // SSL_set1_sigalgs_list takes a textual specification of a set of signature
  // algorithms and configures them on |ssl|. It returns one on success and zero
-@@ -4922,8 +4922,8 @@
+@@ -4940,8 +4940,8 @@
  // more convenient to codesearch for specific algorithm values.
  // OPENSSL_EXPORT int SSL_set1_sigalgs_list(SSL *ssl, const char *str);
  
@@ -1259,7 +1259,7 @@
  // #define SSL_SESSION_set_app_data(s, a) \
  //   (SSL_SESSION_set_ex_data(s, 0, (char *)(a)))
  // #define SSL_SESSION_get_app_data(s) (SSL_SESSION_get_ex_data(s, 0))
-@@ -4939,8 +4939,8 @@
+@@ -4957,8 +4957,8 @@
  //     SSL_CIPHER_get_bits(SSL_get_current_cipher(ssl), out_alg_bits)
  // #define SSL_get_cipher_version(ssl) \
  //     SSL_CIPHER_get_version(SSL_get_current_cipher(ssl))
@@ -1270,7 +1270,7 @@
  // #define SSL_get_time(session) SSL_SESSION_get_time(session)
  // #define SSL_set_time(session, time) SSL_SESSION_set_time((session), (time))
  // #define SSL_get_timeout(session) SSL_SESSION_get_timeout(session)
-@@ -5005,7 +5005,7 @@
+@@ -5075,7 +5075,7 @@
  
  // SSL_get_version returns a string describing the TLS version used by |ssl|.
  // For example, "TLSv1.2" or "DTLSv1".
@@ -1279,7 +1279,7 @@
  
  // SSL_get_cipher_list returns the name of the |n|th cipher in the output of
  // |SSL_get_ciphers| or NULL if out of range. Use |SSL_get_ciphers| instead.
-@@ -5185,14 +5185,14 @@
+@@ -5255,14 +5255,14 @@
  // unresumable session which may be cached, but will never be resumed.
  //
  // If querying properties of the connection, use APIs on the |SSL| object.
@@ -1296,7 +1296,7 @@
  
  // #define OPENSSL_INIT_NO_LOAD_SSL_STRINGS 0
  // #define OPENSSL_INIT_LOAD_SSL_STRINGS 0
-@@ -5260,9 +5260,9 @@
+@@ -5330,9 +5330,9 @@
  // OCSP responses like other server credentials, such as certificates or SCT
  // lists. Configure, store, and refresh them eagerly. This avoids downtime if
  // the CA's OCSP responder is briefly offline.
@@ -1309,7 +1309,7 @@
  
  // SSL_CTX_set_tlsext_status_arg sets additional data for
  // |SSL_CTX_set_tlsext_status_cb|'s callback and returns one.
-@@ -5492,21 +5492,21 @@
+@@ -5562,21 +5562,21 @@
  // #endif // !defined(BORINGSSL_PREFIX)
  
  
@@ -1339,7 +1339,7 @@
  // BORINGSSL_MAKE_UP_REF(SSL_SESSION, SSL_SESSION_up_ref)
  
  // enum class OpenRecordResult {
-@@ -5623,13 +5623,13 @@
+@@ -5693,13 +5693,13 @@
  //     Span<const uint8_t> *out_write_traffic_secret);
  
  
@@ -1357,7 +1357,7 @@
  
  #ifdef ossl_SSL_R_APP_DATA_IN_HANDSHAKE
  #define SSL_R_APP_DATA_IN_HANDSHAKE ossl_SSL_R_APP_DATA_IN_HANDSHAKE
-@@ -6397,4 +6397,4 @@
+@@ -6467,4 +6467,4 @@
  #define SSL_R_TLSV1_ALERT_ECH_REQUIRED ossl_SSL_R_TLSV1_ALERT_ECH_REQUIRED
  #endif
  

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -920,7 +920,7 @@
  
  // SSL_CTX_set_alpn_select_cb sets a callback function on |ctx| that is called
  // during ClientHello processing in order to select an ALPN protocol from the
-@@ -2953,10 +2953,10 @@
+@@ -2953,18 +2953,18 @@
  // The cipher suite is selected before negotiating ALPN. The callback may use
  // |SSL_get_pending_cipher| to query the cipher suite. This may be used to
  // implement HTTP/2's cipher suite constraints.
@@ -935,6 +935,17 @@
  
  // SSL_get0_alpn_selected gets the selected ALPN protocol (if any) from |ssl|.
  // On return it sets |*out_data| to point to |*out_len| bytes of protocol name
+ // (not including the leading length-prefix byte). If the server didn't respond
+ // with a negotiated protocol then |*out_len| will be zero.
+-// OPENSSL_EXPORT void SSL_get0_alpn_selected(const SSL *ssl,
+-//                                            const uint8_t **out_data,
+-//                                            unsigned *out_len);
++OPENSSL_EXPORT void SSL_get0_alpn_selected(const SSL *ssl,
++                                           const uint8_t **out_data,
++                                           unsigned *out_len);
+ 
+ // SSL_CTX_set_allow_unknown_alpn_protos configures client connections on |ctx|
+ // to allow unknown ALPN protocols from the server. Otherwise, by default, the
 @@ -3126,10 +3126,10 @@
  // and returns |OPENSSL_NPN_NEGOTIATED|. Otherwise, it returns
  // |OPENSSL_NPN_NO_OVERLAP| and sets |*out| and |*out_len| to the first

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -215,6 +215,15 @@
  
  // SSL_CTX_set_quiet_shutdown sets quiet shutdown on |ctx| to |mode|. If
  // enabled, |SSL_shutdown| will not send a close_notify alert or wait for one
+@@ -466,7 +467,7 @@
+ // SSL_set_quiet_shutdown sets quiet shutdown on |ssl| to |mode|. If enabled,
+ // |SSL_shutdown| will not send a close_notify alert or wait for one from the
+ // peer. It will instead synchronously return one.
+-// OPENSSL_EXPORT void SSL_set_quiet_shutdown(SSL *ssl, int mode);
++OPENSSL_EXPORT void SSL_set_quiet_shutdown(SSL *ssl, int mode);
+ 
+ // SSL_get_quiet_shutdown returns whether quiet shutdown is enabled for
+ // |ssl|.
 @@ -475,7 +476,7 @@
  // SSL_get_error returns a |SSL_ERROR_*| value for the most recent operation on
  // |ssl|. It should be called after an operation failed to determine whether the

--- a/bssl-compat/patch/include/openssl/ssl.h.patch
+++ b/bssl-compat/patch/include/openssl/ssl.h.patch
@@ -909,6 +909,21 @@
  
  // SSL_CTX_set_alpn_select_cb sets a callback function on |ctx| that is called
  // during ClientHello processing in order to select an ALPN protocol from the
+@@ -2953,10 +2953,10 @@
+ // The cipher suite is selected before negotiating ALPN. The callback may use
+ // |SSL_get_pending_cipher| to query the cipher suite. This may be used to
+ // implement HTTP/2's cipher suite constraints.
+-// OPENSSL_EXPORT void SSL_CTX_set_alpn_select_cb(
+-//     SSL_CTX *ctx, int (*cb)(SSL *ssl, const uint8_t **out, uint8_t *out_len,
+-//                             const uint8_t *in, unsigned in_len, void *arg),
+-//     void *arg);
++OPENSSL_EXPORT void SSL_CTX_set_alpn_select_cb(
++    SSL_CTX *ctx, int (*cb)(SSL *ssl, const uint8_t **out, uint8_t *out_len,
++                            const uint8_t *in, unsigned in_len, void *arg),
++    void *arg);
+ 
+ // SSL_get0_alpn_selected gets the selected ALPN protocol (if any) from |ssl|.
+ // On return it sets |*out_data| to point to |*out_len| bytes of protocol name
 @@ -4045,12 +4045,12 @@
  //
  // See |ex_data.h| for details.

--- a/bssl-compat/patch/include/openssl/ssl.h.sh
+++ b/bssl-compat/patch/include/openssl/ssl.h.sh
@@ -16,6 +16,7 @@ SUBSTITUTIONS+=('SSL_R_[a-zA-Z0-9_]*')
 SUBSTITUTIONS+=('SSL_TLSEXT_ERR_[A-Z_]*')
 SUBSTITUTIONS+=('SSL_SESS_CACHE_[A-Z_]*')
 SUBSTITUTIONS+=('OPENSSL_NPN_[A-Z_]*')
+SUBSTITUTIONS+=('SSL_OP_[a-zA-Z0-9_]*')
 
 EXPRE='s|^//[ \t]#[ \t]*define[ \t]*[^a-zA-Z0-9_]\('
 EXPOST='\)[^a-zA-Z0-9_].*$|#ifdef ossl_\1\n#define \1 ossl_\1\n#endif|'

--- a/bssl-compat/patch/include/openssl/ssl.h.sh
+++ b/bssl-compat/patch/include/openssl/ssl.h.sh
@@ -15,6 +15,7 @@ SUBSTITUTIONS+=('DTLS1_2_VERSION')
 SUBSTITUTIONS+=('SSL_R_[a-zA-Z0-9_]*')
 SUBSTITUTIONS+=('SSL_TLSEXT_ERR_[A-Z_]*')
 SUBSTITUTIONS+=('SSL_SESS_CACHE_[A-Z_]*')
+SUBSTITUTIONS+=('OPENSSL_NPN_[A-Z_]*')
 
 EXPRE='s|^//[ \t]#[ \t]*define[ \t]*[^a-zA-Z0-9_]\('
 EXPOST='\)[^a-zA-Z0-9_].*$|#ifdef ossl_\1\n#define \1 ossl_\1\n#endif|'

--- a/bssl-compat/patch/include/openssl/x509.h.patch
+++ b/bssl-compat/patch/include/openssl/x509.h.patch
@@ -120,15 +120,17 @@
  
  // X509_NAME_get0_der sets |*out_der| and |*out_der_len|
  //
-@@ -2054,7 +2054,7 @@
+@@ -2054,8 +2054,8 @@
  // OPENSSL_EXPORT unsigned long X509_issuer_name_hash_old(X509 *a);
  // OPENSSL_EXPORT unsigned long X509_subject_name_hash_old(X509 *x);
  
 -// OPENSSL_EXPORT int X509_cmp(const X509 *a, const X509 *b);
+-// OPENSSL_EXPORT int X509_NAME_cmp(const X509_NAME *a, const X509_NAME *b);
 +OPENSSL_EXPORT int X509_cmp(const X509 *a, const X509 *b);
- // OPENSSL_EXPORT int X509_NAME_cmp(const X509_NAME *a, const X509_NAME *b);
++OPENSSL_EXPORT int X509_NAME_cmp(const X509_NAME *a, const X509_NAME *b);
  // OPENSSL_EXPORT unsigned long X509_NAME_hash(X509_NAME *x);
  // OPENSSL_EXPORT unsigned long X509_NAME_hash_old(X509_NAME *x);
+ 
 @@ -2404,7 +2404,7 @@
  
  // DECLARE_ASN1_FUNCTIONS_const(RSA_PSS_PARAMS)

--- a/bssl-compat/patch/include/openssl/x509.h.patch
+++ b/bssl-compat/patch/include/openssl/x509.h.patch
@@ -111,6 +111,15 @@
  
  // X509_NAME_free releases memory associated with |name|.
  // OPENSSL_EXPORT void X509_NAME_free(X509_NAME *name);
+@@ -867,7 +867,7 @@
+ // TODO(https://crbug.com/boringssl/407): This function should be const and
+ // thread-safe but is currently neither in some cases, notably if |name| was
+ // mutated.
+-// OPENSSL_EXPORT X509_NAME *X509_NAME_dup(X509_NAME *name);
++OPENSSL_EXPORT X509_NAME *X509_NAME_dup(X509_NAME *name);
+ 
+ // X509_NAME_get0_der sets |*out_der| and |*out_der_len|
+ //
 @@ -2054,7 +2054,7 @@
  // OPENSSL_EXPORT unsigned long X509_issuer_name_hash_old(X509 *a);
  // OPENSSL_EXPORT unsigned long X509_subject_name_hash_old(X509 *x);

--- a/bssl-compat/patch/include/openssl/x509.h.patch
+++ b/bssl-compat/patch/include/openssl/x509.h.patch
@@ -102,6 +102,15 @@
  
  // X509_NAME is an |ASN1_ITEM| whose ASN.1 type is X.509 Name (RFC 5280) and C
  // type is |X509_NAME*|.
+@@ -844,7 +844,7 @@
+ 
+ // X509_NAME_new returns a new, empty |X509_NAME_new|, or NULL on
+ // error.
+-// OPENSSL_EXPORT X509_NAME *X509_NAME_new(void);
++OPENSSL_EXPORT X509_NAME *X509_NAME_new(void);
+ 
+ // X509_NAME_free releases memory associated with |name|.
+ // OPENSSL_EXPORT void X509_NAME_free(X509_NAME *name);
 @@ -2054,7 +2054,7 @@
  // OPENSSL_EXPORT unsigned long X509_issuer_name_hash_old(X509 *a);
  // OPENSSL_EXPORT unsigned long X509_subject_name_hash_old(X509 *x);

--- a/bssl-compat/patch/include/openssl/x509.h.patch
+++ b/bssl-compat/patch/include/openssl/x509.h.patch
@@ -102,7 +102,7 @@
  
  // X509_NAME is an |ASN1_ITEM| whose ASN.1 type is X.509 Name (RFC 5280) and C
  // type is |X509_NAME*|.
-@@ -844,7 +844,7 @@
+@@ -844,10 +844,10 @@
  
  // X509_NAME_new returns a new, empty |X509_NAME_new|, or NULL on
  // error.
@@ -110,7 +110,11 @@
 +OPENSSL_EXPORT X509_NAME *X509_NAME_new(void);
  
  // X509_NAME_free releases memory associated with |name|.
- // OPENSSL_EXPORT void X509_NAME_free(X509_NAME *name);
+-// OPENSSL_EXPORT void X509_NAME_free(X509_NAME *name);
++OPENSSL_EXPORT void X509_NAME_free(X509_NAME *name);
+ 
+ // d2i_X509_NAME parses up to |len| bytes from |*inp| as a DER-encoded X.509
+ // Name (RFC 5280), as described in |d2i_SAMPLE_with_reuse|.
 @@ -867,7 +867,7 @@
  // TODO(https://crbug.com/boringssl/407): This function should be const and
  // thread-safe but is currently neither in some cases, notably if |name| was
@@ -166,6 +170,15 @@
  // BORINGSSL_MAKE_UP_REF(X509, X509_up_ref)
  // BORINGSSL_MAKE_DELETER(X509_ALGOR, X509_ALGOR_free)
  // BORINGSSL_MAKE_DELETER(X509_ATTRIBUTE, X509_ATTRIBUTE_free)
+@@ -2848,7 +2848,7 @@
+ // BORINGSSL_MAKE_DELETER(X509_EXTENSION, X509_EXTENSION_free)
+ // BORINGSSL_MAKE_DELETER(X509_INFO, X509_INFO_free)
+ // BORINGSSL_MAKE_DELETER(X509_LOOKUP, X509_LOOKUP_free)
+-// BORINGSSL_MAKE_DELETER(X509_NAME, X509_NAME_free)
++BORINGSSL_MAKE_DELETER(X509_NAME, X509_NAME_free)
+ // BORINGSSL_MAKE_DELETER(X509_NAME_ENTRY, X509_NAME_ENTRY_free)
+ // BORINGSSL_MAKE_DELETER(X509_PKEY, X509_PKEY_free)
+ // BORINGSSL_MAKE_DELETER(X509_PUBKEY, X509_PUBKEY_free)
 @@ -2860,10 +2860,10 @@
  // BORINGSSL_MAKE_DELETER(X509_STORE_CTX, X509_STORE_CTX_free)
  // BORINGSSL_MAKE_DELETER(X509_VERIFY_PARAM, X509_VERIFY_PARAM_free)

--- a/bssl-compat/patch/source/ssl/ssl_test.cc.patch
+++ b/bssl-compat/patch/source/ssl/ssl_test.cc.patch
@@ -78,14 +78,14 @@
 -// #if defined(OPENSSL_THREADS)
 -// #include <thread>
 -// #endif
--
--
--// BSSL_NAMESPACE_BEGIN
 +#ifdef BSSL_COMPAT
 +#include <ossl/openssl/ssl.h>
 +#include <ossl/openssl/provider.h>
 +#endif
  
+-
+-// BSSL_NAMESPACE_BEGIN
+-
 -// namespace {
 -
 -// #define TRACED_CALL(code)                     \
@@ -160,6 +160,51 @@
  
  // struct ExpectedCipher {
  //   unsigned long id;
+@@ -110,25 +119,25 @@
+ //   std::vector<uint16_t> expected;
+ // };
+ 
+-// template <typename T>
+-// class UnownedSSLExData {
+-//  public:
+-//   UnownedSSLExData() {
+-//     index_ = SSL_get_ex_new_index(0, nullptr, nullptr, nullptr, nullptr);
+-//   }
+-
+-//   T *Get(const SSL *ssl) {
+-//     return index_ < 0 ? nullptr
+-//                       : static_cast<T *>(SSL_get_ex_data(ssl, index_));
+-//   }
+-
+-//   bool Set(SSL *ssl, T *t) {
+-//     return index_ >= 0 && SSL_set_ex_data(ssl, index_, t);
+-//   }
+-
+-//  private:
+-//   int index_;
+-// };
++template <typename T>
++class UnownedSSLExData {
++ public:
++  UnownedSSLExData() {
++    index_ = SSL_get_ex_new_index(0, nullptr, nullptr, nullptr, nullptr);
++  }
++
++  T *Get(const SSL *ssl) {
++    return index_ < 0 ? nullptr
++                      : static_cast<T *>(SSL_get_ex_data(ssl, index_));
++  }
++
++  bool Set(SSL *ssl, T *t) {
++    return index_ >= 0 && SSL_set_ex_data(ssl, index_, t);
++  }
++
++ private:
++  int index_;
++};
+ 
+ // static const CipherTest kCipherTests[] = {
+ //     // Selecting individual ciphers should work.
 @@ -1196,63 +1205,63 @@
  //   }
  // }
@@ -1248,7 +1293,9 @@
 -
 -//   ASSERT_TRUE(SSL_CTX_set_session_id_context(server_ctx_.get(), kContext1,
 -//                                              sizeof(kContext1)));
--
++static int SwitchSessionIDContextSNI(SSL *ssl, int *out_alert, void *arg) {
++  static const uint8_t kContext[] = {3};
+ 
 -//   SSL_CTX_set_session_cache_mode(client_ctx_.get(), SSL_SESS_CACHE_BOTH);
 -//   SSL_CTX_set_session_cache_mode(server_ctx_.get(), SSL_SESS_CACHE_BOTH);
 -
@@ -1294,9 +1341,7 @@
 -
 -//         return ssl_select_cert_success;
 -//       });
-+static int SwitchSessionIDContextSNI(SSL *ssl, int *out_alert, void *arg) {
-+  static const uint8_t kContext[] = {3};
- 
+-
 -//   TRACED_CALL(ExpectSessionReused(client_ctx_.get(), server_ctx_.get(),
 -//                                   session.get(),
 -//                                   false /* expect session not reused */));
@@ -1371,6 +1416,89 @@
  
  // static timeval g_current_time;
  
+@@ -3719,44 +3770,44 @@
+ //   EXPECT_EQ(DTLS1_VERSION, SSL_CTX_get_min_proto_version(ctx.get()));
+ // }
+ 
+-// static const char *GetVersionName(uint16_t version) {
+-//   switch (version) {
+-//     case TLS1_VERSION:
+-//       return "TLSv1";
+-//     case TLS1_1_VERSION:
+-//       return "TLSv1.1";
+-//     case TLS1_2_VERSION:
+-//       return "TLSv1.2";
+-//     case TLS1_3_VERSION:
+-//       return "TLSv1.3";
+-//     case DTLS1_VERSION:
+-//       return "DTLSv1";
+-//     case DTLS1_2_VERSION:
+-//       return "DTLSv1.2";
+-//     default:
+-//       return "???";
+-//   }
+-// }
+-
+-// TEST_P(SSLVersionTest, Version) {
+-//   ASSERT_TRUE(Connect());
+-
+-//   EXPECT_EQ(SSL_version(client_.get()), version());
+-//   EXPECT_EQ(SSL_version(server_.get()), version());
+-
+-//   // Test the version name is reported as expected.
+-//   const char *version_name = GetVersionName(version());
+-//   EXPECT_EQ(strcmp(version_name, SSL_get_version(client_.get())), 0);
+-//   EXPECT_EQ(strcmp(version_name, SSL_get_version(server_.get())), 0);
+-
+-//   // Test SSL_SESSION reports the same name.
+-//   const char *client_name =
+-//       SSL_SESSION_get_version(SSL_get_session(client_.get()));
+-//   const char *server_name =
+-//       SSL_SESSION_get_version(SSL_get_session(server_.get()));
+-//   EXPECT_EQ(strcmp(version_name, client_name), 0);
+-//   EXPECT_EQ(strcmp(version_name, server_name), 0);
+-// }
++static const char *GetVersionName(uint16_t version) {
++  switch (version) {
++    case TLS1_VERSION:
++      return "TLSv1";
++    case TLS1_1_VERSION:
++      return "TLSv1.1";
++    case TLS1_2_VERSION:
++      return "TLSv1.2";
++    case TLS1_3_VERSION:
++      return "TLSv1.3";
++    case DTLS1_VERSION:
++      return "DTLSv1";
++    case DTLS1_2_VERSION:
++      return "DTLSv1.2";
++    default:
++      return "???";
++  }
++}
++
++TEST_P(SSLVersionTest, Version) {
++  ASSERT_TRUE(Connect());
++
++  EXPECT_EQ(SSL_version(client_.get()), version());
++  EXPECT_EQ(SSL_version(server_.get()), version());
++
++  // Test the version name is reported as expected.
++  const char *version_name = GetVersionName(version());
++  EXPECT_EQ(strcmp(version_name, SSL_get_version(client_.get())), 0);
++  EXPECT_EQ(strcmp(version_name, SSL_get_version(server_.get())), 0);
++
++  // Test SSL_SESSION reports the same name.
++  const char *client_name =
++      SSL_SESSION_get_version(SSL_get_session(client_.get()));
++  const char *server_name =
++      SSL_SESSION_get_version(SSL_get_session(server_.get()));
++  EXPECT_EQ(strcmp(version_name, client_name), 0);
++  EXPECT_EQ(strcmp(version_name, server_name), 0);
++}
+ 
+ // Tests that that |SSL_get_pending_cipher| is available during the ALPN
+ // selection callback.
 @@ -4214,43 +4265,46 @@
  //   X509_cmp(cert, cert);
  // }
@@ -1591,7 +1719,89 @@
  
  // TEST_P(SSLVersionTest, DoubleSSLError) {
  //   // Connect the inner SSL connections.
-@@ -8260,5 +8321,5 @@
+@@ -7265,42 +7326,46 @@
+ //   }
+ // }
+ 
+-// TEST_P(SSLVersionTest, SameKeyResume) {
+-//   uint8_t key[48];
+-//   RAND_bytes(key, sizeof(key));
+ 
+-//   bssl::UniquePtr<SSL_CTX> server_ctx2 = CreateContext();
+-//   ASSERT_TRUE(server_ctx2);
+-//   ASSERT_TRUE(UseCertAndKey(server_ctx2.get()));
+-//   ASSERT_TRUE(
+-//       SSL_CTX_set_tlsext_ticket_keys(server_ctx_.get(), key, sizeof(key)));
+-//   ASSERT_TRUE(
+-//       SSL_CTX_set_tlsext_ticket_keys(server_ctx2.get(), key, sizeof(key)));
+-
+-//   SSL_CTX_set_session_cache_mode(client_ctx_.get(), SSL_SESS_CACHE_BOTH);
+-//   SSL_CTX_set_session_cache_mode(server_ctx_.get(), SSL_SESS_CACHE_BOTH);
+-//   SSL_CTX_set_session_cache_mode(server_ctx2.get(), SSL_SESS_CACHE_BOTH);
+-
+-//   // Establish a session for |server_ctx_|.
+-//   bssl::UniquePtr<SSL_SESSION> session =
+-//       CreateClientSession(client_ctx_.get(), server_ctx_.get());
+-//   ASSERT_TRUE(session);
+-//   ClientConfig config;
+-//   config.session = session.get();
+-
+-//   // Resuming with |server_ctx_| again works.
+-//   bssl::UniquePtr<SSL> client, server;
+-//   ASSERT_TRUE(ConnectClientAndServer(&client, &server, client_ctx_.get(),
+-//                                      server_ctx_.get(), config));
+-//   EXPECT_TRUE(SSL_session_reused(client.get()));
+-//   EXPECT_TRUE(SSL_session_reused(server.get()));
+-
+-//   // Resuming with |server_ctx2| also works.
+-//   ASSERT_TRUE(ConnectClientAndServer(&client, &server, client_ctx_.get(),
+-//                                      server_ctx2.get(), config));
+-//   EXPECT_TRUE(SSL_session_reused(client.get()));
+-//   EXPECT_TRUE(SSL_session_reused(server.get()));
+-// }
++TEST_P(SSLVersionTest, SameKeyResume) {
++#ifdef BSSL_COMPAT
++  GTEST_SKIP(); // FIXME: Investigate failures on bssl-compat
++#endif
++  uint8_t key[48];
++  RAND_bytes(key, sizeof(key));
++
++  bssl::UniquePtr<SSL_CTX> server_ctx2 = CreateContext();
++  ASSERT_TRUE(server_ctx2);
++  ASSERT_TRUE(UseCertAndKey(server_ctx2.get()));
++  ASSERT_TRUE(
++      SSL_CTX_set_tlsext_ticket_keys(server_ctx_.get(), key, sizeof(key)));
++  ASSERT_TRUE(
++      SSL_CTX_set_tlsext_ticket_keys(server_ctx2.get(), key, sizeof(key)));
++
++  SSL_CTX_set_session_cache_mode(client_ctx_.get(), SSL_SESS_CACHE_BOTH);
++  SSL_CTX_set_session_cache_mode(server_ctx_.get(), SSL_SESS_CACHE_BOTH);
++  SSL_CTX_set_session_cache_mode(server_ctx2.get(), SSL_SESS_CACHE_BOTH);
++
++  // Establish a session for |server_ctx_|.
++  bssl::UniquePtr<SSL_SESSION> session =
++      CreateClientSession(client_ctx_.get(), server_ctx_.get());
++  ASSERT_TRUE(session);
++  ClientConfig config;
++  config.session = session.get();
++
++  // Resuming with |server_ctx_| again works.
++  bssl::UniquePtr<SSL> client, server;
++  ASSERT_TRUE(ConnectClientAndServer(&client, &server, client_ctx_.get(),
++                                     server_ctx_.get(), config));
++  EXPECT_TRUE(SSL_session_reused(client.get()));
++  EXPECT_TRUE(SSL_session_reused(server.get()));
++
++  // Resuming with |server_ctx2| also works.
++  ASSERT_TRUE(ConnectClientAndServer(&client, &server, client_ctx_.get(),
++                                     server_ctx2.get(), config));
++  EXPECT_TRUE(SSL_session_reused(client.get()));
++  EXPECT_TRUE(SSL_session_reused(server.get()));
++}
+ 
+ // TEST_P(SSLVersionTest, DifferentKeyNoResume) {
+ //   uint8_t key1[48], key2[48];
+@@ -8260,5 +8325,5 @@
  //   }
  // }
  

--- a/bssl-compat/patch/source/ssl/ssl_test.cc.patch
+++ b/bssl-compat/patch/source/ssl/ssl_test.cc.patch
@@ -873,18 +873,18 @@
  // Test that, after calling |SSL_shutdown|, |SSL_write| fails.
 -// TEST_P(SSLVersionTest, WriteAfterShutdown) {
 -//   ASSERT_TRUE(Connect());
-+TEST_P(SSLVersionTest, WriteAfterShutdown) {
-+  ASSERT_TRUE(Connect());
- 
+-
 -//   for (SSL *ssl : {client_.get(), server_.get()}) {
 -//     SCOPED_TRACE(SSL_is_server(ssl) ? "server" : "client");
-+  for (SSL *ssl : {client_.get(), server_.get()}) {
-+    SCOPED_TRACE(SSL_is_server(ssl) ? "server" : "client");
++TEST_P(SSLVersionTest, WriteAfterShutdown) {
++  ASSERT_TRUE(Connect());
  
 -//     bssl::UniquePtr<BIO> mem(BIO_new(BIO_s_mem()));
 -//     ASSERT_TRUE(mem);
 -//     SSL_set0_wbio(ssl, bssl::UpRef(mem).release());
--
++  for (SSL *ssl : {client_.get(), server_.get()}) {
++    SCOPED_TRACE(SSL_is_server(ssl) ? "server" : "client");
+ 
 -//     // Shut down half the connection. |SSL_shutdown| will return 0 to signal
 -//     // only one side has shut down.
 -//     ASSERT_EQ(SSL_shutdown(ssl), 0);
@@ -1293,9 +1293,7 @@
 -
 -//   ASSERT_TRUE(SSL_CTX_set_session_id_context(server_ctx_.get(), kContext1,
 -//                                              sizeof(kContext1)));
-+static int SwitchSessionIDContextSNI(SSL *ssl, int *out_alert, void *arg) {
-+  static const uint8_t kContext[] = {3};
- 
+-
 -//   SSL_CTX_set_session_cache_mode(client_ctx_.get(), SSL_SESS_CACHE_BOTH);
 -//   SSL_CTX_set_session_cache_mode(server_ctx_.get(), SSL_SESS_CACHE_BOTH);
 -
@@ -1341,7 +1339,9 @@
 -
 -//         return ssl_select_cert_success;
 -//       });
--
++static int SwitchSessionIDContextSNI(SSL *ssl, int *out_alert, void *arg) {
++  static const uint8_t kContext[] = {3};
+ 
 -//   TRACED_CALL(ExpectSessionReused(client_ctx_.get(), server_ctx_.get(),
 -//                                   session.get(),
 -//                                   false /* expect session not reused */));
@@ -1499,6 +1499,81 @@
  
  // Tests that that |SSL_get_pending_cipher| is available during the ALPN
  // selection callback.
+@@ -4076,40 +4127,40 @@
+ //   }
+ // }
+ 
+-// TEST_P(SSLVersionTest, GetServerName) {
+-//   ClientConfig config;
+-//   config.servername = "host1";
+-
+-//   SSL_CTX_set_tlsext_servername_callback(
+-//       server_ctx_.get(), [](SSL *ssl, int *out_alert, void *arg) -> int {
+-//         // During the handshake, |SSL_get_servername| must match |config|.
+-//         ClientConfig *config_p = reinterpret_cast<ClientConfig *>(arg);
+-//         EXPECT_STREQ(config_p->servername.c_str(),
+-//                      SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name));
+-//         return SSL_TLSEXT_ERR_OK;
+-//       });
+-//   SSL_CTX_set_tlsext_servername_arg(server_ctx_.get(), &config);
+-
+-//   ASSERT_TRUE(Connect(config));
+-//   // After the handshake, it must also be available.
+-//   EXPECT_STREQ(config.servername.c_str(),
+-//                SSL_get_servername(server_.get(), TLSEXT_NAMETYPE_host_name));
+-
+-//   // Establish a session under host1.
+-//   SSL_CTX_set_session_cache_mode(client_ctx_.get(), SSL_SESS_CACHE_BOTH);
+-//   SSL_CTX_set_session_cache_mode(server_ctx_.get(), SSL_SESS_CACHE_BOTH);
+-//   bssl::UniquePtr<SSL_SESSION> session =
+-//       CreateClientSession(client_ctx_.get(), server_ctx_.get(), config);
+-
+-//   // If the client resumes a session with a different name, |SSL_get_servername|
+-//   // must return the new name.
+-//   ASSERT_TRUE(session);
+-//   config.session = session.get();
+-//   config.servername = "host2";
+-//   ASSERT_TRUE(Connect(config));
+-//   EXPECT_STREQ(config.servername.c_str(),
+-//                SSL_get_servername(server_.get(), TLSEXT_NAMETYPE_host_name));
+-// }
++TEST_P(SSLVersionTest, GetServerName) {
++  ClientConfig config;
++  config.servername = "host1";
++
++  SSL_CTX_set_tlsext_servername_callback(
++      server_ctx_.get(), [](SSL *ssl, int *out_alert, void *arg) -> int {
++        // During the handshake, |SSL_get_servername| must match |config|.
++        ClientConfig *config_p = reinterpret_cast<ClientConfig *>(arg);
++        EXPECT_STREQ(config_p->servername.c_str(),
++                     SSL_get_servername(ssl, TLSEXT_NAMETYPE_host_name));
++        return SSL_TLSEXT_ERR_OK;
++      });
++  SSL_CTX_set_tlsext_servername_arg(server_ctx_.get(), &config);
++
++  ASSERT_TRUE(Connect(config));
++  // After the handshake, it must also be available.
++  EXPECT_STREQ(config.servername.c_str(),
++               SSL_get_servername(server_.get(), TLSEXT_NAMETYPE_host_name));
++
++  // Establish a session under host1.
++  SSL_CTX_set_session_cache_mode(client_ctx_.get(), SSL_SESS_CACHE_BOTH);
++  SSL_CTX_set_session_cache_mode(server_ctx_.get(), SSL_SESS_CACHE_BOTH);
++  bssl::UniquePtr<SSL_SESSION> session =
++      CreateClientSession(client_ctx_.get(), server_ctx_.get(), config);
++
++  // If the client resumes a session with a different name, |SSL_get_servername|
++  // must return the new name.
++  ASSERT_TRUE(session);
++  config.session = session.get();
++  config.servername = "host2";
++  ASSERT_TRUE(Connect(config));
++  EXPECT_STREQ(config.servername.c_str(),
++               SSL_get_servername(server_.get(), TLSEXT_NAMETYPE_host_name));
++}
+ 
+ // Test that session cache mode bits are honored in the client session callback.
+ // TEST_P(SSLVersionTest, ClientSessionCacheMode) {
 @@ -4214,43 +4265,46 @@
  //   X509_cmp(cert, cert);
  // }

--- a/bssl-compat/patch/source/ssl/ssl_test.cc.patch
+++ b/bssl-compat/patch/source/ssl/ssl_test.cc.patch
@@ -326,7 +326,7 @@
  
  // static bssl::UniquePtr<SSL_CTX> CreateContextWithTestCertificate(
  //     const SSL_METHOD *method) {
-@@ -1408,171 +1417,195 @@
+@@ -1408,198 +1417,222 @@
  //   return KeyFromPEM(kKeyPEM);
  // }
  
@@ -683,6 +683,57 @@
  
  // Test that |SSL_get_client_CA_list| echoes back the configured parameter even
  // before configuring as a server.
+-// TEST(SSLTest, ClientCAList) {
+-//   bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+-//   ASSERT_TRUE(ctx);
+-//   bssl::UniquePtr<SSL> ssl(SSL_new(ctx.get()));
+-//   ASSERT_TRUE(ssl);
+-
+-//   bssl::UniquePtr<X509_NAME> name(X509_NAME_new());
+-//   ASSERT_TRUE(name);
+-
+-//   bssl::UniquePtr<X509_NAME> name_dup(X509_NAME_dup(name.get()));
+-//   ASSERT_TRUE(name_dup);
+-
+-//   bssl::UniquePtr<STACK_OF(X509_NAME)> stack(sk_X509_NAME_new_null());
+-//   ASSERT_TRUE(stack);
+-//   ASSERT_TRUE(PushToStack(stack.get(), std::move(name_dup)));
+-
+-//   // |SSL_set_client_CA_list| takes ownership.
+-//   SSL_set_client_CA_list(ssl.get(), stack.release());
+-
+-//   STACK_OF(X509_NAME) *result = SSL_get_client_CA_list(ssl.get());
+-//   ASSERT_TRUE(result);
+-//   ASSERT_EQ(1u, sk_X509_NAME_num(result));
+-//   EXPECT_EQ(0, X509_NAME_cmp(sk_X509_NAME_value(result, 0), name.get()));
+-// }
++TEST(SSLTest, ClientCAList) {
++  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
++  ASSERT_TRUE(ctx);
++  bssl::UniquePtr<SSL> ssl(SSL_new(ctx.get()));
++  ASSERT_TRUE(ssl);
++
++  bssl::UniquePtr<X509_NAME> name(X509_NAME_new());
++  ASSERT_TRUE(name);
++
++  bssl::UniquePtr<X509_NAME> name_dup(X509_NAME_dup(name.get()));
++  ASSERT_TRUE(name_dup);
++
++  bssl::UniquePtr<STACK_OF(X509_NAME)> stack(sk_X509_NAME_new_null());
++  ASSERT_TRUE(stack);
++  ASSERT_TRUE(PushToStack(stack.get(), std::move(name_dup)));
++
++  // |SSL_set_client_CA_list| takes ownership.
++  SSL_set_client_CA_list(ssl.get(), stack.release());
++
++  STACK_OF(X509_NAME) *result = SSL_get_client_CA_list(ssl.get());
++  ASSERT_TRUE(result);
++  ASSERT_EQ(1u, sk_X509_NAME_num(result));
++  EXPECT_EQ(0, X509_NAME_cmp(sk_X509_NAME_value(result, 0), name.get()));
++}
+ 
+ // TEST(SSLTest, AddClientCA) {
+ //   bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
 @@ -2495,62 +2528,71 @@
  // SSLVersionTest executes its test cases under all available protocol versions.
  // Test cases call |Connect| to create a connection using context objects with
@@ -876,14 +927,12 @@
 -
 -//   for (SSL *ssl : {client_.get(), server_.get()}) {
 -//     SCOPED_TRACE(SSL_is_server(ssl) ? "server" : "client");
-+TEST_P(SSLVersionTest, WriteAfterShutdown) {
-+  ASSERT_TRUE(Connect());
- 
+-
 -//     bssl::UniquePtr<BIO> mem(BIO_new(BIO_s_mem()));
 -//     ASSERT_TRUE(mem);
 -//     SSL_set0_wbio(ssl, bssl::UpRef(mem).release());
-+  for (SSL *ssl : {client_.get(), server_.get()}) {
-+    SCOPED_TRACE(SSL_is_server(ssl) ? "server" : "client");
++TEST_P(SSLVersionTest, WriteAfterShutdown) {
++  ASSERT_TRUE(Connect());
  
 -//     // Shut down half the connection. |SSL_shutdown| will return 0 to signal
 -//     // only one side has shut down.
@@ -895,7 +944,9 @@
 -//     ASSERT_TRUE(BIO_mem_contents(mem.get(), &unused, &len));
 -//     EXPECT_NE(0u, len);
 -//     EXPECT_TRUE(BIO_reset(mem.get()));
--
++  for (SSL *ssl : {client_.get(), server_.get()}) {
++    SCOPED_TRACE(SSL_is_server(ssl) ? "server" : "client");
+ 
 -//     // Writing should fail.
 -//     EXPECT_EQ(-1, SSL_write(ssl, "a", 1));
 -
@@ -1801,7 +1852,7 @@
 -// TEST_P(SSLVersionTest, SameKeyResume) {
 -//   uint8_t key[48];
 -//   RAND_bytes(key, sizeof(key));
- 
+-
 -//   bssl::UniquePtr<SSL_CTX> server_ctx2 = CreateContext();
 -//   ASSERT_TRUE(server_ctx2);
 -//   ASSERT_TRUE(UseCertAndKey(server_ctx2.get()));
@@ -1820,7 +1871,7 @@
 -//   ASSERT_TRUE(session);
 -//   ClientConfig config;
 -//   config.session = session.get();
--
+ 
 -//   // Resuming with |server_ctx_| again works.
 -//   bssl::UniquePtr<SSL> client, server;
 -//   ASSERT_TRUE(ConnectClientAndServer(&client, &server, client_ctx_.get(),

--- a/bssl-compat/source/SSL_CTX_set_alpn_select_cb.cc
+++ b/bssl-compat/source/SSL_CTX_set_alpn_select_cb.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+extern "C" void SSL_CTX_set_alpn_select_cb(SSL_CTX *ctx, int (*cb)(SSL *ssl, const uint8_t **out, uint8_t *out_len, const uint8_t *in, unsigned in_len, void *arg), void *arg) {
+  ossl.ossl_SSL_CTX_set_alpn_select_cb(ctx, cb, arg);
+}

--- a/bssl-compat/source/SSL_CTX_set_options.cc
+++ b/bssl-compat/source/SSL_CTX_set_options.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/955ef7991e41ac6c0ea5114b4b9abb98cc5fd614/include/openssl/ssl.h#L729
+ * https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set_options.html
+ */
+extern "C" uint32_t SSL_CTX_set_options(SSL_CTX *ctx, uint32_t options) {
+  return ossl.ossl_SSL_CTX_set_options(ctx, options);
+}

--- a/bssl-compat/source/SSL_CTX_set_timeout.cc
+++ b/bssl-compat/source/SSL_CTX_set_timeout.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/955ef7991e41ac6c0ea5114b4b9abb98cc5fd614/include/openssl/ssl.h#L1998
+ * https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set_timeout.html
+ */
+extern "C" uint32_t SSL_CTX_set_timeout(SSL_CTX *ctx, uint32_t timeout) {
+  return ossl.ossl_SSL_CTX_set_timeout(ctx, timeout);
+}

--- a/bssl-compat/source/SSL_CTX_set_tlsext_servername_arg.cc
+++ b/bssl-compat/source/SSL_CTX_set_tlsext_servername_arg.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/955ef7991e41ac6c0ea5114b4b9abb98cc5fd614/include/openssl/ssl.h#L2778
+ * https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set_tlsext_servername_arg.html
+ */
+extern "C" int SSL_CTX_set_tlsext_servername_arg(SSL_CTX *ctx, void *arg) {
+  return ossl.ossl_SSL_CTX_set_tlsext_servername_arg(ctx, arg);
+}

--- a/bssl-compat/source/SSL_CTX_set_tlsext_ticket_key_cb.cc
+++ b/bssl-compat/source/SSL_CTX_set_tlsext_ticket_key_cb.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/955ef7991e41ac6c0ea5114b4b9abb98cc5fd614/include/openssl/ssl.h#L2216
+ * https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set_tlsext_ticket_key_cb.html
+ */
+extern "C" int SSL_CTX_set_tlsext_ticket_key_cb(SSL_CTX *ctx, int (*callback)(SSL *ssl, uint8_t *key_name, uint8_t *iv, EVP_CIPHER_CTX *ctx, HMAC_CTX *hmac_ctx, int encrypt)) {
+  return ossl.ossl_SSL_CTX_set_tlsext_ticket_key_cb(ctx, callback);
+}

--- a/bssl-compat/source/SSL_CTX_set_verify_depth.cc
+++ b/bssl-compat/source/SSL_CTX_set_verify_depth.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/955ef7991e41ac6c0ea5114b4b9abb98cc5fd614/include/openssl/ssl.h#L2481
+ * https://www.openssl.org/docs/man3.0/man3/SSL_CTX_set_verify_depth.html
+ */
+extern "C" void SSL_CTX_set_verify_depth(SSL_CTX *ctx, int depth) {
+  ossl.ossl_SSL_CTX_set_verify_depth(ctx, depth);
+}

--- a/bssl-compat/source/SSL_CTX_use_PrivateKey_file.cc
+++ b/bssl-compat/source/SSL_CTX_use_PrivateKey_file.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/955ef7991e41ac6c0ea5114b4b9abb98cc5fd614/include/openssl/ssl.h#L1199
+ * https://www.openssl.org/docs/man3.0/man3/SSL_CTX_use_PrivateKey_file.html
+ */
+extern "C" int SSL_CTX_use_PrivateKey_file(SSL_CTX *ctx, const char *file, int type) {
+  return ossl.ossl_SSL_CTX_use_PrivateKey_file(ctx, file, type);
+}

--- a/bssl-compat/source/SSL_CTX_use_certificate_file.cc
+++ b/bssl-compat/source/SSL_CTX_use_certificate_file.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/955ef7991e41ac6c0ea5114b4b9abb98cc5fd614/include/openssl/ssl.h#L1194
+ * https://www.openssl.org/docs/man3.0/man3/SSL_CTX_use_certificate_file.html
+ */
+extern "C" int SSL_CTX_use_certificate_file(SSL_CTX *ctx, const char *file, int type) {
+  return ossl.ossl_SSL_CTX_use_certificate_file(ctx, file, type);
+}

--- a/bssl-compat/source/SSL_SESSION_free.cc
+++ b/bssl-compat/source/SSL_SESSION_free.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+extern "C" void SSL_SESSION_free(SSL_SESSION *session) {
+  ossl.ossl_SSL_SESSION_free(session);
+}

--- a/bssl-compat/source/SSL_SESSION_get_ticket_lifetime_hint.cc
+++ b/bssl-compat/source/SSL_SESSION_get_ticket_lifetime_hint.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+extern "C" uint32_t SSL_SESSION_get_ticket_lifetime_hint(const SSL_SESSION *session) {
+  return ossl.ossl_SSL_SESSION_get_ticket_lifetime_hint(session);
+}

--- a/bssl-compat/source/SSL_SESSION_get_version.cc
+++ b/bssl-compat/source/SSL_SESSION_get_version.cc
@@ -1,0 +1,12 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+#include "internal.h"
+
+
+/*
+ * https://github.com/google/boringssl/blob/955ef7991e41ac6c0ea5114b4b9abb98cc5fd614/include/openssl/ssl.h#L1714
+ * https://www.openssl.org/docs/man3.0/man3/SSL_SESSION_get_protocol_version.html
+ */
+extern "C" const char *SSL_SESSION_get_version(const SSL_SESSION *session) {
+  return TLS_VERSION_to_string(ossl.ossl_SSL_SESSION_get_protocol_version(session));
+}

--- a/bssl-compat/source/SSL_get0_alpn_selected.cc
+++ b/bssl-compat/source/SSL_get0_alpn_selected.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+extern "C" void SSL_get0_alpn_selected(const SSL *ssl, const uint8_t **out_data, unsigned *out_len) {
+  ossl.ossl_SSL_get0_alpn_selected(ssl, out_data, out_len);
+}

--- a/bssl-compat/source/SSL_get_SSL_CTX.cc
+++ b/bssl-compat/source/SSL_get_SSL_CTX.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/955ef7991e41ac6c0ea5114b4b9abb98cc5fd614/include/openssl/ssl.h#L235
+ * https://www.openssl.org/docs/man3.0/man3/SSL_get_SSL_CTX.html
+ */
+extern "C" SSL_CTX *SSL_get_SSL_CTX(const SSL *ssl) {
+  return ossl.ossl_SSL_get_SSL_CTX(ssl);
+}

--- a/bssl-compat/source/SSL_get_client_CA_list.cc
+++ b/bssl-compat/source/SSL_get_client_CA_list.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/955ef7991e41ac6c0ea5114b4b9abb98cc5fd614/include/openssl/ssl.h#L2693
+ * https://www.openssl.org/docs/man3.0/man3/SSL_get_client_CA_list.html
+ */
+extern "C" STACK_OF(X509_NAME) *SSL_get_client_CA_list(const SSL *ssl) {
+  return reinterpret_cast<STACK_OF(X509_NAME)*>(ossl_SSL_get_client_CA_list(ssl));
+}

--- a/bssl-compat/source/SSL_get_current_cipher.cc
+++ b/bssl-compat/source/SSL_get_current_cipher.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/955ef7991e41ac6c0ea5114b4b9abb98cc5fd614/include/openssl/ssl.h#L2693
+ * https://www.openssl.org/docs/man3.0/man3/SSL_get_current_cipher.html
+ */
+extern "C" const SSL_CIPHER *SSL_get_current_cipher(const SSL *ssl) {
+  return ossl.ossl_SSL_get_current_cipher(ssl);
+}

--- a/bssl-compat/source/SSL_get_ex_data.cc
+++ b/bssl-compat/source/SSL_get_ex_data.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/ssl.h#L3881
+ * https://www.openssl.org/docs/man3.0/man3/SSL_get_ex_data.html
+ */
+extern "C" void *SSL_get_ex_data(const SSL *ssl, int idx) {
+  return ossl.ossl_SSL_get_ex_data(ssl, idx);
+}

--- a/bssl-compat/source/SSL_get_ex_data_X509_STORE_CTX_idx.cc
+++ b/bssl-compat/source/SSL_get_ex_data_X509_STORE_CTX_idx.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/955ef7991e41ac6c0ea5114b4b9abb98cc5fd614/include/openssl/ssl.h#L2570
+ * https://www.openssl.org/docs/man3.0/man3/SSL_get_ex_data_X509_STORE_CTX_idx.html
+ */
+extern "C" int SSL_get_ex_data_X509_STORE_CTX_idx(void) {
+  return ossl.ossl_SSL_get_ex_data_X509_STORE_CTX_idx();
+}

--- a/bssl-compat/source/SSL_get_ex_new_index.cc
+++ b/bssl-compat/source/SSL_get_ex_new_index.cc
@@ -1,0 +1,16 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/098695591f3a2665fccef83a3732ecfc99acdcdd/src/include/openssl/ssl.h#LL3882C20-L3882C40
+ * https://www.openssl.org/docs/man3.0/man3/SSL_get_ex_new_index.html
+ * 
+ * Out of the three callback function pointers, BoringSSL only makes use of the
+ * free_func. The new & dup callbacks are completely ignored, and therefore
+ * never called, even if a real function pointer is passed, which is why we
+ * pass them as nullptr to OpenSSL.
+ */
+extern "C" int SSL_get_ex_new_index(long argl, void *argp, CRYPTO_EX_unused *new_func, CRYPTO_EX_dup *dup_func, CRYPTO_EX_free *free_func) {
+  return ossl.ossl_SSL_get_ex_new_index(argl, argp, nullptr, nullptr, free_func);
+}

--- a/bssl-compat/source/SSL_get_servername.cc
+++ b/bssl-compat/source/SSL_get_servername.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/955ef7991e41ac6c0ea5114b4b9abb98cc5fd614/include/openssl/ssl.h#L2756
+ * https://www.openssl.org/docs/man3.0/man3/SSL_get_servername.html
+ */
+extern "C" const char *SSL_get_servername(const SSL *ssl, const int type) {
+  return ossl.ossl_SSL_get_servername(ssl, type);
+}

--- a/bssl-compat/source/SSL_get_session.cc
+++ b/bssl-compat/source/SSL_get_session.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/955ef7991e41ac6c0ea5114b4b9abb98cc5fd614/include/openssl/ssl.h#L5004
+ * https://www.openssl.org/docs/man3.0/man3/SSL_get_session.html
+ */
+extern "C" SSL_SESSION *SSL_get_session(const SSL *ssl) {
+  return ossl.ossl_SSL_get_session(ssl);
+}

--- a/bssl-compat/source/SSL_get_version.cc
+++ b/bssl-compat/source/SSL_get_version.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/955ef7991e41ac6c0ea5114b4b9abb98cc5fd614/include/openssl/ssl.h#L4824
+ * https://www.openssl.org/docs/man3.0/man3/SSL_get_version.html
+ */
+extern "C" const char *SSL_get_version(const SSL *ssl) {
+  return ossl.ossl_SSL_get_version(ssl);
+}

--- a/bssl-compat/source/SSL_new.cc
+++ b/bssl-compat/source/SSL_new.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+extern "C" SSL *SSL_new(SSL_CTX *ctx) {
+  return ossl.ossl_SSL_new(ctx);
+}

--- a/bssl-compat/source/SSL_read.cc
+++ b/bssl-compat/source/SSL_read.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+extern "C" int SSL_read(SSL *ssl, void *buf, int num) {
+  return ossl.ossl_SSL_read(ssl, buf, num);
+}

--- a/bssl-compat/source/SSL_select_next_proto.cc
+++ b/bssl-compat/source/SSL_select_next_proto.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+extern "C" int SSL_select_next_proto(uint8_t **out, uint8_t *out_len, const uint8_t *peer, unsigned peer_len, const uint8_t *supported, unsigned supported_len) {
+  return ossl.ossl_SSL_select_next_proto(out, out_len, peer, peer_len, supported, supported_len);
+}

--- a/bssl-compat/source/SSL_set_alpn_protos.cc
+++ b/bssl-compat/source/SSL_set_alpn_protos.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+extern "C" int SSL_set_alpn_protos(SSL *ssl, const uint8_t *protos, unsigned protos_len) {
+  return ossl.ossl_SSL_set_alpn_protos(ssl, protos, protos_len);
+}

--- a/bssl-compat/source/SSL_set_cert_cb.cc
+++ b/bssl-compat/source/SSL_set_cert_cb.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+extern "C" void SSL_set_cert_cb(SSL *ssl, int (*cb)(SSL *ssl, void *arg), void *arg) {
+  ossl.ossl_SSL_set_cert_cb(ssl, cb, arg);
+}

--- a/bssl-compat/source/SSL_set_cipher_list.cc
+++ b/bssl-compat/source/SSL_set_cipher_list.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+extern "C" int SSL_set_cipher_list(SSL *ssl, const char *str) {
+  return ossl.ossl_SSL_set_cipher_list(ssl, str);
+}

--- a/bssl-compat/source/SSL_set_client_CA_list.cc
+++ b/bssl-compat/source/SSL_set_client_CA_list.cc
@@ -1,0 +1,11 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/955ef7991e41ac6c0ea5114b4b9abb98cc5fd614/include/openssl/ssl.h#L2665
+ * https://www.openssl.org/docs/man3.0/man3/SSL_set_client_CA_list.html
+ */
+extern "C" void SSL_set_client_CA_list(SSL *ssl, STACK_OF(X509_NAME) *name_list) {
+  ossl.ossl_SSL_set_client_CA_list(ssl, reinterpret_cast<ossl_STACK_OF(ossl_X509_NAME)*>(name_list));
+}

--- a/bssl-compat/source/SSL_set_ex_data.cc
+++ b/bssl-compat/source/SSL_set_ex_data.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+extern "C" int SSL_set_ex_data(SSL *ssl, int idx, void *data) {
+  return ossl.ossl_SSL_set_ex_data(ssl, idx, data);
+}

--- a/bssl-compat/source/SSL_set_fd.cc
+++ b/bssl-compat/source/SSL_set_fd.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+extern "C" int SSL_set_fd(SSL *ssl, int fd) {
+  return ossl.ossl_SSL_set_fd(ssl, fd);
+}

--- a/bssl-compat/source/SSL_set_quiet_shutdown.cc
+++ b/bssl-compat/source/SSL_set_quiet_shutdown.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+extern "C" void SSL_set_quiet_shutdown(SSL *ssl, int mode) {
+  ossl_SSL_set_quiet_shutdown(ssl, mode);
+}

--- a/bssl-compat/source/TLS_VERSION_to_string.cc
+++ b/bssl-compat/source/TLS_VERSION_to_string.cc
@@ -1,0 +1,14 @@
+#include <openssl/ssl.h>
+
+
+const char *TLS_VERSION_to_string(int version) {
+  switch (version) {
+    case TLS1_VERSION:    return "TLSv1";
+    case TLS1_1_VERSION:  return "TLSv1.1";
+    case TLS1_2_VERSION:  return "TLSv1.2";
+    case TLS1_3_VERSION:  return "TLSv1.3";
+    case DTLS1_VERSION:   return "DTLSv1";
+    case DTLS1_2_VERSION: return "DTLSv1.2";
+    default:  return "???";
+  }
+}

--- a/bssl-compat/source/X509_NAME_cmp.cc
+++ b/bssl-compat/source/X509_NAME_cmp.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L2058
+ * https://www.openssl.org/docs/man3.0/man3/X509_NAME_cmp.html
+ */
+extern "C" int X509_NAME_cmp(const X509_NAME *a, const X509_NAME *b) {
+  return ossl.ossl_X509_NAME_cmp(a, b);
+}

--- a/bssl-compat/source/X509_NAME_dup.cc
+++ b/bssl-compat/source/X509_NAME_dup.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L870
+ * https://www.openssl.org/docs/man3.0/man3/X509_NAME_dup.html
+ */
+extern "C" X509_NAME *X509_NAME_dup(X509_NAME *name) {
+  return ossl.ossl_X509_NAME_dup(name);
+}

--- a/bssl-compat/source/X509_NAME_free.cc
+++ b/bssl-compat/source/X509_NAME_free.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L850
+ * https://www.openssl.org/docs/man3.0/man3/X509_NAME_free.html
+ */
+extern "C" void X509_NAME_free(X509_NAME *name) {
+  ossl.ossl_X509_NAME_free(name);
+}

--- a/bssl-compat/source/X509_NAME_new.cc
+++ b/bssl-compat/source/X509_NAME_new.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L847
+ * https://www.openssl.org/docs/man3.0/man3/X509_NAME_new.html
+ */
+extern "C" X509_NAME *X509_NAME_new(void) {
+  return ossl.ossl_X509_NAME_new();
+}

--- a/bssl-compat/source/extra/ssl_extra.ld
+++ b/bssl-compat/source/extra/ssl_extra.ld
@@ -8,7 +8,6 @@ PROVIDE(SSL_CTX_get_ex_data = ossl_SSL_CTX_get_ex_data);
 PROVIDE(SSL_CTX_new = ossl_SSL_CTX_new);
 PROVIDE(SSL_CTX_set_ex_data = ossl_SSL_CTX_set_ex_data);
 PROVIDE(SSL_CTX_use_certificate_file = ossl_SSL_CTX_use_certificate_file);
-PROVIDE(SSL_CTX_use_PrivateKey_file = ossl_SSL_CTX_use_PrivateKey_file);
 PROVIDE(SSL_CTX_load_verify_locations = ossl_SSL_CTX_load_verify_locations);
 PROVIDE(SSL_free = ossl_SSL_free);
 PROVIDE(SSL_get_ciphers = ossl_SSL_get_ciphers);

--- a/bssl-compat/source/extra/ssl_extra.ld
+++ b/bssl-compat/source/extra/ssl_extra.ld
@@ -12,7 +12,6 @@ PROVIDE(SSL_CTX_use_PrivateKey_file = ossl_SSL_CTX_use_PrivateKey_file);
 PROVIDE(SSL_CTX_load_verify_locations = ossl_SSL_CTX_load_verify_locations);
 PROVIDE(SSL_free = ossl_SSL_free);
 PROVIDE(SSL_get_ciphers = ossl_SSL_get_ciphers);
-PROVIDE(SSL_get_SSL_CTX = ossl_SSL_get_SSL_CTX);
 PROVIDE(SSL_set_fd = ossl_SSL_set_fd);
 PROVIDE(SSL_SESSION_set_protocol_version = ossl_SSL_SESSION_set_protocol_version);
 PROVIDE(SSL_is_server = ossl_SSL_is_server);

--- a/bssl-compat/source/extra/ssl_extra.ld
+++ b/bssl-compat/source/extra/ssl_extra.ld
@@ -17,7 +17,6 @@ PROVIDE(SSL_new = ossl_SSL_new);
 PROVIDE(SSL_set_fd = ossl_SSL_set_fd);
 PROVIDE(SSL_read = ossl_SSL_read);
 PROVIDE(SSL_SESSION_set_protocol_version = ossl_SSL_SESSION_set_protocol_version);
-PROVIDE(SSL_SESSION_free = ossl_SSL_SESSION_free);
 PROVIDE(SSL_is_server = ossl_SSL_is_server);
 PROVIDE(SSL_CTX_use_certificate_chain_file = ossl_SSL_CTX_use_certificate_chain_file);
 PROVIDE(SSL_CTX_add_client_CA = ossl_SSL_CTX_add_client_CA);

--- a/bssl-compat/source/extra/ssl_extra.ld
+++ b/bssl-compat/source/extra/ssl_extra.ld
@@ -7,7 +7,6 @@ PROVIDE(SSL_CTX_free = ossl_SSL_CTX_free);
 PROVIDE(SSL_CTX_get_ex_data = ossl_SSL_CTX_get_ex_data);
 PROVIDE(SSL_CTX_new = ossl_SSL_CTX_new);
 PROVIDE(SSL_CTX_set_ex_data = ossl_SSL_CTX_set_ex_data);
-PROVIDE(SSL_CTX_use_certificate_file = ossl_SSL_CTX_use_certificate_file);
 PROVIDE(SSL_CTX_load_verify_locations = ossl_SSL_CTX_load_verify_locations);
 PROVIDE(SSL_free = ossl_SSL_free);
 PROVIDE(SSL_get_ciphers = ossl_SSL_get_ciphers);

--- a/bssl-compat/source/extra/ssl_extra.ld
+++ b/bssl-compat/source/extra/ssl_extra.ld
@@ -13,7 +13,6 @@ PROVIDE(SSL_CTX_load_verify_locations = ossl_SSL_CTX_load_verify_locations);
 PROVIDE(SSL_free = ossl_SSL_free);
 PROVIDE(SSL_get_ciphers = ossl_SSL_get_ciphers);
 PROVIDE(SSL_get_SSL_CTX = ossl_SSL_get_SSL_CTX);
-PROVIDE(SSL_new = ossl_SSL_new);
 PROVIDE(SSL_set_fd = ossl_SSL_set_fd);
 PROVIDE(SSL_SESSION_set_protocol_version = ossl_SSL_SESSION_set_protocol_version);
 PROVIDE(SSL_is_server = ossl_SSL_is_server);

--- a/bssl-compat/source/extra/ssl_extra.ld
+++ b/bssl-compat/source/extra/ssl_extra.ld
@@ -15,7 +15,6 @@ PROVIDE(SSL_get_ciphers = ossl_SSL_get_ciphers);
 PROVIDE(SSL_get_SSL_CTX = ossl_SSL_get_SSL_CTX);
 PROVIDE(SSL_new = ossl_SSL_new);
 PROVIDE(SSL_set_fd = ossl_SSL_set_fd);
-PROVIDE(SSL_read = ossl_SSL_read);
 PROVIDE(SSL_SESSION_set_protocol_version = ossl_SSL_SESSION_set_protocol_version);
 PROVIDE(SSL_is_server = ossl_SSL_is_server);
 PROVIDE(SSL_CTX_use_certificate_chain_file = ossl_SSL_CTX_use_certificate_chain_file);

--- a/bssl-compat/source/internal.h
+++ b/bssl-compat/source/internal.h
@@ -1,0 +1,6 @@
+#ifndef _BSSL_COMPAT_INTERNAL_H_
+#define _BSSL_COMPAT_INTERNAL_H_
+
+const char *TLS_VERSION_to_string(int version);
+
+#endif // _BSSL_COMPAT_INTERNAL_H_

--- a/bssl-compat/source/log.c
+++ b/bssl-compat/source/log.c
@@ -2,6 +2,8 @@
 #include "log.h"
 #include <stdarg.h>
 #include <stdio.h>
+#include <stdlib.h>
+
 
 void bssl_compat_log(int level, const char *file, int line, const char *fmt, ...) {
   fprintf(stderr, "%s:%d ", file, line);
@@ -10,4 +12,7 @@ void bssl_compat_log(int level, const char *file, int line, const char *fmt, ...
   vfprintf(stderr, fmt, args);
   va_end(args);
   fprintf(stderr, "\n");
+  if (level == BSSL_COMPAT_LOG_FATAL) {
+    exit(-1);
+  }
 }

--- a/bssl-compat/source/test/test_ssl.cc
+++ b/bssl-compat/source/test/test_ssl.cc
@@ -1192,3 +1192,14 @@ TEST(SSLTest, test_SSL_ex_data) {
   }
   ASSERT_EQ(2, free_func_calls);
 }
+
+TEST(SSLTest, test_SSL_set_cipher_list) {
+  bssl::UniquePtr<SSL_CTX> ctx {SSL_CTX_new(TLS_server_method())};
+  bssl::UniquePtr<SSL> ssl {SSL_new(ctx.get())};
+
+  ASSERT_TRUE(SSL_set_cipher_list(ssl.get(), "HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4"));
+  ASSERT_TRUE(SSL_set_cipher_list(ssl.get(), "HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4"));
+  ASSERT_FALSE(SSL_set_cipher_list(ssl.get(), "NO:VALID:CIPHERS"));
+  ASSERT_TRUE(SSL_set_cipher_list(ssl.get(), "ONE:VALID:CIPHER:PSK"));
+  ASSERT_TRUE(SSL_set_cipher_list(ssl.get(), "HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4"));
+}

--- a/bssl-compat/source/test/test_ssl.cc
+++ b/bssl-compat/source/test/test_ssl.cc
@@ -1203,3 +1203,15 @@ TEST(SSLTest, test_SSL_set_cipher_list) {
   ASSERT_TRUE(SSL_set_cipher_list(ssl.get(), "ONE:VALID:CIPHER:PSK"));
   ASSERT_TRUE(SSL_set_cipher_list(ssl.get(), "HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4"));
 }
+
+TEST(SSLTest, test_SSL_set_app_data) {
+  bssl::UniquePtr<SSL_CTX> ctx {SSL_CTX_new(TLS_server_method())};
+  bssl::UniquePtr<SSL> ssl {SSL_new(ctx.get())};
+
+  int i {42};
+
+  ASSERT_TRUE(SSL_set_app_data(ssl.get(), &i));
+  ASSERT_EQ(&i, SSL_get_app_data(ssl.get()));
+  ASSERT_TRUE(SSL_set_app_data(ssl.get(), nullptr));
+  ASSERT_EQ(nullptr, SSL_get_app_data(ssl.get()));
+}


### PR DESCRIPTION
Added:
- SSL_CTX_set_options()
- SSL_CTX_set_timeout()
- SSL_CTX_set_tlsext_ticket_key_cb()
- SSL_CTX_set_verify_depth()
- SSL_CTX_use_certificate_file()
- SSL_CTX_use_PrivateKey_file()
- SSL_get_cipher_name()
- X509_NAME_free()
- X509_NAME_cmp()
- X509_NAME_dup()
- X509_NAME_new()
- SSL_set_client_CA_list()
- SSL_get_client_CA_list()
- SSL_get_current_cipher()
- SSL_get_ex_data_X509_STORE_CTX_idx()
- SSL_CTX_set_tlsext_servername_arg()
- SSL_get_servername()
- SSL_get_SSL_CTX()
- SSL_SESSION_get_version()
- SSL_get_session()
- SSL_get_version()
- SSL_new()
- SSL_read()
- SSL_get0_alpn_selected()
- SSL_select_next_proto()
- SSL_SESSION_free()
- SSL_SESSION_get_ticket_lifetime_hint()
- SSL_CTX_set_alpn_select_cb()
- SSL_set_alpn_protos()
- SSL_get/set_app_data()
- SSL_set_cert_cb()
- SSL_set_cipher_list()
- SSL_get_ex_data()
- SSL_get_ex_new_index()
- SSL_set_ex_data()
- SSL_set_fd()
- SSL_set_quiet_shutdown()
- SSL_set_verify()
- SSL_set1_curves_list()

Enabled more BoringSSL unit tests
- SSLTest.ClientCAList
- WithVersion/SSLVersionTest.GetServerName/*
- WithVersion/SSLVersionTest.Version/*
- WithVersion/SSLVersionTest.SameKeyResume/*
