### PR TITLE
OSSM-3366 Added more <openssl/ec.h> functions

### DIFF
--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(bssl-compat STATIC
   source/DTLS_method.cc
   source/EC_GROUP_get0_order.cc
   source/EC_GROUP_get_curve_name.cc
+  source/EC_GROUP_get_degree.cc
   source/EC_KEY_free.cc
   source/EC_KEY_get0_group.cc
   source/EC_KEY_parse_private_key.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library(bssl-compat STATIC
   source/digest.c
   source/DTLS_method.cc
   source/EC_GROUP_get_curve_name.cc
+  source/EC_KEY_free.cc
   source/EC_KEY_get0_group.cc
   source/EC_KEY_parse_private_key.cc
   source/err.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(bssl-compat STATIC
   source/d2i_SSL_SESSION.c
   source/digest.c
   source/DTLS_method.cc
+  source/EC_KEY_get0_group.cc
   source/err.c
   source/evp.c
   source/EVP_DecodeBase64.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(bssl-compat STATIC
   source/d2i_SSL_SESSION.c
   source/digest.c
   source/DTLS_method.cc
+  source/ECDSA_sign.cc
   source/ECDSA_size.cc
   source/EC_GROUP_get0_order.cc
   source/EC_GROUP_get_curve_name.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(bssl-compat STATIC
   source/d2i_SSL_SESSION.c
   source/digest.c
   source/DTLS_method.cc
+  source/ECDSA_size.cc
   source/EC_GROUP_get0_order.cc
   source/EC_GROUP_get_curve_name.cc
   source/EC_GROUP_get_degree.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(bssl-compat STATIC
   source/d2i_SSL_SESSION.c
   source/digest.c
   source/DTLS_method.cc
+  source/EC_GROUP_get0_order.cc
   source/EC_GROUP_get_curve_name.cc
   source/EC_KEY_free.cc
   source/EC_KEY_get0_group.cc
@@ -337,6 +338,7 @@ set(utests-source-list
   source/test/test_bn.cc
   source/test/test_cipher.cc
   source/test/test_crypto.cc
+  source/test/test_ec_key.cc
   source/test/test_evp.cc
   source/test/test_rsa.cc
   source/test/test_ssl.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library(bssl-compat STATIC
   source/DTLS_method.cc
   source/EC_GROUP_get_curve_name.cc
   source/EC_KEY_get0_group.cc
+  source/EC_KEY_parse_private_key.cc
   source/err.c
   source/evp.c
   source/EVP_DecodeBase64.c

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -58,6 +58,7 @@ add_library(bssl-compat STATIC
   source/d2i_SSL_SESSION.c
   source/digest.c
   source/DTLS_method.cc
+  source/EC_GROUP_get_curve_name.cc
   source/EC_KEY_get0_group.cc
   source/err.c
   source/evp.c
@@ -318,8 +319,9 @@ set(utests-bssl-source-list
   source/crypto/bio/bio_test.cc
   source/crypto/digest_extra/digest_test.cc
   source/crypto/err/err_test.cc
-  source/crypto/rsa_extra/rsa_test.cc
+  #source/crypto/evp/evp_extra_test.cc
   source/crypto/rand_extra/rand_test.cc
+  source/crypto/rsa_extra/rsa_test.cc
   source/crypto/stack/stack_test.cc
   source/crypto/test/test_util.cc
   source/crypto/test/test_util.h

--- a/bssl-compat/patch/include/openssl/base.h.patch
+++ b/bssl-compat/patch/include/openssl/base.h.patch
@@ -512,8 +512,9 @@
 +typedef struct crypto_buffer_st CRYPTO_BUFFER;
  // typedef struct dh_st DH;
  // typedef struct dsa_st DSA;
- // typedef struct ec_group_st EC_GROUP;
+-// typedef struct ec_group_st EC_GROUP;
 -// typedef struct ec_key_st EC_KEY;
++typedef ossl_EC_GROUP EC_GROUP;
 +typedef ossl_EC_KEY EC_KEY;
  // typedef struct ec_point_st EC_POINT;
  // typedef struct ecdsa_method_st ECDSA_METHOD;

--- a/bssl-compat/patch/include/openssl/ec.h.patch
+++ b/bssl-compat/patch/include/openssl/ec.h.patch
@@ -21,6 +21,15 @@
  
  
  // Low-level operations on elliptic curves.
+@@ -131,7 +131,7 @@
+ 
+ // EC_GROUP_get0_order returns a pointer to the internal |BIGNUM| object in
+ // |group| that specifies the order of the group.
+-// OPENSSL_EXPORT const BIGNUM *EC_GROUP_get0_order(const EC_GROUP *group);
++OPENSSL_EXPORT const BIGNUM *EC_GROUP_get0_order(const EC_GROUP *group);
+ 
+ // EC_GROUP_order_bits returns the number of bits of the order of |group|.
+ // OPENSSL_EXPORT int EC_GROUP_order_bits(const EC_GROUP *group);
 @@ -151,7 +151,7 @@
  //                                           BN_CTX *ctx);
  

--- a/bssl-compat/patch/include/openssl/ec.h.patch
+++ b/bssl-compat/patch/include/openssl/ec.h.patch
@@ -1,0 +1,66 @@
+--- a/include/openssl/ec.h
++++ b/include/openssl/ec.h
+@@ -65,14 +65,14 @@
+  * Sheueling Chang Shantz and Douglas Stebila of Sun Microsystems
+  * Laboratories. */
+ 
+-// #ifndef OPENSSL_HEADER_EC_H
+-// #define OPENSSL_HEADER_EC_H
++#ifndef OPENSSL_HEADER_EC_H
++#define OPENSSL_HEADER_EC_H
+ 
+-// #include <openssl/base.h>
++#include <openssl/base.h>
+ 
+-// #if defined(__cplusplus)
+-// extern "C" {
+-// #endif
++#if defined(__cplusplus)
++extern "C" {
++#endif
+ 
+ 
+ // Low-level operations on elliptic curves.
+@@ -391,26 +391,26 @@
+ // OPENSSL_EXPORT void EC_POINT_clear_free(EC_POINT *point);
+ 
+ 
+-// #if defined(__cplusplus)
+-// }  // extern C
+-// #endif
++#if defined(__cplusplus)
++}  // extern C
++#endif
+ 
+ // Old code expects to get EC_KEY from ec.h.
+-// #include <openssl/ec_key.h>
++#include <openssl/ec_key.h>
+ 
+-// #if defined(__cplusplus)
+-// extern "C++" {
++#if defined(__cplusplus)
++extern "C++" {
+ 
+-// BSSL_NAMESPACE_BEGIN
++BSSL_NAMESPACE_BEGIN
+ 
+ // BORINGSSL_MAKE_DELETER(EC_POINT, EC_POINT_free)
+ // BORINGSSL_MAKE_DELETER(EC_GROUP, EC_GROUP_free)
+ 
+-// BSSL_NAMESPACE_END
++BSSL_NAMESPACE_END
+ 
+-// }  // extern C++
++}  // extern C++
+ 
+-// #endif
++#endif
+ 
+ #ifdef ossl_EC_R_BUFFER_TOO_SMALL
+ #define EC_R_BUFFER_TOO_SMALL ossl_EC_R_BUFFER_TOO_SMALL
+@@ -515,4 +515,4 @@
+ #define EC_R_INVALID_SCALAR ossl_EC_R_INVALID_SCALAR
+ #endif
+ 
+-// #endif  // OPENSSL_HEADER_EC_H
++#endif  // OPENSSL_HEADER_EC_H

--- a/bssl-compat/patch/include/openssl/ec.h.patch
+++ b/bssl-compat/patch/include/openssl/ec.h.patch
@@ -30,7 +30,7 @@
  
  // EC_GROUP_order_bits returns the number of bits of the order of |group|.
  // OPENSSL_EXPORT int EC_GROUP_order_bits(const EC_GROUP *group);
-@@ -151,7 +151,7 @@
+@@ -151,11 +151,11 @@
  //                                           BN_CTX *ctx);
  
  // EC_GROUP_get_curve_name returns a NID that identifies |group|.
@@ -39,6 +39,11 @@
  
  // EC_GROUP_get_degree returns the number of bits needed to represent an
  // element of the field underlying |group|.
+-// OPENSSL_EXPORT unsigned EC_GROUP_get_degree(const EC_GROUP *group);
++OPENSSL_EXPORT unsigned EC_GROUP_get_degree(const EC_GROUP *group);
+ 
+ // EC_curve_nid2nist returns the NIST name of the elliptic curve specified by
+ // |nid|, or NULL if |nid| is not a NIST curve. For example, it returns "P-256"
 @@ -391,26 +391,26 @@
  // OPENSSL_EXPORT void EC_POINT_clear_free(EC_POINT *point);
  

--- a/bssl-compat/patch/include/openssl/ec.h.patch
+++ b/bssl-compat/patch/include/openssl/ec.h.patch
@@ -21,6 +21,15 @@
  
  
  // Low-level operations on elliptic curves.
+@@ -151,7 +151,7 @@
+ //                                           BN_CTX *ctx);
+ 
+ // EC_GROUP_get_curve_name returns a NID that identifies |group|.
+-// OPENSSL_EXPORT int EC_GROUP_get_curve_name(const EC_GROUP *group);
++OPENSSL_EXPORT int EC_GROUP_get_curve_name(const EC_GROUP *group);
+ 
+ // EC_GROUP_get_degree returns the number of bits needed to represent an
+ // element of the field underlying |group|.
 @@ -391,26 +391,26 @@
  // OPENSSL_EXPORT void EC_POINT_clear_free(EC_POINT *point);
  

--- a/bssl-compat/patch/include/openssl/ec_key.h.patch
+++ b/bssl-compat/patch/include/openssl/ec_key.h.patch
@@ -1,0 +1,69 @@
+--- a/include/openssl/ec_key.h
++++ b/include/openssl/ec_key.h
+@@ -65,18 +65,18 @@
+  * Sheueling Chang Shantz and Douglas Stebila of Sun Microsystems
+  * Laboratories. */
+ 
+-// #ifndef OPENSSL_HEADER_EC_KEY_H
+-// #define OPENSSL_HEADER_EC_KEY_H
++#ifndef OPENSSL_HEADER_EC_KEY_H
++#define OPENSSL_HEADER_EC_KEY_H
+ 
+-// #include <openssl/base.h>
++#include <openssl/base.h>
+ 
+-// #include <openssl/ec.h>
+-// #include <openssl/engine.h>
+-// #include <openssl/ex_data.h>
+-
+-// #if defined(__cplusplus)
+-// extern "C" {
+-// #endif
++#include <openssl/ec.h>
++#include <openssl/engine.h>
++#include <openssl/ex_data.h>
++
++#if defined(__cplusplus)
++extern "C" {
++#endif
+ 
+ 
+ // ec_key.h contains functions that handle elliptic-curve points that are
+@@ -117,7 +117,7 @@
+ // OPENSSL_EXPORT int EC_KEY_is_opaque(const EC_KEY *key);
+ 
+ // EC_KEY_get0_group returns a pointer to the |EC_GROUP| object inside |key|.
+-// OPENSSL_EXPORT const EC_GROUP *EC_KEY_get0_group(const EC_KEY *key);
++OPENSSL_EXPORT const EC_GROUP *EC_KEY_get0_group(const EC_KEY *key);
+ 
+ // EC_KEY_set_group sets the |EC_GROUP| object that |key| will use to |group|.
+ // It returns one on success and zero if |key| is already configured with a
+@@ -341,20 +341,20 @@
+ // OPENSSL_EXPORT int i2o_ECPublicKey(const EC_KEY *key, unsigned char **outp);
+ 
+ 
+-// #if defined(__cplusplus)
+-// }  // extern C
++#if defined(__cplusplus)
++}  // extern C
+ 
+-// extern "C++" {
++extern "C++" {
+ 
+-// BSSL_NAMESPACE_BEGIN
++BSSL_NAMESPACE_BEGIN
+ 
+ // BORINGSSL_MAKE_DELETER(EC_KEY, EC_KEY_free)
+ // BORINGSSL_MAKE_UP_REF(EC_KEY, EC_KEY_up_ref)
+ 
+-// BSSL_NAMESPACE_END
++BSSL_NAMESPACE_END
+ 
+-// }  // extern C++
++}  // extern C++
+ 
+-// #endif
++#endif
+ 
+-// #endif  // OPENSSL_HEADER_EC_KEY_H
++#endif  // OPENSSL_HEADER_EC_KEY_H

--- a/bssl-compat/patch/include/openssl/ec_key.h.patch
+++ b/bssl-compat/patch/include/openssl/ec_key.h.patch
@@ -38,6 +38,17 @@
  
  // EC_KEY_set_group sets the |EC_GROUP| object that |key| will use to |group|.
  // It returns one on success and zero if |key| is already configured with a
+@@ -222,8 +222,8 @@
+ // NULL on error. If |group| is non-null, the parameters field of the
+ // ECPrivateKey may be omitted (but must match |group| if present). Otherwise,
+ // the parameters field is required.
+-// OPENSSL_EXPORT EC_KEY *EC_KEY_parse_private_key(CBS *cbs,
+-//                                                 const EC_GROUP *group);
++OPENSSL_EXPORT EC_KEY *EC_KEY_parse_private_key(CBS *cbs,
++                                                const EC_GROUP *group);
+ 
+ // EC_KEY_marshal_private_key marshals |key| as a DER-encoded ECPrivateKey
+ // structure (RFC 5915) and appends the result to |cbb|. It returns one on
 @@ -341,20 +341,20 @@
  // OPENSSL_EXPORT int i2o_ECPublicKey(const EC_KEY *key, unsigned char **outp);
  

--- a/bssl-compat/patch/include/openssl/ec_key.h.patch
+++ b/bssl-compat/patch/include/openssl/ec_key.h.patch
@@ -29,6 +29,15 @@
  
  
  // ec_key.h contains functions that handle elliptic-curve points that are
+@@ -103,7 +103,7 @@
+ // OPENSSL_EXPORT EC_KEY *EC_KEY_new_by_curve_name(int nid);
+ 
+ // EC_KEY_free frees all the data owned by |key| and |key| itself.
+-// OPENSSL_EXPORT void EC_KEY_free(EC_KEY *key);
++OPENSSL_EXPORT void EC_KEY_free(EC_KEY *key);
+ 
+ // EC_KEY_dup returns a fresh copy of |src| or NULL on error.
+ // OPENSSL_EXPORT EC_KEY *EC_KEY_dup(const EC_KEY *src);
 @@ -117,7 +117,7 @@
  // OPENSSL_EXPORT int EC_KEY_is_opaque(const EC_KEY *key);
  

--- a/bssl-compat/patch/include/openssl/ecdsa.h.patch
+++ b/bssl-compat/patch/include/openssl/ecdsa.h.patch
@@ -24,6 +24,19 @@
  
  
  // ECDSA contains functions for signing and verifying with the Digital Signature
+@@ -76,9 +76,9 @@
+ //
+ // WARNING: |digest| must be the output of some hash function on the data to be
+ // signed. Passing unhashed inputs will not result in a secure signature scheme.
+-// OPENSSL_EXPORT int ECDSA_sign(int type, const uint8_t *digest,
+-//                               size_t digest_len, uint8_t *sig,
+-//                               unsigned int *sig_len, const EC_KEY *key);
++OPENSSL_EXPORT int ECDSA_sign(int type, const uint8_t *digest,
++                              size_t digest_len, uint8_t *sig,
++                              unsigned int *sig_len, const EC_KEY *key);
+ 
+ // ECDSA_verify verifies that |sig_len| bytes from |sig| constitute a valid
+ // signature by |key| of |digest|. (The |type| argument should be zero.) It
 @@ -94,7 +94,7 @@
  
  // ECDSA_size returns the maximum size of an ECDSA signature using |key|. It

--- a/bssl-compat/patch/include/openssl/ecdsa.h.patch
+++ b/bssl-compat/patch/include/openssl/ecdsa.h.patch
@@ -1,0 +1,69 @@
+--- a/include/openssl/ecdsa.h
++++ b/include/openssl/ecdsa.h
+@@ -50,16 +50,16 @@
+  * (eay@cryptsoft.com).  This product includes software written by Tim
+  * Hudson (tjh@cryptsoft.com). */
+ 
+-// #ifndef OPENSSL_HEADER_ECDSA_H
+-// #define OPENSSL_HEADER_ECDSA_H
++#ifndef OPENSSL_HEADER_ECDSA_H
++#define OPENSSL_HEADER_ECDSA_H
+ 
+-// #include <openssl/base.h>
++#include <openssl/base.h>
+ 
+-// #include <openssl/ec_key.h>
++#include <openssl/ec_key.h>
+ 
+-// #if defined(__cplusplus)
+-// extern "C" {
+-// #endif
++#if defined(__cplusplus)
++extern "C" {
++#endif
+ 
+ 
+ // ECDSA contains functions for signing and verifying with the Digital Signature
+@@ -94,7 +94,7 @@
+ 
+ // ECDSA_size returns the maximum size of an ECDSA signature using |key|. It
+ // returns zero if |key| is NULL or if it doesn't have a group set.
+-// OPENSSL_EXPORT size_t ECDSA_size(const EC_KEY *key);
++OPENSSL_EXPORT size_t ECDSA_size(const EC_KEY *key);
+ 
+ 
+ // Low-level signing and verification.
+@@ -211,20 +211,20 @@
+ // OPENSSL_EXPORT int i2d_ECDSA_SIG(const ECDSA_SIG *sig, uint8_t **outp);
+ 
+ 
+-// #if defined(__cplusplus)
+-// }  // extern C
++#if defined(__cplusplus)
++}  // extern C
+ 
+-// extern "C++" {
++extern "C++" {
+ 
+-// BSSL_NAMESPACE_BEGIN
++BSSL_NAMESPACE_BEGIN
+ 
+ // BORINGSSL_MAKE_DELETER(ECDSA_SIG, ECDSA_SIG_free)
+ 
+-// BSSL_NAMESPACE_END
++BSSL_NAMESPACE_END
+ 
+-// }  // extern C++
++}  // extern C++
+ 
+-// #endif
++#endif
+ 
+ #ifdef ossl_ECDSA_R_BAD_SIGNATURE
+ #define ECDSA_R_BAD_SIGNATURE ossl_ECDSA_R_BAD_SIGNATURE
+@@ -245,4 +245,4 @@
+ #define ECDSA_R_ENCODE_ERROR ossl_ECDSA_R_ENCODE_ERROR
+ #endif
+ 
+-// #endif  // OPENSSL_HEADER_ECDSA_H
++#endif  // OPENSSL_HEADER_ECDSA_H

--- a/bssl-compat/patch/include/openssl/pkcs8.h.patch
+++ b/bssl-compat/patch/include/openssl/pkcs8.h.patch
@@ -1,0 +1,61 @@
+--- a/include/openssl/pkcs8.h
++++ b/include/openssl/pkcs8.h
+@@ -54,16 +54,16 @@
+  * Hudson (tjh@cryptsoft.com). */
+ 
+ 
+-// #ifndef OPENSSL_HEADER_PKCS8_H
+-// #define OPENSSL_HEADER_PKCS8_H
++#ifndef OPENSSL_HEADER_PKCS8_H
++#define OPENSSL_HEADER_PKCS8_H
+ 
+-// #include <openssl/base.h>
+-// #include <openssl/x509.h>
++#include <openssl/base.h>
++#include <openssl/x509.h>
+ 
+ 
+-// #if defined(__cplusplus)
+-// extern "C" {
+-// #endif
++#if defined(__cplusplus)
++extern "C" {
++#endif
+ 
+ 
+ // PKCS8_encrypt serializes and encrypts a PKCS8_PRIV_KEY_INFO with PBES1 or
+@@ -236,21 +236,21 @@
+ // OPENSSL_EXPORT void PKCS12_free(PKCS12 *p12);
+ 
+ 
+-// #if defined(__cplusplus)
+-// }  // extern C
++#if defined(__cplusplus)
++}  // extern C
+ 
+-// extern "C++" {
++extern "C++" {
+ 
+-// BSSL_NAMESPACE_BEGIN
++BSSL_NAMESPACE_BEGIN
+ 
+ // BORINGSSL_MAKE_DELETER(PKCS12, PKCS12_free)
+ // BORINGSSL_MAKE_DELETER(PKCS8_PRIV_KEY_INFO, PKCS8_PRIV_KEY_INFO_free)
+ 
+-// BSSL_NAMESPACE_END
++BSSL_NAMESPACE_END
+ 
+-// }  // extern C++
++}  // extern C++
+ 
+-// #endif
++#endif
+ 
+ #ifdef ossl_PKCS8_R_BAD_PKCS12_DATA
+ #define PKCS8_R_BAD_PKCS12_DATA ossl_PKCS8_R_BAD_PKCS12_DATA
+@@ -355,4 +355,4 @@
+ #define PKCS8_R_AMBIGUOUS_FRIENDLY_NAME ossl_PKCS8_R_AMBIGUOUS_FRIENDLY_NAME
+ #endif
+ 
+-// #endif  // OPENSSL_HEADER_PKCS8_H
++#endif  // OPENSSL_HEADER_PKCS8_H

--- a/bssl-compat/source/ECDSA_sign.cc
+++ b/bssl-compat/source/ECDSA_sign.cc
@@ -1,0 +1,11 @@
+#include <openssl/ecdsa.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/cfafcd454fd01ebc40f1a7f43537dd306b7b64c3/include/openssl/ecdsa.h#L79
+ * https://www.openssl.org/docs/man3.0/man3/ECDSA_sign.html
+ */
+extern "C" int ECDSA_sign(int type, const uint8_t *digest, size_t digest_len, uint8_t *sig, unsigned int *sig_len, const EC_KEY *key) {
+  return ossl.ossl_ECDSA_sign(type, digest, digest_len, sig, sig_len, const_cast<EC_KEY*>(key));
+}

--- a/bssl-compat/source/ECDSA_size.cc
+++ b/bssl-compat/source/ECDSA_size.cc
@@ -1,0 +1,11 @@
+#include <openssl/ecdsa.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/cfafcd454fd01ebc40f1a7f43537dd306b7b64c3/include/openssl/ecdsa.h#L97
+ * https://www.openssl.org/docs/man3.0/man3/ECDSA_size.html
+ */
+extern "C" size_t ECDSA_size(const EC_KEY *key) {
+  return ossl.ossl_ECDSA_size(key);
+}

--- a/bssl-compat/source/EC_GROUP_get0_order.cc
+++ b/bssl-compat/source/EC_GROUP_get0_order.cc
@@ -1,0 +1,11 @@
+#include <openssl/ec.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/c7a3c46574e7fc32357b2cc68f961c56c72b0ca4/include/openssl/ec.h#L134
+ * https://www.openssl.org/docs/man3.0/man3/EC_GROUP_get0_order.html
+ */
+extern "C" const BIGNUM *EC_GROUP_get0_order(const EC_GROUP *group) {
+  return ossl.ossl_EC_GROUP_get0_order(group);
+}

--- a/bssl-compat/source/EC_GROUP_get_curve_name.cc
+++ b/bssl-compat/source/EC_GROUP_get_curve_name.cc
@@ -1,0 +1,11 @@
+#include <openssl/ec.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/c7a3c46574e7fc32357b2cc68f961c56c72b0ca4/include/openssl/ec.h#L154
+ * https://www.openssl.org/docs/man3.0/man3/EC_GROUP_get_curve_name.html
+ */
+extern "C" int EC_GROUP_get_curve_name(const EC_GROUP *group) {
+  return ossl.ossl_EC_GROUP_get_curve_name(group);
+}

--- a/bssl-compat/source/EC_GROUP_get_degree.cc
+++ b/bssl-compat/source/EC_GROUP_get_degree.cc
@@ -1,0 +1,11 @@
+#include <openssl/ec.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/c7a3c46574e7fc32357b2cc68f961c56c72b0ca4/include/openssl/ec.h#L158
+ * https://www.openssl.org/docs/man3.0/man3/EC_GROUP_get_degree.html
+ */
+extern "C" unsigned EC_GROUP_get_degree(const EC_GROUP *group) {
+  return ossl.ossl_EC_GROUP_get_degree(group);
+}

--- a/bssl-compat/source/EC_KEY_free.cc
+++ b/bssl-compat/source/EC_KEY_free.cc
@@ -1,0 +1,11 @@
+#include <openssl/ec_key.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/8bbefbfeee609b17622deedd100163c12f5c95dc/include/openssl/ec_key.h#L106
+ * https://www.openssl.org/docs/man3.0/man3/EC_KEY_free.html
+ */
+extern "C" void EC_KEY_free(EC_KEY *key) {
+  ossl.ossl_EC_KEY_free(key);
+}

--- a/bssl-compat/source/EC_KEY_get0_group.cc
+++ b/bssl-compat/source/EC_KEY_get0_group.cc
@@ -1,0 +1,11 @@
+#include <openssl/ec_key.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/8bbefbfeee609b17622deedd100163c12f5c95dc/include/openssl/ec_key.h#L120
+ * https://www.openssl.org/docs/man3.0/man3/EC_KEY_get0_group.html
+ */
+extern "C" const EC_GROUP *EC_KEY_get0_group(const EC_KEY *key) {
+  return ossl.ossl_EC_KEY_get0_group(key);
+}

--- a/bssl-compat/source/EC_KEY_parse_private_key.cc
+++ b/bssl-compat/source/EC_KEY_parse_private_key.cc
@@ -1,0 +1,30 @@
+#include <openssl/ec_key.h>
+#include <openssl/bytestring.h>
+#include <ossl.h>
+#include "log.h"
+
+
+/*
+ * https://github.com/google/boringssl/blob/8bbefbfeee609b17622deedd100163c12f5c95dc/include/openssl/ec_key.h#L225
+ * https://www.openssl.org/docs/man3.0/man3/d2i_ECPrivateKey.html
+ */
+extern "C" EC_KEY *EC_KEY_parse_private_key(CBS *cbs, const EC_GROUP *group) {
+  if (group != nullptr) {
+    bssl_compat_fatal("%s() with non-null group not implemented", __func__);
+  }
+
+  auto data1 {CBS_data(cbs)}; // save so we can work out the skip
+  auto data2 {data1}; // gets advanced by d2i_ECPrivateKey()
+  auto length {CBS_len(cbs)};
+
+  EC_KEY *key = ossl.ossl_d2i_ECPrivateKey(nullptr, &data2, length);
+
+  if (key) {
+    if (!CBS_skip(cbs, data2 - data1)) {
+      ossl.ossl_EC_KEY_free(key);
+      key = nullptr;
+    }
+  }
+
+  return key;
+}

--- a/bssl-compat/source/test/test_ec_key.cc
+++ b/bssl-compat/source/test/test_ec_key.cc
@@ -1,0 +1,29 @@
+#include <gtest/gtest.h>
+#include <openssl/ec.h>
+#include <openssl/bytestring.h>
+#include <openssl/nid.h>
+#include <openssl/bn.h>
+
+
+// Copied from: boringssl/crypto/fipsmodule/ec/ec_test.cc
+static const uint8_t kECKeyWithoutPublic[] = {
+  0x30, 0x31, 0x02, 0x01, 0x01, 0x04, 0x20, 0xc6, 0xc1, 0xaa, 0xda, 0x15, 0xb0,
+  0x76, 0x61, 0xf8, 0x14, 0x2c, 0x6c, 0xaf, 0x0f, 0xdb, 0x24, 0x1a, 0xff, 0x2e,
+  0xfe, 0x46, 0xc0, 0x93, 0x8b, 0x74, 0xf2, 0xbc, 0xc5, 0x30, 0x52, 0xb0, 0x77,
+  0xa0, 0x0a, 0x06, 0x08, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x03, 0x01, 0x07,
+};
+
+TEST(EC_KEYTest, test_EC_KEY_parse_private_key) {
+  CBS cbs;
+  CBS_init(&cbs, kECKeyWithoutPublic, sizeof(kECKeyWithoutPublic));
+
+  EC_KEY *key = EC_KEY_parse_private_key(&cbs, nullptr);
+  ASSERT_TRUE(key);
+  const EC_GROUP *group = EC_KEY_get0_group(key);
+  ASSERT_TRUE(group);
+  ASSERT_EQ(NID_X9_62_prime256v1, EC_GROUP_get_curve_name(group));
+  const BIGNUM *order {EC_GROUP_get0_order(group)};
+  ASSERT_TRUE(order);
+  ASSERT_EQ(256, BN_num_bits(order));
+  EC_KEY_free(key);
+}

--- a/bssl-compat/source/test/test_ec_key.cc
+++ b/bssl-compat/source/test/test_ec_key.cc
@@ -19,11 +19,17 @@ TEST(EC_KEYTest, test_EC_KEY_parse_private_key) {
 
   EC_KEY *key = EC_KEY_parse_private_key(&cbs, nullptr);
   ASSERT_TRUE(key);
+
   const EC_GROUP *group = EC_KEY_get0_group(key);
   ASSERT_TRUE(group);
+
   ASSERT_EQ(NID_X9_62_prime256v1, EC_GROUP_get_curve_name(group));
+
   const BIGNUM *order {EC_GROUP_get0_order(group)};
   ASSERT_TRUE(order);
   ASSERT_EQ(256, BN_num_bits(order));
+
+  ASSERT_EQ(256, EC_GROUP_get_degree(group));
+
   EC_KEY_free(key);
 }


### PR DESCRIPTION
Added:

- ECDSA_sign()
- ECDSA_size()
- EC_GROUP_get_degree()
- EC_GROUP_get0_order()
- EC_KEY_free()
- EC_KEY_parse_private_key()
- EC_GROUP_get_curve_name()
- EC_KEY_get0_group()

Signed-off-by: Ted Poole <tpoole@redhat.com>