### PR TITLE
OSSM-3365 Added more <openssl/x509.h> functions

### DIFF
--- a/bssl-compat/.gitignore
+++ b/bssl-compat/.gitignore
@@ -99,6 +99,7 @@ source/crypto/test/file_test_gtest.cc
 source/crypto/test/file_test.h
 source/crypto/test/test_util.cc
 source/crypto/test/test_util.h
+source/crypto/x509/x509_test.cc
 source/ossl.c
 source/ssl/
 source/ssl/internal.h

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -224,6 +224,7 @@ add_library(bssl-compat STATIC
   source/X509_up_ref.cc
   source/X509_verify_cert.cc
   source/X509_verify_cert_error_string.cc
+  source/X509_VERIFY_PARAM_set1.cc
 )
 
 target_add_bssl_source(bssl-compat

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -71,6 +71,7 @@ add_library(bssl-compat STATIC
   source/evp.c
   source/EVP_DecodeBase64.c
   source/EVP_DecodedLength.c
+  source/GENERAL_NAME_set0_value.cc
   source/HMAC.cc
   source/HMAC_CTX_free.cc
   source/HMAC_CTX_new.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -220,6 +220,7 @@ add_library(bssl-compat STATIC
   source/X509_NAME_dup.cc
   source/X509_NAME_free.cc
   source/X509_NAME_new.cc
+  source/X509_STORE_CTX_get0_param.cc
   source/X509_STORE_CTX_init.cc
   source/X509_STORE_CTX_new.cc
   source/X509_STORE_new.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -219,6 +219,7 @@ add_library(bssl-compat STATIC
   source/X509_NAME_dup.cc
   source/X509_NAME_free.cc
   source/X509_NAME_new.cc
+  source/X509_verify_cert.cc
 )
 
 target_add_bssl_source(bssl-compat

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -220,6 +220,7 @@ add_library(bssl-compat STATIC
   source/X509_NAME_dup.cc
   source/X509_NAME_free.cc
   source/X509_NAME_new.cc
+  source/X509_STORE_CTX_new.cc
   source/X509_STORE_new.cc
   source/X509_STORE_set_flags.cc
   source/X509_STORE_set_verify_cb.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -219,6 +219,7 @@ add_library(bssl-compat STATIC
   source/X509_NAME_dup.cc
   source/X509_NAME_free.cc
   source/X509_NAME_new.cc
+  source/X509_STORE_set_flags.cc
   source/X509_STORE_set_verify_cb.cc
   source/X509_up_ref.cc
   source/X509_verify_cert.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -219,6 +219,7 @@ add_library(bssl-compat STATIC
   source/X509_NAME_dup.cc
   source/X509_NAME_free.cc
   source/X509_NAME_new.cc
+  source/X509_up_ref.cc
   source/X509_verify_cert.cc
   source/X509_verify_cert_error_string.cc
 )

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -219,6 +219,7 @@ add_library(bssl-compat STATIC
   source/X509_NAME_dup.cc
   source/X509_NAME_free.cc
   source/X509_NAME_new.cc
+  source/X509_STORE_set_verify_cb.cc
   source/X509_up_ref.cc
   source/X509_verify_cert.cc
   source/X509_verify_cert_error_string.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -220,6 +220,7 @@ add_library(bssl-compat STATIC
   source/X509_NAME_dup.cc
   source/X509_NAME_free.cc
   source/X509_NAME_new.cc
+  source/X509_STORE_new.cc
   source/X509_STORE_set_flags.cc
   source/X509_STORE_set_verify_cb.cc
   source/X509_up_ref.cc

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -215,21 +215,31 @@ add_library(bssl-compat STATIC
   source/TLS_method.cc
   source/TLS_VERSION_to_string.cc
   source/X509_alias_get0.cc
+  source/X509_CRL_free.cc
+  source/X509_CRL_up_ref.cc
   source/X509_get_pubkey.cc
   source/X509_NAME_cmp.cc
   source/X509_NAME_dup.cc
   source/X509_NAME_free.cc
   source/X509_NAME_new.cc
+  source/X509_STORE_CTX_free.cc
   source/X509_STORE_CTX_get0_param.cc
+  source/X509_STORE_CTX_get_error.cc
   source/X509_STORE_CTX_init.cc
   source/X509_STORE_CTX_new.cc
+  source/X509_STORE_CTX_set0_crls.cc
+  source/X509_STORE_CTX_trusted_stack.cc
+  source/X509_STORE_free.cc
   source/X509_STORE_new.cc
   source/X509_STORE_set_flags.cc
   source/X509_STORE_set_verify_cb.cc
   source/X509_up_ref.cc
   source/X509_verify_cert.cc
   source/X509_verify_cert_error_string.cc
+  source/X509_VERIFY_PARAM_clear_flags.cc
   source/X509_VERIFY_PARAM_set1.cc
+  source/X509_VERIFY_PARAM_set_flags.cc
+  source/X509_VERIFY_PARAM_set_time.cc
 )
 
 target_add_bssl_source(bssl-compat
@@ -361,6 +371,7 @@ set(utests-bssl-source-list
   source/crypto/test/file_test.h
   source/crypto/test/test_util.cc
   source/crypto/test/test_util.h
+  source/crypto/x509/x509_test.cc
   source/ssl/ssl_c_test.c
   source/ssl/ssl_test.cc
 )

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -220,6 +220,7 @@ add_library(bssl-compat STATIC
   source/X509_NAME_free.cc
   source/X509_NAME_new.cc
   source/X509_verify_cert.cc
+  source/X509_verify_cert_error_string.cc
 )
 
 target_add_bssl_source(bssl-compat

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -220,6 +220,7 @@ add_library(bssl-compat STATIC
   source/X509_NAME_dup.cc
   source/X509_NAME_free.cc
   source/X509_NAME_new.cc
+  source/X509_STORE_CTX_init.cc
   source/X509_STORE_CTX_new.cc
   source/X509_STORE_new.cc
   source/X509_STORE_set_flags.cc

--- a/bssl-compat/patch/include/openssl/base.h.patch
+++ b/bssl-compat/patch/include/openssl/base.h.patch
@@ -485,7 +485,8 @@
 -// typedef struct X509_VERIFY_PARAM_st X509_VERIFY_PARAM;
 +typedef ossl_X509_VERIFY_PARAM X509_VERIFY_PARAM;
  // typedef struct X509_algor_st X509_ALGOR;
- // typedef struct X509_crl_st X509_CRL;
+-// typedef struct X509_crl_st X509_CRL;
++typedef ossl_X509_CRL X509_CRL;
  // typedef struct X509_extension_st X509_EXTENSION;
  // typedef struct X509_info_st X509_INFO;
 -// typedef struct X509_name_entry_st X509_NAME_ENTRY;

--- a/bssl-compat/patch/include/openssl/x509.h.patch
+++ b/bssl-compat/patch/include/openssl/x509.h.patch
@@ -133,6 +133,15 @@
  
  // X509_NAME_get0_der sets |*out_der| and |*out_der_len|
  //
+@@ -1756,7 +1756,7 @@
+ // X509_verify_cert_error_string returns |err| as a human-readable string, where
+ // |err| should be one of the |X509_V_*| values. If |err| is unknown, it returns
+ // a default description.
+-// OPENSSL_EXPORT const char *X509_verify_cert_error_string(long err);
++OPENSSL_EXPORT const char *X509_verify_cert_error_string(long err);
+ 
+ // X509_verify checks that |x509| has a valid signature by |pkey|. It returns
+ // one if the signature is valid and zero otherwise. Note this function only
 @@ -2054,8 +2054,8 @@
  // OPENSSL_EXPORT unsigned long X509_issuer_name_hash_old(X509 *a);
  // OPENSSL_EXPORT unsigned long X509_subject_name_hash_old(X509 *x);
@@ -162,7 +171,7 @@
  // SSL_CTX -> X509_STORE
  //                 -> X509_LOOKUP
  //                         ->X509_LOOKUP_METHOD
-@@ -2828,18 +2828,18 @@
+@@ -2988,18 +2988,18 @@
  // OPENSSL_EXPORT void X509_VERIFY_PARAM_table_cleanup(void);
  
  
@@ -188,7 +197,7 @@
  // BORINGSSL_MAKE_UP_REF(X509, X509_up_ref)
  // BORINGSSL_MAKE_DELETER(X509_ALGOR, X509_ALGOR_free)
  // BORINGSSL_MAKE_DELETER(X509_ATTRIBUTE, X509_ATTRIBUTE_free)
-@@ -2848,7 +2848,7 @@
+@@ -3008,7 +3008,7 @@
  // BORINGSSL_MAKE_DELETER(X509_EXTENSION, X509_EXTENSION_free)
  // BORINGSSL_MAKE_DELETER(X509_INFO, X509_INFO_free)
  // BORINGSSL_MAKE_DELETER(X509_LOOKUP, X509_LOOKUP_free)
@@ -197,7 +206,7 @@
  // BORINGSSL_MAKE_DELETER(X509_NAME_ENTRY, X509_NAME_ENTRY_free)
  // BORINGSSL_MAKE_DELETER(X509_PKEY, X509_PKEY_free)
  // BORINGSSL_MAKE_DELETER(X509_PUBKEY, X509_PUBKEY_free)
-@@ -2860,10 +2860,10 @@
+@@ -3020,10 +3020,10 @@
  // BORINGSSL_MAKE_DELETER(X509_STORE_CTX, X509_STORE_CTX_free)
  // BORINGSSL_MAKE_DELETER(X509_VERIFY_PARAM, X509_VERIFY_PARAM_free)
  
@@ -211,7 +220,7 @@
  
  #ifdef ossl_X509_R_AKID_MISMATCH
  #define X509_R_AKID_MISMATCH ossl_X509_R_AKID_MISMATCH
-@@ -2998,4 +2998,4 @@
+@@ -3158,4 +3158,4 @@
  #define X509_R_NO_CRL_FOUND ossl_X509_R_NO_CRL_FOUND
  #endif
  

--- a/bssl-compat/patch/include/openssl/x509.h.patch
+++ b/bssl-compat/patch/include/openssl/x509.h.patch
@@ -236,6 +236,17 @@
  // OPENSSL_EXPORT void X509_STORE_CTX_trusted_stack(X509_STORE_CTX *ctx,
  //                                                  STACK_OF(X509) *sk);
  // OPENSSL_EXPORT void X509_STORE_CTX_cleanup(X509_STORE_CTX *ctx);
+@@ -2922,8 +2922,8 @@
+ // OPENSSL_EXPORT void X509_STORE_CTX_set_verify_cb(
+ //     X509_STORE_CTX *ctx, int (*verify_cb)(int, X509_STORE_CTX *));
+ 
+-// OPENSSL_EXPORT X509_VERIFY_PARAM *X509_STORE_CTX_get0_param(
+-//     X509_STORE_CTX *ctx);
++OPENSSL_EXPORT X509_VERIFY_PARAM *X509_STORE_CTX_get0_param(
++    X509_STORE_CTX *ctx);
+ // OPENSSL_EXPORT void X509_STORE_CTX_set0_param(X509_STORE_CTX *ctx,
+ //                                               X509_VERIFY_PARAM *param);
+ // OPENSSL_EXPORT int X509_STORE_CTX_set_default(X509_STORE_CTX *ctx,
 @@ -2935,8 +2935,8 @@
  // OPENSSL_EXPORT void X509_VERIFY_PARAM_free(X509_VERIFY_PARAM *param);
  // OPENSSL_EXPORT int X509_VERIFY_PARAM_inherit(X509_VERIFY_PARAM *to,

--- a/bssl-compat/patch/include/openssl/x509.h.patch
+++ b/bssl-compat/patch/include/openssl/x509.h.patch
@@ -217,7 +217,7 @@
  // #define X509_STORE_set_verify_cb_func(ctx, func) \
  //   X509_STORE_set_verify_cb((ctx), (func))
  // OPENSSL_EXPORT X509_STORE_CTX_verify_cb
-@@ -2831,7 +2831,7 @@
+@@ -2831,15 +2831,15 @@
  // OPENSSL_EXPORT X509_STORE_CTX_cleanup_fn
  // X509_STORE_get_cleanup(X509_STORE *ctx);
  
@@ -226,6 +226,16 @@
  
  // OPENSSL_EXPORT int X509_STORE_CTX_get1_issuer(X509 **issuer,
  //                                               X509_STORE_CTX *ctx, X509 *x);
+ 
+ // OPENSSL_EXPORT void X509_STORE_CTX_zero(X509_STORE_CTX *ctx);
+ // OPENSSL_EXPORT void X509_STORE_CTX_free(X509_STORE_CTX *ctx);
+-// OPENSSL_EXPORT int X509_STORE_CTX_init(X509_STORE_CTX *ctx, X509_STORE *store,
+-//                                        X509 *x509, STACK_OF(X509) *chain);
++OPENSSL_EXPORT int X509_STORE_CTX_init(X509_STORE_CTX *ctx, X509_STORE *store,
++                                       X509 *x509, STACK_OF(X509) *chain);
+ // OPENSSL_EXPORT void X509_STORE_CTX_trusted_stack(X509_STORE_CTX *ctx,
+ //                                                  STACK_OF(X509) *sk);
+ // OPENSSL_EXPORT void X509_STORE_CTX_cleanup(X509_STORE_CTX *ctx);
 @@ -2935,8 +2935,8 @@
  // OPENSSL_EXPORT void X509_VERIFY_PARAM_free(X509_VERIFY_PARAM *param);
  // OPENSSL_EXPORT int X509_VERIFY_PARAM_inherit(X509_VERIFY_PARAM *to,

--- a/bssl-compat/patch/include/openssl/x509.h.patch
+++ b/bssl-compat/patch/include/openssl/x509.h.patch
@@ -208,6 +208,17 @@
  // #define X509_STORE_set_verify_cb_func(ctx, func) \
  //   X509_STORE_set_verify_cb((ctx), (func))
  // OPENSSL_EXPORT X509_STORE_CTX_verify_cb
+@@ -2935,8 +2935,8 @@
+ // OPENSSL_EXPORT void X509_VERIFY_PARAM_free(X509_VERIFY_PARAM *param);
+ // OPENSSL_EXPORT int X509_VERIFY_PARAM_inherit(X509_VERIFY_PARAM *to,
+ //                                              const X509_VERIFY_PARAM *from);
+-// OPENSSL_EXPORT int X509_VERIFY_PARAM_set1(X509_VERIFY_PARAM *to,
+-//                                           const X509_VERIFY_PARAM *from);
++OPENSSL_EXPORT int X509_VERIFY_PARAM_set1(X509_VERIFY_PARAM *to,
++                                          const X509_VERIFY_PARAM *from);
+ // OPENSSL_EXPORT int X509_VERIFY_PARAM_set1_name(X509_VERIFY_PARAM *param,
+ //                                                const char *name);
+ // OPENSSL_EXPORT int X509_VERIFY_PARAM_set_flags(X509_VERIFY_PARAM *param,
 @@ -2988,18 +2988,18 @@
  // OPENSSL_EXPORT void X509_VERIFY_PARAM_table_cleanup(void);
  

--- a/bssl-compat/patch/include/openssl/x509.h.patch
+++ b/bssl-compat/patch/include/openssl/x509.h.patch
@@ -108,6 +108,32 @@
  
  // X509_keyid_get0 looks up |x509|'s key ID. If found, it sets |*out_len| to the
  // key ID's length and returns a pointer to a buffer containing the contents. If
+@@ -462,14 +462,14 @@
+ // Instead, mutation functions should only be used when issuing new CRLs, as
+ // described in a later section.
+ 
+-// DEFINE_STACK_OF(X509_CRL)
++DEFINE_STACK_OF(X509_CRL)
+ 
+ // X509_CRL is an |ASN1_ITEM| whose ASN.1 type is X.509 CertificateList (RFC
+ // 5280) and C type is |X509_CRL*|.
+ // DECLARE_ASN1_ITEM(X509_CRL)
+ 
+ // X509_CRL_up_ref adds one to the reference count of |crl| and returns one.
+-// OPENSSL_EXPORT int X509_CRL_up_ref(X509_CRL *crl);
++OPENSSL_EXPORT int X509_CRL_up_ref(X509_CRL *crl);
+ 
+ // X509_CRL_dup returns a newly-allocated copy of |crl|, or NULL on error. This
+ // function works by serializing the structure, so if |crl| is incomplete, it
+@@ -482,7 +482,7 @@
+ 
+ // X509_CRL_free decrements |crl|'s reference count and, if zero, releases
+ // memory associated with |crl|.
+-// OPENSSL_EXPORT void X509_CRL_free(X509_CRL *crl);
++OPENSSL_EXPORT void X509_CRL_free(X509_CRL *crl);
+ 
+ // d2i_X509_CRL parses up to |len| bytes from |*inp| as a DER-encoded X.509
+ // CertificateList (RFC 5280), as described in |d2i_SAMPLE_with_reuse|.
 @@ -835,8 +835,8 @@
  // moved to the subject alternative name extension. In modern usage, X.509 names
  // are primarily opaque identifiers to link a certificate with its issuer.
@@ -188,16 +214,18 @@
  // typedef int (*X509_STORE_CTX_verify_fn)(X509_STORE_CTX *);
  // typedef int (*X509_STORE_CTX_get_issuer_fn)(X509 **issuer, X509_STORE_CTX *ctx,
  //                                             X509 *x);
-@@ -2763,7 +2763,7 @@
+@@ -2763,16 +2763,16 @@
  // OPENSSL_EXPORT void X509_OBJECT_free_contents(X509_OBJECT *a);
  // OPENSSL_EXPORT int X509_OBJECT_get_type(const X509_OBJECT *a);
  // OPENSSL_EXPORT X509 *X509_OBJECT_get0_X509(const X509_OBJECT *a);
 -// OPENSSL_EXPORT X509_STORE *X509_STORE_new(void);
 +OPENSSL_EXPORT X509_STORE *X509_STORE_new(void);
  // OPENSSL_EXPORT int X509_STORE_up_ref(X509_STORE *store);
- // OPENSSL_EXPORT void X509_STORE_free(X509_STORE *v);
+-// OPENSSL_EXPORT void X509_STORE_free(X509_STORE *v);
++OPENSSL_EXPORT void X509_STORE_free(X509_STORE *v);
  
-@@ -2772,7 +2772,7 @@
+ // OPENSSL_EXPORT STACK_OF(X509_OBJECT) *X509_STORE_get0_objects(X509_STORE *st);
+ // OPENSSL_EXPORT STACK_OF(X509) *X509_STORE_get1_certs(X509_STORE_CTX *st,
  //                                                      X509_NAME *nm);
  // OPENSSL_EXPORT STACK_OF(X509_CRL) *X509_STORE_get1_crls(X509_STORE_CTX *st,
  //                                                         X509_NAME *nm);
@@ -217,7 +245,7 @@
  // #define X509_STORE_set_verify_cb_func(ctx, func) \
  //   X509_STORE_set_verify_cb((ctx), (func))
  // OPENSSL_EXPORT X509_STORE_CTX_verify_cb
-@@ -2831,15 +2831,15 @@
+@@ -2831,17 +2831,17 @@
  // OPENSSL_EXPORT X509_STORE_CTX_cleanup_fn
  // X509_STORE_get_cleanup(X509_STORE *ctx);
  
@@ -228,14 +256,39 @@
  //                                               X509_STORE_CTX *ctx, X509 *x);
  
  // OPENSSL_EXPORT void X509_STORE_CTX_zero(X509_STORE_CTX *ctx);
- // OPENSSL_EXPORT void X509_STORE_CTX_free(X509_STORE_CTX *ctx);
+-// OPENSSL_EXPORT void X509_STORE_CTX_free(X509_STORE_CTX *ctx);
 -// OPENSSL_EXPORT int X509_STORE_CTX_init(X509_STORE_CTX *ctx, X509_STORE *store,
 -//                                        X509 *x509, STACK_OF(X509) *chain);
+-// OPENSSL_EXPORT void X509_STORE_CTX_trusted_stack(X509_STORE_CTX *ctx,
+-//                                                  STACK_OF(X509) *sk);
++OPENSSL_EXPORT void X509_STORE_CTX_free(X509_STORE_CTX *ctx);
 +OPENSSL_EXPORT int X509_STORE_CTX_init(X509_STORE_CTX *ctx, X509_STORE *store,
 +                                       X509 *x509, STACK_OF(X509) *chain);
- // OPENSSL_EXPORT void X509_STORE_CTX_trusted_stack(X509_STORE_CTX *ctx,
- //                                                  STACK_OF(X509) *sk);
++OPENSSL_EXPORT void X509_STORE_CTX_trusted_stack(X509_STORE_CTX *ctx,
++                                                 STACK_OF(X509) *sk);
  // OPENSSL_EXPORT void X509_STORE_CTX_cleanup(X509_STORE_CTX *ctx);
+ 
+ // OPENSSL_EXPORT X509_STORE *X509_STORE_CTX_get0_store(X509_STORE_CTX *ctx);
+@@ -2892,7 +2892,7 @@
+ //                                              const char *dir);
+ // OPENSSL_EXPORT int X509_STORE_set_default_paths(X509_STORE *ctx);
+ // #endif
+-// OPENSSL_EXPORT int X509_STORE_CTX_get_error(X509_STORE_CTX *ctx);
++OPENSSL_EXPORT int X509_STORE_CTX_get_error(X509_STORE_CTX *ctx);
+ // OPENSSL_EXPORT void X509_STORE_CTX_set_error(X509_STORE_CTX *ctx, int s);
+ // OPENSSL_EXPORT int X509_STORE_CTX_get_error_depth(X509_STORE_CTX *ctx);
+ // OPENSSL_EXPORT X509 *X509_STORE_CTX_get_current_cert(X509_STORE_CTX *ctx);
+@@ -2908,8 +2908,8 @@
+ //                                              STACK_OF(X509) *sk);
+ // OPENSSL_EXPORT STACK_OF(X509) *X509_STORE_CTX_get0_untrusted(
+ //     X509_STORE_CTX *ctx);
+-// OPENSSL_EXPORT void X509_STORE_CTX_set0_crls(X509_STORE_CTX *c,
+-//                                              STACK_OF(X509_CRL) *sk);
++OPENSSL_EXPORT void X509_STORE_CTX_set0_crls(X509_STORE_CTX *c,
++                                             STACK_OF(X509_CRL) *sk);
+ // OPENSSL_EXPORT int X509_STORE_CTX_set_purpose(X509_STORE_CTX *ctx, int purpose);
+ // OPENSSL_EXPORT int X509_STORE_CTX_set_trust(X509_STORE_CTX *ctx, int trust);
+ // OPENSSL_EXPORT int X509_STORE_CTX_purpose_inherit(X509_STORE_CTX *ctx,
 @@ -2922,8 +2922,8 @@
  // OPENSSL_EXPORT void X509_STORE_CTX_set_verify_cb(
  //     X509_STORE_CTX *ctx, int (*verify_cb)(int, X509_STORE_CTX *));
@@ -247,7 +300,7 @@
  // OPENSSL_EXPORT void X509_STORE_CTX_set0_param(X509_STORE_CTX *ctx,
  //                                               X509_VERIFY_PARAM *param);
  // OPENSSL_EXPORT int X509_STORE_CTX_set_default(X509_STORE_CTX *ctx,
-@@ -2935,8 +2935,8 @@
+@@ -2935,14 +2935,14 @@
  // OPENSSL_EXPORT void X509_VERIFY_PARAM_free(X509_VERIFY_PARAM *param);
  // OPENSSL_EXPORT int X509_VERIFY_PARAM_inherit(X509_VERIFY_PARAM *to,
  //                                              const X509_VERIFY_PARAM *from);
@@ -257,8 +310,29 @@
 +                                          const X509_VERIFY_PARAM *from);
  // OPENSSL_EXPORT int X509_VERIFY_PARAM_set1_name(X509_VERIFY_PARAM *param,
  //                                                const char *name);
- // OPENSSL_EXPORT int X509_VERIFY_PARAM_set_flags(X509_VERIFY_PARAM *param,
-@@ -2988,18 +2988,18 @@
+-// OPENSSL_EXPORT int X509_VERIFY_PARAM_set_flags(X509_VERIFY_PARAM *param,
+-//                                                unsigned long flags);
+-// OPENSSL_EXPORT int X509_VERIFY_PARAM_clear_flags(X509_VERIFY_PARAM *param,
+-//                                                  unsigned long flags);
++OPENSSL_EXPORT int X509_VERIFY_PARAM_set_flags(X509_VERIFY_PARAM *param,
++                                               unsigned long flags);
++OPENSSL_EXPORT int X509_VERIFY_PARAM_clear_flags(X509_VERIFY_PARAM *param,
++                                                 unsigned long flags);
+ // OPENSSL_EXPORT unsigned long X509_VERIFY_PARAM_get_flags(
+ //     X509_VERIFY_PARAM *param);
+ // OPENSSL_EXPORT int X509_VERIFY_PARAM_set_purpose(X509_VERIFY_PARAM *param,
+@@ -2951,8 +2951,8 @@
+ //                                                int trust);
+ // OPENSSL_EXPORT void X509_VERIFY_PARAM_set_depth(X509_VERIFY_PARAM *param,
+ //                                                 int depth);
+-// OPENSSL_EXPORT void X509_VERIFY_PARAM_set_time(X509_VERIFY_PARAM *param,
+-//                                                time_t t);
++OPENSSL_EXPORT void X509_VERIFY_PARAM_set_time(X509_VERIFY_PARAM *param,
++                                               time_t t);
+ // OPENSSL_EXPORT int X509_VERIFY_PARAM_add0_policy(X509_VERIFY_PARAM *param,
+ //                                                  ASN1_OBJECT *policy);
+ // OPENSSL_EXPORT int X509_VERIFY_PARAM_set1_policies(
+@@ -2988,42 +2988,42 @@
  // OPENSSL_EXPORT void X509_VERIFY_PARAM_table_cleanup(void);
  
  
@@ -280,11 +354,15 @@
  // BORINGSSL_MAKE_DELETER(NETSCAPE_SPKI, NETSCAPE_SPKI_free)
  // BORINGSSL_MAKE_DELETER(RSA_PSS_PARAMS, RSA_PSS_PARAMS_free)
 -// BORINGSSL_MAKE_DELETER(X509, X509_free)
+-// BORINGSSL_MAKE_UP_REF(X509, X509_up_ref)
 +BORINGSSL_MAKE_DELETER(X509, X509_free)
- // BORINGSSL_MAKE_UP_REF(X509, X509_up_ref)
++BORINGSSL_MAKE_UP_REF(X509, X509_up_ref)
  // BORINGSSL_MAKE_DELETER(X509_ALGOR, X509_ALGOR_free)
  // BORINGSSL_MAKE_DELETER(X509_ATTRIBUTE, X509_ATTRIBUTE_free)
-@@ -3008,7 +3008,7 @@
+-// BORINGSSL_MAKE_DELETER(X509_CRL, X509_CRL_free)
+-// BORINGSSL_MAKE_UP_REF(X509_CRL, X509_CRL_up_ref)
++BORINGSSL_MAKE_DELETER(X509_CRL, X509_CRL_free)
++BORINGSSL_MAKE_UP_REF(X509_CRL, X509_CRL_up_ref)
  // BORINGSSL_MAKE_DELETER(X509_EXTENSION, X509_EXTENSION_free)
  // BORINGSSL_MAKE_DELETER(X509_INFO, X509_INFO_free)
  // BORINGSSL_MAKE_DELETER(X509_LOOKUP, X509_LOOKUP_free)
@@ -293,8 +371,14 @@
  // BORINGSSL_MAKE_DELETER(X509_NAME_ENTRY, X509_NAME_ENTRY_free)
  // BORINGSSL_MAKE_DELETER(X509_PKEY, X509_PKEY_free)
  // BORINGSSL_MAKE_DELETER(X509_PUBKEY, X509_PUBKEY_free)
-@@ -3020,10 +3020,10 @@
- // BORINGSSL_MAKE_DELETER(X509_STORE_CTX, X509_STORE_CTX_free)
+ // BORINGSSL_MAKE_DELETER(X509_REQ, X509_REQ_free)
+ // BORINGSSL_MAKE_DELETER(X509_REVOKED, X509_REVOKED_free)
+ // BORINGSSL_MAKE_DELETER(X509_SIG, X509_SIG_free)
+-// BORINGSSL_MAKE_DELETER(X509_STORE, X509_STORE_free)
++BORINGSSL_MAKE_DELETER(X509_STORE, X509_STORE_free)
+ // BORINGSSL_MAKE_UP_REF(X509_STORE, X509_STORE_up_ref)
+-// BORINGSSL_MAKE_DELETER(X509_STORE_CTX, X509_STORE_CTX_free)
++BORINGSSL_MAKE_DELETER(X509_STORE_CTX, X509_STORE_CTX_free)
  // BORINGSSL_MAKE_DELETER(X509_VERIFY_PARAM, X509_VERIFY_PARAM_free)
  
 -// BSSL_NAMESPACE_END

--- a/bssl-compat/patch/include/openssl/x509.h.patch
+++ b/bssl-compat/patch/include/openssl/x509.h.patch
@@ -144,6 +144,15 @@
  // OPENSSL_EXPORT unsigned long X509_NAME_hash(X509_NAME *x);
  // OPENSSL_EXPORT unsigned long X509_NAME_hash_old(X509_NAME *x);
  
+@@ -2321,7 +2321,7 @@
+ // OPENSSL_EXPORT ASN1_TYPE *X509_ATTRIBUTE_get0_type(X509_ATTRIBUTE *attr,
+ //                                                    int idx);
+ 
+-// OPENSSL_EXPORT int X509_verify_cert(X509_STORE_CTX *ctx);
++OPENSSL_EXPORT int X509_verify_cert(X509_STORE_CTX *ctx);
+ 
+ // lookup a cert from a X509 STACK
+ // OPENSSL_EXPORT X509 *X509_find_by_issuer_and_serial(STACK_OF(X509) *sk,
 @@ -2404,7 +2404,7 @@
  
  // DECLARE_ASN1_FUNCTIONS_const(RSA_PSS_PARAMS)

--- a/bssl-compat/patch/include/openssl/x509.h.patch
+++ b/bssl-compat/patch/include/openssl/x509.h.patch
@@ -179,6 +179,26 @@
  // SSL_CTX -> X509_STORE
  //                 -> X509_LOOKUP
  //                         ->X509_LOOKUP_METHOD
+@@ -2429,7 +2429,7 @@
+ // DEFINE_STACK_OF(X509_OBJECT)
+ // DEFINE_STACK_OF(X509_VERIFY_PARAM)
+ 
+-// typedef int (*X509_STORE_CTX_verify_cb)(int, X509_STORE_CTX *);
++typedef int (*X509_STORE_CTX_verify_cb)(int, X509_STORE_CTX *);
+ // typedef int (*X509_STORE_CTX_verify_fn)(X509_STORE_CTX *);
+ // typedef int (*X509_STORE_CTX_get_issuer_fn)(X509 **issuer, X509_STORE_CTX *ctx,
+ //                                             X509 *x);
+@@ -2786,8 +2786,8 @@
+ // OPENSSL_EXPORT void X509_STORE_CTX_set_verify(X509_STORE_CTX *ctx,
+ //                                               X509_STORE_CTX_verify_fn verify);
+ // OPENSSL_EXPORT X509_STORE_CTX_verify_fn X509_STORE_get_verify(X509_STORE *ctx);
+-// OPENSSL_EXPORT void X509_STORE_set_verify_cb(
+-//     X509_STORE *ctx, X509_STORE_CTX_verify_cb verify_cb);
++OPENSSL_EXPORT void X509_STORE_set_verify_cb(
++    X509_STORE *ctx, X509_STORE_CTX_verify_cb verify_cb);
+ // #define X509_STORE_set_verify_cb_func(ctx, func) \
+ //   X509_STORE_set_verify_cb((ctx), (func))
+ // OPENSSL_EXPORT X509_STORE_CTX_verify_cb
 @@ -2988,18 +2988,18 @@
  // OPENSSL_EXPORT void X509_VERIFY_PARAM_table_cleanup(void);
  

--- a/bssl-compat/patch/include/openssl/x509.h.patch
+++ b/bssl-compat/patch/include/openssl/x509.h.patch
@@ -188,6 +188,15 @@
  // typedef int (*X509_STORE_CTX_verify_fn)(X509_STORE_CTX *);
  // typedef int (*X509_STORE_CTX_get_issuer_fn)(X509 **issuer, X509_STORE_CTX *ctx,
  //                                             X509 *x);
+@@ -2772,7 +2772,7 @@
+ //                                                      X509_NAME *nm);
+ // OPENSSL_EXPORT STACK_OF(X509_CRL) *X509_STORE_get1_crls(X509_STORE_CTX *st,
+ //                                                         X509_NAME *nm);
+-// OPENSSL_EXPORT int X509_STORE_set_flags(X509_STORE *ctx, unsigned long flags);
++OPENSSL_EXPORT int X509_STORE_set_flags(X509_STORE *ctx, unsigned long flags);
+ // OPENSSL_EXPORT int X509_STORE_set_purpose(X509_STORE *ctx, int purpose);
+ // OPENSSL_EXPORT int X509_STORE_set_trust(X509_STORE *ctx, int trust);
+ // OPENSSL_EXPORT int X509_STORE_set1_param(X509_STORE *ctx,
 @@ -2786,8 +2786,8 @@
  // OPENSSL_EXPORT void X509_STORE_CTX_set_verify(X509_STORE_CTX *ctx,
  //                                               X509_STORE_CTX_verify_fn verify);

--- a/bssl-compat/patch/include/openssl/x509.h.patch
+++ b/bssl-compat/patch/include/openssl/x509.h.patch
@@ -217,6 +217,15 @@
  // #define X509_STORE_set_verify_cb_func(ctx, func) \
  //   X509_STORE_set_verify_cb((ctx), (func))
  // OPENSSL_EXPORT X509_STORE_CTX_verify_cb
+@@ -2831,7 +2831,7 @@
+ // OPENSSL_EXPORT X509_STORE_CTX_cleanup_fn
+ // X509_STORE_get_cleanup(X509_STORE *ctx);
+ 
+-// OPENSSL_EXPORT X509_STORE_CTX *X509_STORE_CTX_new(void);
++OPENSSL_EXPORT X509_STORE_CTX *X509_STORE_CTX_new(void);
+ 
+ // OPENSSL_EXPORT int X509_STORE_CTX_get1_issuer(X509 **issuer,
+ //                                               X509_STORE_CTX *ctx, X509 *x);
 @@ -2935,8 +2935,8 @@
  // OPENSSL_EXPORT void X509_VERIFY_PARAM_free(X509_VERIFY_PARAM *param);
  // OPENSSL_EXPORT int X509_VERIFY_PARAM_inherit(X509_VERIFY_PARAM *to,

--- a/bssl-compat/patch/include/openssl/x509.h.patch
+++ b/bssl-compat/patch/include/openssl/x509.h.patch
@@ -55,7 +55,7 @@
  
  
  // Legacy X.509 library.
-@@ -116,7 +116,7 @@
+@@ -116,14 +116,14 @@
  // Instead, mutation functions should only be used when issuing new
  // certificates, as described in a later section.
  
@@ -64,6 +64,14 @@
  
  // X509 is an |ASN1_ITEM| whose ASN.1 type is X.509 Certificate (RFC 5280) and C
  // type is |X509*|.
+ // DECLARE_ASN1_ITEM(X509)
+ 
+ // X509_up_ref adds one to the reference count of |x509| and returns one.
+-// OPENSSL_EXPORT int X509_up_ref(X509 *x509);
++OPENSSL_EXPORT int X509_up_ref(X509 *x509);
+ 
+ // X509_chain_up_ref returns a newly-allocated |STACK_OF(X509)| containing a
+ // shallow copy of |chain|, or NULL on error. That is, the return value has the
 @@ -143,7 +143,7 @@
  
  // X509_free decrements |x509|'s reference count and, if zero, releases memory

--- a/bssl-compat/patch/include/openssl/x509.h.patch
+++ b/bssl-compat/patch/include/openssl/x509.h.patch
@@ -188,6 +188,15 @@
  // typedef int (*X509_STORE_CTX_verify_fn)(X509_STORE_CTX *);
  // typedef int (*X509_STORE_CTX_get_issuer_fn)(X509 **issuer, X509_STORE_CTX *ctx,
  //                                             X509 *x);
+@@ -2763,7 +2763,7 @@
+ // OPENSSL_EXPORT void X509_OBJECT_free_contents(X509_OBJECT *a);
+ // OPENSSL_EXPORT int X509_OBJECT_get_type(const X509_OBJECT *a);
+ // OPENSSL_EXPORT X509 *X509_OBJECT_get0_X509(const X509_OBJECT *a);
+-// OPENSSL_EXPORT X509_STORE *X509_STORE_new(void);
++OPENSSL_EXPORT X509_STORE *X509_STORE_new(void);
+ // OPENSSL_EXPORT int X509_STORE_up_ref(X509_STORE *store);
+ // OPENSSL_EXPORT void X509_STORE_free(X509_STORE *v);
+ 
 @@ -2772,7 +2772,7 @@
  //                                                      X509_NAME *nm);
  // OPENSSL_EXPORT STACK_OF(X509_CRL) *X509_STORE_get1_crls(X509_STORE_CTX *st,

--- a/bssl-compat/patch/include/openssl/x509.h.sh
+++ b/bssl-compat/patch/include/openssl/x509.h.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
-sed -i -e 's|^// \(#[ \t]*define[ \t]*\)\(X509_R_[a-zA-Z0-9_]*\)[^a-zA-Z0-9_].*$|#ifdef ossl_\2\n\1\2 ossl_\2\n#endif|g' "$1"
+sed -i -e 's|^// \(#[ \t]*define[ \t]*\)\(X509_R_[a-zA-Z0-9_]*\)[^a-zA-Z0-9_].*$|#ifdef ossl_\2\n\1\2 ossl_\2\n#endif|g' \
+       -e 's|^// \(#[ \t]*define[ \t]*\)\(X509_V_[a-zA-Z0-9_]*\)[^a-zA-Z0-9_].*$|#ifdef ossl_\2\n\1\2 ossl_\2\n#endif|g' "$1"
 

--- a/bssl-compat/patch/include/openssl/x509v3.h.patch
+++ b/bssl-compat/patch/include/openssl/x509v3.h.patch
@@ -1,0 +1,118 @@
+--- a/include/openssl/x509v3.h
++++ b/include/openssl/x509v3.h
+@@ -52,17 +52,17 @@
+  * (eay@cryptsoft.com).  This product includes software written by Tim
+  * Hudson (tjh@cryptsoft.com). */
+ 
+-// #ifndef HEADER_X509V3_H
+-// #define HEADER_X509V3_H
++#ifndef HEADER_X509V3_H
++#define HEADER_X509V3_H
+ 
+-// #include <openssl/bio.h>
+-// #include <openssl/conf.h>
+-// #include <openssl/lhash.h>
+-// #include <openssl/x509.h>
+-
+-// #if defined(__cplusplus)
+-// extern "C" {
+-// #endif
++#include <openssl/bio.h>
++#include <openssl/conf.h>
++#include <openssl/lhash.h>
++#include <openssl/x509.h>
++
++#if defined(__cplusplus)
++extern "C" {
++#endif
+ 
+ 
+ // Legacy X.509 library.
+@@ -169,38 +169,7 @@
+ //   ASN1_STRING *partyName;
+ // } EDIPARTYNAME;
+ 
+-// typedef struct GENERAL_NAME_st {
+-// #define GEN_OTHERNAME 0
+-// #define GEN_EMAIL 1
+-// #define GEN_DNS 2
+-// #define GEN_X400 3
+-// #define GEN_DIRNAME 4
+-// #define GEN_EDIPARTY 5
+-// #define GEN_URI 6
+-// #define GEN_IPADD 7
+-// #define GEN_RID 8
+-
+-//   int type;
+-//   union {
+-//     char *ptr;
+-//     OTHERNAME *otherName;  // otherName
+-//     ASN1_IA5STRING *rfc822Name;
+-//     ASN1_IA5STRING *dNSName;
+-//     ASN1_TYPE *x400Address;
+-//     X509_NAME *directoryName;
+-//     EDIPARTYNAME *ediPartyName;
+-//     ASN1_IA5STRING *uniformResourceIdentifier;
+-//     ASN1_OCTET_STRING *iPAddress;
+-//     ASN1_OBJECT *registeredID;
+-
+-//     // Old names
+-//     ASN1_OCTET_STRING *ip;  // iPAddress
+-//     X509_NAME *dirn;        // dirn
+-//     ASN1_IA5STRING *ia5;    // rfc822Name, dNSName, uniformResourceIdentifier
+-//     ASN1_OBJECT *rid;       // registeredID
+-//     ASN1_TYPE *other;       // x400Address
+-//   } d;
+-// } GENERAL_NAME;
++typedef struct ossl_GENERAL_NAME_st GENERAL_NAME;
+ 
+ // DEFINE_STACK_OF(GENERAL_NAME)
+ 
+@@ -497,8 +466,8 @@
+ // DECLARE_ASN1_FUNCTIONS_const(OTHERNAME)
+ // DECLARE_ASN1_FUNCTIONS_const(EDIPARTYNAME)
+ // OPENSSL_EXPORT int OTHERNAME_cmp(OTHERNAME *a, OTHERNAME *b);
+-// OPENSSL_EXPORT void GENERAL_NAME_set0_value(GENERAL_NAME *a, int type,
+-//                                             void *value);
++OPENSSL_EXPORT void GENERAL_NAME_set0_value(GENERAL_NAME *a, int type,
++                                            void *value);
+ // OPENSSL_EXPORT void *GENERAL_NAME_get0_value(const GENERAL_NAME *a, int *ptype);
+ // OPENSSL_EXPORT int GENERAL_NAME_set0_othername(GENERAL_NAME *gen,
+ //                                                ASN1_OBJECT *oid,
+@@ -912,12 +881,12 @@
+ // made after this point may be overwritten when the script is next run.
+ 
+ 
+-// #if defined(__cplusplus)
+-// }  // extern C
++#if defined(__cplusplus)
++}  // extern C
+ 
+-// extern "C++" {
++extern "C++" {
+ 
+-// BSSL_NAMESPACE_BEGIN
++BSSL_NAMESPACE_BEGIN
+ 
+ // BORINGSSL_MAKE_DELETER(ACCESS_DESCRIPTION, ACCESS_DESCRIPTION_free)
+ // BORINGSSL_MAKE_DELETER(AUTHORITY_KEYID, AUTHORITY_KEYID_free)
+@@ -931,10 +900,10 @@
+ // BORINGSSL_MAKE_DELETER(POLICY_MAPPING, POLICY_MAPPING_free)
+ // BORINGSSL_MAKE_DELETER(POLICYINFO, POLICYINFO_free)
+ 
+-// BSSL_NAMESPACE_END
++BSSL_NAMESPACE_END
+ 
+-// }  // extern C++
+-// #endif
++}  // extern C++
++#endif
+ 
+ #ifdef ossl_X509V3_R_BAD_IP_ADDRESS
+ #define X509V3_R_BAD_IP_ADDRESS ossl_X509V3_R_BAD_IP_ADDRESS
+@@ -1132,4 +1101,4 @@
+ #define X509V3_R_TRAILING_DATA_IN_EXTENSION ossl_X509V3_R_TRAILING_DATA_IN_EXTENSION
+ #endif
+ 
+-// #endif
++#endif

--- a/bssl-compat/patch/source/crypto/x509/x509_test.cc.patch
+++ b/bssl-compat/patch/source/crypto/x509/x509_test.cc.patch
@@ -1,0 +1,733 @@
+--- a/source/crypto/x509/x509_test.cc
++++ b/source/crypto/x509/x509_test.cc
+@@ -12,177 +12,177 @@
+  * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+  * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
+ 
+-// #include <algorithm>
+-// #include <functional>
+-// #include <string>
+-// #include <vector>
+-
+-// #include <gtest/gtest.h>
+-
+-// #include <openssl/asn1.h>
+-// #include <openssl/bio.h>
+-// #include <openssl/bytestring.h>
+-// #include <openssl/crypto.h>
+-// #include <openssl/curve25519.h>
+-// #include <openssl/digest.h>
+-// #include <openssl/err.h>
+-// #include <openssl/nid.h>
+-// #include <openssl/pem.h>
+-// #include <openssl/pool.h>
+-// #include <openssl/x509.h>
+-// #include <openssl/x509v3.h>
++#include <algorithm>
++#include <functional>
++#include <string>
++#include <vector>
++
++#include <gtest/gtest.h>
++
++#include <openssl/asn1.h>
++#include <openssl/bio.h>
++#include <openssl/bytestring.h>
++#include <openssl/crypto.h>
++#include <openssl/curve25519.h>
++#include <openssl/digest.h>
++#include <openssl/err.h>
++#include <openssl/nid.h>
++#include <openssl/pem.h>
++#include <openssl/pool.h>
++#include <openssl/x509.h>
++#include <openssl/x509v3.h>
+ 
+ // #include "internal.h"
+-// #include "../internal.h"
+-// #include "../test/test_util.h"
++#include "../internal.h"
++#include "../test/test_util.h"
+ // #include "../x509v3/internal.h"
+ 
+ 
+-// std::string GetTestData(const char *path);
++std::string GetTestData(const char *path);
+ 
+-// static const char kCrossSigningRootPEM[] = R"(
+-// -----BEGIN CERTIFICATE-----
+-// MIICcTCCAdqgAwIBAgIIagJHiPvE0MowDQYJKoZIhvcNAQELBQAwPDEaMBgGA1UE
+-// ChMRQm9yaW5nU1NMIFRFU1RJTkcxHjAcBgNVBAMTFUNyb3NzLXNpZ25pbmcgUm9v
+-// dCBDQTAgFw0xNTAxMDEwMDAwMDBaGA8yMTAwMDEwMTAwMDAwMFowPDEaMBgGA1UE
+-// ChMRQm9yaW5nU1NMIFRFU1RJTkcxHjAcBgNVBAMTFUNyb3NzLXNpZ25pbmcgUm9v
+-// dCBDQTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAwo3qFvSB9Zmlbpzn9wJp
+-// ikI75Rxkatez8VkLqyxbOhPYl2Haz8F5p1gDG96dCI6jcLGgu3AKT9uhEQyyUko5
+-// EKYasazSeA9CQrdyhPg0mkTYVETnPM1W/ebid1YtqQbq1CMWlq2aTDoSGAReGFKP
+-// RTdXAbuAXzpCfi/d8LqV13UCAwEAAaN6MHgwDgYDVR0PAQH/BAQDAgIEMB0GA1Ud
+-// JQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAPBgNVHRMBAf8EBTADAQH/MBkGA1Ud
+-// DgQSBBBHKHC7V3Z/3oLvEZx0RZRwMBsGA1UdIwQUMBKAEEcocLtXdn/egu8RnHRF
+-// lHAwDQYJKoZIhvcNAQELBQADgYEAnglibsy6mGtpIXivtlcz4zIEnHw/lNW+r/eC
+-// CY7evZTmOoOuC/x9SS3MF9vawt1HFUummWM6ZgErqVBOXIB4//ykrcCgf5ZbF5Hr
+-// +3EFprKhBqYiXdD8hpBkrBoXwn85LPYWNd2TceCrx0YtLIprE2R5MB2RIq8y4Jk3
+-// YFXvkME=
+-// -----END CERTIFICATE-----
+-// )";
+-
+-// static const char kRootCAPEM[] = R"(
+-// -----BEGIN CERTIFICATE-----
+-// MIICVTCCAb6gAwIBAgIIAj5CwoHlWuYwDQYJKoZIhvcNAQELBQAwLjEaMBgGA1UE
+-// ChMRQm9yaW5nU1NMIFRFU1RJTkcxEDAOBgNVBAMTB1Jvb3QgQ0EwIBcNMTUwMTAx
+-// MDAwMDAwWhgPMjEwMDAxMDEwMDAwMDBaMC4xGjAYBgNVBAoTEUJvcmluZ1NTTCBU
+-// RVNUSU5HMRAwDgYDVQQDEwdSb290IENBMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB
+-// iQKBgQDpDn8RDOZa5oaDcPZRBy4CeBH1siSSOO4mYgLHlPE+oXdqwI/VImi2XeJM
+-// 2uCFETXCknJJjYG0iJdrt/yyRFvZTQZw+QzGj+mz36NqhGxDWb6dstB2m8PX+plZ
+-// w7jl81MDvUnWs8yiQ/6twgu5AbhWKZQDJKcNKCEpqa6UW0r5nwIDAQABo3oweDAO
+-// BgNVHQ8BAf8EBAMCAgQwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA8G
+-// A1UdEwEB/wQFMAMBAf8wGQYDVR0OBBIEEEA31wH7QC+4HH5UBCeMWQEwGwYDVR0j
+-// BBQwEoAQQDfXAftAL7gcflQEJ4xZATANBgkqhkiG9w0BAQsFAAOBgQDXylEK77Za
+-// kKeY6ZerrScWyZhrjIGtHFu09qVpdJEzrk87k2G7iHHR9CAvSofCgEExKtWNS9dN
+-// +9WiZp/U48iHLk7qaYXdEuO07No4BYtXn+lkOykE+FUxmA4wvOF1cTd2tdj3MzX2
+-// kfGIBAYhzGZWhY3JbhIfTEfY1PNM1pWChQ==
+-// -----END CERTIFICATE-----
+-// )";
+-
+-// static const char kRootCrossSignedPEM[] = R"(
+-// -----BEGIN CERTIFICATE-----
+-// MIICYzCCAcygAwIBAgIIAj5CwoHlWuYwDQYJKoZIhvcNAQELBQAwPDEaMBgGA1UE
+-// ChMRQm9yaW5nU1NMIFRFU1RJTkcxHjAcBgNVBAMTFUNyb3NzLXNpZ25pbmcgUm9v
+-// dCBDQTAgFw0xNTAxMDEwMDAwMDBaGA8yMTAwMDEwMTAwMDAwMFowLjEaMBgGA1UE
+-// ChMRQm9yaW5nU1NMIFRFU1RJTkcxEDAOBgNVBAMTB1Jvb3QgQ0EwgZ8wDQYJKoZI
+-// hvcNAQEBBQADgY0AMIGJAoGBAOkOfxEM5lrmhoNw9lEHLgJ4EfWyJJI47iZiAseU
+-// 8T6hd2rAj9UiaLZd4kza4IURNcKSckmNgbSIl2u3/LJEW9lNBnD5DMaP6bPfo2qE
+-// bENZvp2y0Habw9f6mVnDuOXzUwO9SdazzKJD/q3CC7kBuFYplAMkpw0oISmprpRb
+-// SvmfAgMBAAGjejB4MA4GA1UdDwEB/wQEAwICBDAdBgNVHSUEFjAUBggrBgEFBQcD
+-// AQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAZBgNVHQ4EEgQQQDfXAftAL7gc
+-// flQEJ4xZATAbBgNVHSMEFDASgBBHKHC7V3Z/3oLvEZx0RZRwMA0GCSqGSIb3DQEB
+-// CwUAA4GBAErTxYJ0en9HVRHAAr5OO5wuk5Iq3VMc79TMyQLCXVL8YH8Uk7KEwv+q
+-// 9MEKZv2eR/Vfm4HlXlUuIqfgUXbwrAYC/YVVX86Wnbpy/jc73NYVCq8FEZeO+0XU
+-// 90SWAPDdp+iL7aZdimnMtG1qlM1edmz8AKbrhN/R3IbA2CL0nCWV
+-// -----END CERTIFICATE-----
+-// )";
+-
+-// static const char kIntermediatePEM[] = R"(
+-// -----BEGIN CERTIFICATE-----
+-// MIICXjCCAcegAwIBAgIJAKJMH+7rscPcMA0GCSqGSIb3DQEBCwUAMC4xGjAYBgNV
+-// BAoTEUJvcmluZ1NTTCBURVNUSU5HMRAwDgYDVQQDEwdSb290IENBMCAXDTE1MDEw
+-// MTAwMDAwMFoYDzIxMDAwMTAxMDAwMDAwWjA2MRowGAYDVQQKExFCb3JpbmdTU0wg
+-// VEVTVElORzEYMBYGA1UEAxMPSW50ZXJtZWRpYXRlIENBMIGfMA0GCSqGSIb3DQEB
+-// AQUAA4GNADCBiQKBgQC7YtI0l8ocTYJ0gKyXTtPL4iMJCNY4OcxXl48jkncVG1Hl
+-// blicgNUa1r9m9YFtVkxvBinb8dXiUpEGhVg4awRPDcatlsBSEBuJkiZGYbRcAmSu
+-// CmZYnf6u3aYQ18SU8WqVERPpE4cwVVs+6kwlzRw0+XDoZAczu8ZezVhCUc6NbQID
+-// AQABo3oweDAOBgNVHQ8BAf8EBAMCAgQwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsG
+-// AQUFBwMCMA8GA1UdEwEB/wQFMAMBAf8wGQYDVR0OBBIEEIwaaKi1dttdV3sfjRSy
+-// BqMwGwYDVR0jBBQwEoAQQDfXAftAL7gcflQEJ4xZATANBgkqhkiG9w0BAQsFAAOB
+-// gQCvnolNWEHuQS8PFVVyuLR+FKBeUUdrVbSfHSzTqNAqQGp0C9fk5oCzDq6ZgTfY
+-// ESXM4cJhb3IAnW0UM0NFsYSKQJ50JZL2L3z5ZLQhHdbs4RmODGoC40BVdnJ4/qgB
+-// aGSh09eQRvAVmbVCviDK2ipkWNegdyI19jFfNP5uIkGlYg==
+-// -----END CERTIFICATE-----
+-// )";
+-
+-// static const char kIntermediateSelfSignedPEM[] = R"(
+-// -----BEGIN CERTIFICATE-----
+-// MIICZjCCAc+gAwIBAgIJAKJMH+7rscPcMA0GCSqGSIb3DQEBCwUAMDYxGjAYBgNV
+-// BAoTEUJvcmluZ1NTTCBURVNUSU5HMRgwFgYDVQQDEw9JbnRlcm1lZGlhdGUgQ0Ew
+-// IBcNMTUwMTAxMDAwMDAwWhgPMjEwMDAxMDEwMDAwMDBaMDYxGjAYBgNVBAoTEUJv
+-// cmluZ1NTTCBURVNUSU5HMRgwFgYDVQQDEw9JbnRlcm1lZGlhdGUgQ0EwgZ8wDQYJ
+-// KoZIhvcNAQEBBQADgY0AMIGJAoGBALti0jSXyhxNgnSArJdO08viIwkI1jg5zFeX
+-// jyOSdxUbUeVuWJyA1RrWv2b1gW1WTG8GKdvx1eJSkQaFWDhrBE8Nxq2WwFIQG4mS
+-// JkZhtFwCZK4KZlid/q7dphDXxJTxapURE+kThzBVWz7qTCXNHDT5cOhkBzO7xl7N
+-// WEJRzo1tAgMBAAGjejB4MA4GA1UdDwEB/wQEAwICBDAdBgNVHSUEFjAUBggrBgEF
+-// BQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAZBgNVHQ4EEgQQjBpoqLV2
+-// 211Xex+NFLIGozAbBgNVHSMEFDASgBCMGmiotXbbXVd7H40UsgajMA0GCSqGSIb3
+-// DQEBCwUAA4GBALcccSrAQ0/EqQBsx0ZDTUydHXXNP2DrUkpUKmAXIe8McqIVSlkT
+-// 6H4xz7z8VRKBo9j+drjjtCw2i0CQc8aOLxRb5WJ8eVLnaW2XRlUqAzhF0CrulfVI
+-// E4Vs6ZLU+fra1WAuIj6qFiigRja+3YkZArG8tMA9vtlhTX/g7YBZIkqH
+-// -----END CERTIFICATE-----
+-// )";
+-
+-// static const char kLeafPEM[] = R"(
+-// -----BEGIN CERTIFICATE-----
+-// MIICXjCCAcegAwIBAgIIWjO48ufpunYwDQYJKoZIhvcNAQELBQAwNjEaMBgGA1UE
+-// ChMRQm9yaW5nU1NMIFRFU1RJTkcxGDAWBgNVBAMTD0ludGVybWVkaWF0ZSBDQTAg
+-// Fw0xNTAxMDEwMDAwMDBaGA8yMTAwMDEwMTAwMDAwMFowMjEaMBgGA1UEChMRQm9y
+-// aW5nU1NMIFRFU1RJTkcxFDASBgNVBAMTC2V4YW1wbGUuY29tMIGfMA0GCSqGSIb3
+-// DQEBAQUAA4GNADCBiQKBgQDD0U0ZYgqShJ7oOjsyNKyVXEHqeafmk/bAoPqY/h1c
+-// oPw2E8KmeqiUSoTPjG5IXSblOxcqpbAXgnjPzo8DI3GNMhAf8SYNYsoH7gc7Uy7j
+-// 5x8bUrisGnuTHqkqH6d4/e7ETJ7i3CpR8bvK16DggEvQTudLipz8FBHtYhFakfdh
+-// TwIDAQABo3cwdTAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEG
+-// CCsGAQUFBwMCMAwGA1UdEwEB/wQCMAAwGQYDVR0OBBIEEKN5pvbur7mlXjeMEYA0
+-// 4nUwGwYDVR0jBBQwEoAQjBpoqLV2211Xex+NFLIGozANBgkqhkiG9w0BAQsFAAOB
+-// gQBj/p+JChp//LnXWC1k121LM/ii7hFzQzMrt70bny406SGz9jAjaPOX4S3gt38y
+-// rhjpPukBlSzgQXFg66y6q5qp1nQTD1Cw6NkKBe9WuBlY3iYfmsf7WT8nhlT1CttU
+-// xNCwyMX9mtdXdQicOfNjIGUCD5OLV5PgHFPRKiHHioBAhg==
+-// -----END CERTIFICATE-----
+-// )";
+-
+-// static const char kLeafNoKeyUsagePEM[] = R"(
+-// -----BEGIN CERTIFICATE-----
+-// MIICNTCCAZ6gAwIBAgIJAIFQGaLQ0G2mMA0GCSqGSIb3DQEBCwUAMDYxGjAYBgNV
+-// BAoTEUJvcmluZ1NTTCBURVNUSU5HMRgwFgYDVQQDEw9JbnRlcm1lZGlhdGUgQ0Ew
+-// IBcNMTUwMTAxMDAwMDAwWhgPMjEwMDAxMDEwMDAwMDBaMDcxGjAYBgNVBAoTEUJv
+-// cmluZ1NTTCBURVNUSU5HMRkwFwYDVQQDExBldmlsLmV4YW1wbGUuY29tMIGfMA0G
+-// CSqGSIb3DQEBAQUAA4GNADCBiQKBgQDOKoZe75NPz77EOaMMl4/0s3PyQw++zJvp
+-// ejHAxZiTPCJgMbEHLrSzNoHdopg+CLUH5bE4wTXM8w9Inv5P8OAFJt7gJuPUunmk
+-// j+NoU3QfzOR6BroePcz1vXX9jyVHRs087M/sLqWRHu9IR+/A+UTcBaWaFiDVUxtJ
+-// YOwFMwjNPQIDAQABo0gwRjAMBgNVHRMBAf8EAjAAMBkGA1UdDgQSBBBJfLEUWHq1
+-// 27rZ1AVx2J5GMBsGA1UdIwQUMBKAEIwaaKi1dttdV3sfjRSyBqMwDQYJKoZIhvcN
+-// AQELBQADgYEALVKN2Y3LZJOtu6SxFIYKxbLaXhTGTdIjxipZhmbBRDFjbZjZZOTe
+-// 6Oo+VDNPYco4rBexK7umYXJyfTqoY0E8dbiImhTcGTEj7OAB3DbBomgU1AYe+t2D
+-// uwBqh4Y3Eto+Zn4pMVsxGEfUpjzjZDel7bN1/oU/9KWPpDfywfUmjgk=
+-// -----END CERTIFICATE-----
+-// )";
+-
+-// static const char kForgeryPEM[] = R"(
+-// -----BEGIN CERTIFICATE-----
+-// MIICZzCCAdCgAwIBAgIIdTlMzQoKkeMwDQYJKoZIhvcNAQELBQAwNzEaMBgGA1UE
+-// ChMRQm9yaW5nU1NMIFRFU1RJTkcxGTAXBgNVBAMTEGV2aWwuZXhhbXBsZS5jb20w
+-// IBcNMTUwMTAxMDAwMDAwWhgPMjEwMDAxMDEwMDAwMDBaMDoxGjAYBgNVBAoTEUJv
+-// cmluZ1NTTCBURVNUSU5HMRwwGgYDVQQDExNmb3JnZXJ5LmV4YW1wbGUuY29tMIGf
+-// MA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDADTwruBQZGb7Ay6s9HiYv5d1lwtEy
+-// xQdA2Sy8Rn8uA20Q4KgqwVY7wzIZ+z5Butrsmwb70gdG1XU+yRaDeE7XVoW6jSpm
+-// 0sw35/5vJbTcL4THEFbnX0OPZnvpuZDFUkvVtq5kxpDWsVyM24G8EEq7kPih3Sa3
+-// OMhXVXF8kso6UQIDAQABo3cwdTAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYI
+-// KwYBBQUHAwEGCCsGAQUFBwMCMAwGA1UdEwEB/wQCMAAwGQYDVR0OBBIEEEYJ/WHM
+-// 8p64erPWIg4/liwwGwYDVR0jBBQwEoAQSXyxFFh6tdu62dQFcdieRjANBgkqhkiG
+-// 9w0BAQsFAAOBgQA+zH7bHPElWRWJvjxDqRexmYLn+D3Aivs8XgXQJsM94W0EzSUf
+-// DSLfRgaQwcb2gg2xpDFoG+W0vc6O651uF23WGt5JaFFJJxqjII05IexfCNhuPmp4
+-// 4UZAXPttuJXpn74IY1tuouaM06B3vXKZR+/ityKmfJvSwxacmFcK+2ziAg==
+-// -----END CERTIFICATE-----
+-// )";
++static const char kCrossSigningRootPEM[] = R"(
++-----BEGIN CERTIFICATE-----
++MIICcTCCAdqgAwIBAgIIagJHiPvE0MowDQYJKoZIhvcNAQELBQAwPDEaMBgGA1UE
++ChMRQm9yaW5nU1NMIFRFU1RJTkcxHjAcBgNVBAMTFUNyb3NzLXNpZ25pbmcgUm9v
++dCBDQTAgFw0xNTAxMDEwMDAwMDBaGA8yMTAwMDEwMTAwMDAwMFowPDEaMBgGA1UE
++ChMRQm9yaW5nU1NMIFRFU1RJTkcxHjAcBgNVBAMTFUNyb3NzLXNpZ25pbmcgUm9v
++dCBDQTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAwo3qFvSB9Zmlbpzn9wJp
++ikI75Rxkatez8VkLqyxbOhPYl2Haz8F5p1gDG96dCI6jcLGgu3AKT9uhEQyyUko5
++EKYasazSeA9CQrdyhPg0mkTYVETnPM1W/ebid1YtqQbq1CMWlq2aTDoSGAReGFKP
++RTdXAbuAXzpCfi/d8LqV13UCAwEAAaN6MHgwDgYDVR0PAQH/BAQDAgIEMB0GA1Ud
++JQQWMBQGCCsGAQUFBwMBBggrBgEFBQcDAjAPBgNVHRMBAf8EBTADAQH/MBkGA1Ud
++DgQSBBBHKHC7V3Z/3oLvEZx0RZRwMBsGA1UdIwQUMBKAEEcocLtXdn/egu8RnHRF
++lHAwDQYJKoZIhvcNAQELBQADgYEAnglibsy6mGtpIXivtlcz4zIEnHw/lNW+r/eC
++CY7evZTmOoOuC/x9SS3MF9vawt1HFUummWM6ZgErqVBOXIB4//ykrcCgf5ZbF5Hr
+++3EFprKhBqYiXdD8hpBkrBoXwn85LPYWNd2TceCrx0YtLIprE2R5MB2RIq8y4Jk3
++YFXvkME=
++-----END CERTIFICATE-----
++)";
++
++static const char kRootCAPEM[] = R"(
++-----BEGIN CERTIFICATE-----
++MIICVTCCAb6gAwIBAgIIAj5CwoHlWuYwDQYJKoZIhvcNAQELBQAwLjEaMBgGA1UE
++ChMRQm9yaW5nU1NMIFRFU1RJTkcxEDAOBgNVBAMTB1Jvb3QgQ0EwIBcNMTUwMTAx
++MDAwMDAwWhgPMjEwMDAxMDEwMDAwMDBaMC4xGjAYBgNVBAoTEUJvcmluZ1NTTCBU
++RVNUSU5HMRAwDgYDVQQDEwdSb290IENBMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB
++iQKBgQDpDn8RDOZa5oaDcPZRBy4CeBH1siSSOO4mYgLHlPE+oXdqwI/VImi2XeJM
++2uCFETXCknJJjYG0iJdrt/yyRFvZTQZw+QzGj+mz36NqhGxDWb6dstB2m8PX+plZ
++w7jl81MDvUnWs8yiQ/6twgu5AbhWKZQDJKcNKCEpqa6UW0r5nwIDAQABo3oweDAO
++BgNVHQ8BAf8EBAMCAgQwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCMA8G
++A1UdEwEB/wQFMAMBAf8wGQYDVR0OBBIEEEA31wH7QC+4HH5UBCeMWQEwGwYDVR0j
++BBQwEoAQQDfXAftAL7gcflQEJ4xZATANBgkqhkiG9w0BAQsFAAOBgQDXylEK77Za
++kKeY6ZerrScWyZhrjIGtHFu09qVpdJEzrk87k2G7iHHR9CAvSofCgEExKtWNS9dN
+++9WiZp/U48iHLk7qaYXdEuO07No4BYtXn+lkOykE+FUxmA4wvOF1cTd2tdj3MzX2
++kfGIBAYhzGZWhY3JbhIfTEfY1PNM1pWChQ==
++-----END CERTIFICATE-----
++)";
++
++static const char kRootCrossSignedPEM[] = R"(
++-----BEGIN CERTIFICATE-----
++MIICYzCCAcygAwIBAgIIAj5CwoHlWuYwDQYJKoZIhvcNAQELBQAwPDEaMBgGA1UE
++ChMRQm9yaW5nU1NMIFRFU1RJTkcxHjAcBgNVBAMTFUNyb3NzLXNpZ25pbmcgUm9v
++dCBDQTAgFw0xNTAxMDEwMDAwMDBaGA8yMTAwMDEwMTAwMDAwMFowLjEaMBgGA1UE
++ChMRQm9yaW5nU1NMIFRFU1RJTkcxEDAOBgNVBAMTB1Jvb3QgQ0EwgZ8wDQYJKoZI
++hvcNAQEBBQADgY0AMIGJAoGBAOkOfxEM5lrmhoNw9lEHLgJ4EfWyJJI47iZiAseU
++8T6hd2rAj9UiaLZd4kza4IURNcKSckmNgbSIl2u3/LJEW9lNBnD5DMaP6bPfo2qE
++bENZvp2y0Habw9f6mVnDuOXzUwO9SdazzKJD/q3CC7kBuFYplAMkpw0oISmprpRb
++SvmfAgMBAAGjejB4MA4GA1UdDwEB/wQEAwICBDAdBgNVHSUEFjAUBggrBgEFBQcD
++AQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAZBgNVHQ4EEgQQQDfXAftAL7gc
++flQEJ4xZATAbBgNVHSMEFDASgBBHKHC7V3Z/3oLvEZx0RZRwMA0GCSqGSIb3DQEB
++CwUAA4GBAErTxYJ0en9HVRHAAr5OO5wuk5Iq3VMc79TMyQLCXVL8YH8Uk7KEwv+q
++9MEKZv2eR/Vfm4HlXlUuIqfgUXbwrAYC/YVVX86Wnbpy/jc73NYVCq8FEZeO+0XU
++90SWAPDdp+iL7aZdimnMtG1qlM1edmz8AKbrhN/R3IbA2CL0nCWV
++-----END CERTIFICATE-----
++)";
++
++static const char kIntermediatePEM[] = R"(
++-----BEGIN CERTIFICATE-----
++MIICXjCCAcegAwIBAgIJAKJMH+7rscPcMA0GCSqGSIb3DQEBCwUAMC4xGjAYBgNV
++BAoTEUJvcmluZ1NTTCBURVNUSU5HMRAwDgYDVQQDEwdSb290IENBMCAXDTE1MDEw
++MTAwMDAwMFoYDzIxMDAwMTAxMDAwMDAwWjA2MRowGAYDVQQKExFCb3JpbmdTU0wg
++VEVTVElORzEYMBYGA1UEAxMPSW50ZXJtZWRpYXRlIENBMIGfMA0GCSqGSIb3DQEB
++AQUAA4GNADCBiQKBgQC7YtI0l8ocTYJ0gKyXTtPL4iMJCNY4OcxXl48jkncVG1Hl
++blicgNUa1r9m9YFtVkxvBinb8dXiUpEGhVg4awRPDcatlsBSEBuJkiZGYbRcAmSu
++CmZYnf6u3aYQ18SU8WqVERPpE4cwVVs+6kwlzRw0+XDoZAczu8ZezVhCUc6NbQID
++AQABo3oweDAOBgNVHQ8BAf8EBAMCAgQwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsG
++AQUFBwMCMA8GA1UdEwEB/wQFMAMBAf8wGQYDVR0OBBIEEIwaaKi1dttdV3sfjRSy
++BqMwGwYDVR0jBBQwEoAQQDfXAftAL7gcflQEJ4xZATANBgkqhkiG9w0BAQsFAAOB
++gQCvnolNWEHuQS8PFVVyuLR+FKBeUUdrVbSfHSzTqNAqQGp0C9fk5oCzDq6ZgTfY
++ESXM4cJhb3IAnW0UM0NFsYSKQJ50JZL2L3z5ZLQhHdbs4RmODGoC40BVdnJ4/qgB
++aGSh09eQRvAVmbVCviDK2ipkWNegdyI19jFfNP5uIkGlYg==
++-----END CERTIFICATE-----
++)";
++
++static const char kIntermediateSelfSignedPEM[] = R"(
++-----BEGIN CERTIFICATE-----
++MIICZjCCAc+gAwIBAgIJAKJMH+7rscPcMA0GCSqGSIb3DQEBCwUAMDYxGjAYBgNV
++BAoTEUJvcmluZ1NTTCBURVNUSU5HMRgwFgYDVQQDEw9JbnRlcm1lZGlhdGUgQ0Ew
++IBcNMTUwMTAxMDAwMDAwWhgPMjEwMDAxMDEwMDAwMDBaMDYxGjAYBgNVBAoTEUJv
++cmluZ1NTTCBURVNUSU5HMRgwFgYDVQQDEw9JbnRlcm1lZGlhdGUgQ0EwgZ8wDQYJ
++KoZIhvcNAQEBBQADgY0AMIGJAoGBALti0jSXyhxNgnSArJdO08viIwkI1jg5zFeX
++jyOSdxUbUeVuWJyA1RrWv2b1gW1WTG8GKdvx1eJSkQaFWDhrBE8Nxq2WwFIQG4mS
++JkZhtFwCZK4KZlid/q7dphDXxJTxapURE+kThzBVWz7qTCXNHDT5cOhkBzO7xl7N
++WEJRzo1tAgMBAAGjejB4MA4GA1UdDwEB/wQEAwICBDAdBgNVHSUEFjAUBggrBgEF
++BQcDAQYIKwYBBQUHAwIwDwYDVR0TAQH/BAUwAwEB/zAZBgNVHQ4EEgQQjBpoqLV2
++211Xex+NFLIGozAbBgNVHSMEFDASgBCMGmiotXbbXVd7H40UsgajMA0GCSqGSIb3
++DQEBCwUAA4GBALcccSrAQ0/EqQBsx0ZDTUydHXXNP2DrUkpUKmAXIe8McqIVSlkT
++6H4xz7z8VRKBo9j+drjjtCw2i0CQc8aOLxRb5WJ8eVLnaW2XRlUqAzhF0CrulfVI
++E4Vs6ZLU+fra1WAuIj6qFiigRja+3YkZArG8tMA9vtlhTX/g7YBZIkqH
++-----END CERTIFICATE-----
++)";
++
++static const char kLeafPEM[] = R"(
++-----BEGIN CERTIFICATE-----
++MIICXjCCAcegAwIBAgIIWjO48ufpunYwDQYJKoZIhvcNAQELBQAwNjEaMBgGA1UE
++ChMRQm9yaW5nU1NMIFRFU1RJTkcxGDAWBgNVBAMTD0ludGVybWVkaWF0ZSBDQTAg
++Fw0xNTAxMDEwMDAwMDBaGA8yMTAwMDEwMTAwMDAwMFowMjEaMBgGA1UEChMRQm9y
++aW5nU1NMIFRFU1RJTkcxFDASBgNVBAMTC2V4YW1wbGUuY29tMIGfMA0GCSqGSIb3
++DQEBAQUAA4GNADCBiQKBgQDD0U0ZYgqShJ7oOjsyNKyVXEHqeafmk/bAoPqY/h1c
++oPw2E8KmeqiUSoTPjG5IXSblOxcqpbAXgnjPzo8DI3GNMhAf8SYNYsoH7gc7Uy7j
++5x8bUrisGnuTHqkqH6d4/e7ETJ7i3CpR8bvK16DggEvQTudLipz8FBHtYhFakfdh
++TwIDAQABo3cwdTAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEG
++CCsGAQUFBwMCMAwGA1UdEwEB/wQCMAAwGQYDVR0OBBIEEKN5pvbur7mlXjeMEYA0
++4nUwGwYDVR0jBBQwEoAQjBpoqLV2211Xex+NFLIGozANBgkqhkiG9w0BAQsFAAOB
++gQBj/p+JChp//LnXWC1k121LM/ii7hFzQzMrt70bny406SGz9jAjaPOX4S3gt38y
++rhjpPukBlSzgQXFg66y6q5qp1nQTD1Cw6NkKBe9WuBlY3iYfmsf7WT8nhlT1CttU
++xNCwyMX9mtdXdQicOfNjIGUCD5OLV5PgHFPRKiHHioBAhg==
++-----END CERTIFICATE-----
++)";
++
++static const char kLeafNoKeyUsagePEM[] = R"(
++-----BEGIN CERTIFICATE-----
++MIICNTCCAZ6gAwIBAgIJAIFQGaLQ0G2mMA0GCSqGSIb3DQEBCwUAMDYxGjAYBgNV
++BAoTEUJvcmluZ1NTTCBURVNUSU5HMRgwFgYDVQQDEw9JbnRlcm1lZGlhdGUgQ0Ew
++IBcNMTUwMTAxMDAwMDAwWhgPMjEwMDAxMDEwMDAwMDBaMDcxGjAYBgNVBAoTEUJv
++cmluZ1NTTCBURVNUSU5HMRkwFwYDVQQDExBldmlsLmV4YW1wbGUuY29tMIGfMA0G
++CSqGSIb3DQEBAQUAA4GNADCBiQKBgQDOKoZe75NPz77EOaMMl4/0s3PyQw++zJvp
++ejHAxZiTPCJgMbEHLrSzNoHdopg+CLUH5bE4wTXM8w9Inv5P8OAFJt7gJuPUunmk
++j+NoU3QfzOR6BroePcz1vXX9jyVHRs087M/sLqWRHu9IR+/A+UTcBaWaFiDVUxtJ
++YOwFMwjNPQIDAQABo0gwRjAMBgNVHRMBAf8EAjAAMBkGA1UdDgQSBBBJfLEUWHq1
++27rZ1AVx2J5GMBsGA1UdIwQUMBKAEIwaaKi1dttdV3sfjRSyBqMwDQYJKoZIhvcN
++AQELBQADgYEALVKN2Y3LZJOtu6SxFIYKxbLaXhTGTdIjxipZhmbBRDFjbZjZZOTe
++6Oo+VDNPYco4rBexK7umYXJyfTqoY0E8dbiImhTcGTEj7OAB3DbBomgU1AYe+t2D
++uwBqh4Y3Eto+Zn4pMVsxGEfUpjzjZDel7bN1/oU/9KWPpDfywfUmjgk=
++-----END CERTIFICATE-----
++)";
++
++static const char kForgeryPEM[] = R"(
++-----BEGIN CERTIFICATE-----
++MIICZzCCAdCgAwIBAgIIdTlMzQoKkeMwDQYJKoZIhvcNAQELBQAwNzEaMBgGA1UE
++ChMRQm9yaW5nU1NMIFRFU1RJTkcxGTAXBgNVBAMTEGV2aWwuZXhhbXBsZS5jb20w
++IBcNMTUwMTAxMDAwMDAwWhgPMjEwMDAxMDEwMDAwMDBaMDoxGjAYBgNVBAoTEUJv
++cmluZ1NTTCBURVNUSU5HMRwwGgYDVQQDExNmb3JnZXJ5LmV4YW1wbGUuY29tMIGf
++MA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDADTwruBQZGb7Ay6s9HiYv5d1lwtEy
++xQdA2Sy8Rn8uA20Q4KgqwVY7wzIZ+z5Butrsmwb70gdG1XU+yRaDeE7XVoW6jSpm
++0sw35/5vJbTcL4THEFbnX0OPZnvpuZDFUkvVtq5kxpDWsVyM24G8EEq7kPih3Sa3
++OMhXVXF8kso6UQIDAQABo3cwdTAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYI
++KwYBBQUHAwEGCCsGAQUFBwMCMAwGA1UdEwEB/wQCMAAwGQYDVR0OBBIEEEYJ/WHM
++8p64erPWIg4/liwwGwYDVR0jBBQwEoAQSXyxFFh6tdu62dQFcdieRjANBgkqhkiG
++9w0BAQsFAAOBgQA+zH7bHPElWRWJvjxDqRexmYLn+D3Aivs8XgXQJsM94W0EzSUf
++DSLfRgaQwcb2gg2xpDFoG+W0vc6O651uF23WGt5JaFFJJxqjII05IexfCNhuPmp4
++4UZAXPttuJXpn74IY1tuouaM06B3vXKZR+/ityKmfJvSwxacmFcK+2ziAg==
++-----END CERTIFICATE-----
++)";
+ 
+ // kExamplePSSCert is an example RSA-PSS self-signed certificate, signed with
+ // the default hash functions.
+@@ -1049,11 +1049,11 @@
+ 
+ // CertFromPEM parses the given, NUL-terminated PEM block and returns an
+ // |X509*|.
+-// static bssl::UniquePtr<X509> CertFromPEM(const char *pem) {
+-//   bssl::UniquePtr<BIO> bio(BIO_new_mem_buf(pem, strlen(pem)));
+-//   return bssl::UniquePtr<X509>(
+-//       PEM_read_bio_X509(bio.get(), nullptr, nullptr, nullptr));
+-// }
++static bssl::UniquePtr<X509> CertFromPEM(const char *pem) {
++  bssl::UniquePtr<BIO> bio(BIO_new_mem_buf(pem, strlen(pem)));
++  return bssl::UniquePtr<X509>(
++      PEM_read_bio_X509(bio.get(), nullptr, nullptr, nullptr));
++}
+ 
+ // CRLFromPEM parses the given, NUL-terminated PEM block and returns an
+ // |X509_CRL*|.
+@@ -1082,190 +1082,190 @@
+ 
+ // CertsToStack converts a vector of |X509*| to an OpenSSL STACK_OF(X509),
+ // bumping the reference counts for each certificate in question.
+-// static bssl::UniquePtr<STACK_OF(X509)> CertsToStack(
+-//     const std::vector<X509 *> &certs) {
+-//   bssl::UniquePtr<STACK_OF(X509)> stack(sk_X509_new_null());
+-//   if (!stack) {
+-//     return nullptr;
+-//   }
+-//   for (auto cert : certs) {
+-//     if (!bssl::PushToStack(stack.get(), bssl::UpRef(cert))) {
+-//       return nullptr;
+-//     }
+-//   }
++static bssl::UniquePtr<STACK_OF(X509)> CertsToStack(
++    const std::vector<X509 *> &certs) {
++  bssl::UniquePtr<STACK_OF(X509)> stack(sk_X509_new_null());
++  if (!stack) {
++    return nullptr;
++  }
++  for (auto cert : certs) {
++    if (!bssl::PushToStack(stack.get(), bssl::UpRef(cert))) {
++      return nullptr;
++    }
++  }
+ 
+-//   return stack;
+-// }
++  return stack;
++}
+ 
+ // CRLsToStack converts a vector of |X509_CRL*| to an OpenSSL
+ // STACK_OF(X509_CRL), bumping the reference counts for each CRL in question.
+-// static bssl::UniquePtr<STACK_OF(X509_CRL)> CRLsToStack(
+-//     const std::vector<X509_CRL *> &crls) {
+-//   bssl::UniquePtr<STACK_OF(X509_CRL)> stack(sk_X509_CRL_new_null());
+-//   if (!stack) {
+-//     return nullptr;
+-//   }
+-//   for (auto crl : crls) {
+-//     if (!bssl::PushToStack(stack.get(), bssl::UpRef(crl))) {
+-//       return nullptr;
+-//     }
+-//   }
+-
+-//   return stack;
+-// }
+-
+-// static const time_t kReferenceTime = 1474934400 /* Sep 27th, 2016 */;
+-
+-// static int Verify(
+-//     X509 *leaf, const std::vector<X509 *> &roots,
+-//     const std::vector<X509 *> &intermediates,
+-//     const std::vector<X509_CRL *> &crls, unsigned long flags = 0,
+-//     std::function<void(X509_VERIFY_PARAM *)> configure_callback = nullptr,
+-//     int (*verify_callback)(int, X509_STORE_CTX *) = nullptr) {
+-//   bssl::UniquePtr<STACK_OF(X509)> roots_stack(CertsToStack(roots));
+-//   bssl::UniquePtr<STACK_OF(X509)> intermediates_stack(
+-//       CertsToStack(intermediates));
+-//   bssl::UniquePtr<STACK_OF(X509_CRL)> crls_stack(CRLsToStack(crls));
+-
+-//   if (!roots_stack ||
+-//       !intermediates_stack ||
+-//       !crls_stack) {
+-//     return X509_V_ERR_UNSPECIFIED;
+-//   }
+-
+-//   bssl::UniquePtr<X509_STORE_CTX> ctx(X509_STORE_CTX_new());
+-//   bssl::UniquePtr<X509_STORE> store(X509_STORE_new());
+-//   if (!ctx ||
+-//       !store) {
+-//     return X509_V_ERR_UNSPECIFIED;
+-//   }
+-
+-//   if (!X509_STORE_CTX_init(ctx.get(), store.get(), leaf,
+-//                            intermediates_stack.get())) {
+-//     return X509_V_ERR_UNSPECIFIED;
+-//   }
+-
+-//   X509_STORE_CTX_trusted_stack(ctx.get(), roots_stack.get());
+-//   X509_STORE_CTX_set0_crls(ctx.get(), crls_stack.get());
+-
+-//   X509_VERIFY_PARAM *param = X509_STORE_CTX_get0_param(ctx.get());
+-//   X509_VERIFY_PARAM_set_time(param, kReferenceTime);
+-//   if (configure_callback) {
+-//     configure_callback(param);
+-//   }
+-//   if (flags) {
+-//     X509_VERIFY_PARAM_set_flags(param, flags);
+-//   }
+-
+-//   ERR_clear_error();
+-//   if (X509_verify_cert(ctx.get()) != 1) {
+-//     return X509_STORE_CTX_get_error(ctx.get());
+-//   }
+-
+-//   return X509_V_OK;
+-// }
+-
+-// TEST(X509Test, TestVerify) {
+-//   //  cross_signing_root
+-//   //         |
+-//   //   root_cross_signed    root
+-//   //              \         /
+-//   //             intermediate
+-//   //                |     |
+-//   //              leaf  leaf_no_key_usage
+-//   //                      |
+-//   //                    forgery
+-//   bssl::UniquePtr<X509> cross_signing_root(CertFromPEM(kCrossSigningRootPEM));
+-//   bssl::UniquePtr<X509> root(CertFromPEM(kRootCAPEM));
+-//   bssl::UniquePtr<X509> root_cross_signed(CertFromPEM(kRootCrossSignedPEM));
+-//   bssl::UniquePtr<X509> intermediate(CertFromPEM(kIntermediatePEM));
+-//   bssl::UniquePtr<X509> intermediate_self_signed(
+-//       CertFromPEM(kIntermediateSelfSignedPEM));
+-//   bssl::UniquePtr<X509> leaf(CertFromPEM(kLeafPEM));
+-//   bssl::UniquePtr<X509> leaf_no_key_usage(CertFromPEM(kLeafNoKeyUsagePEM));
+-//   bssl::UniquePtr<X509> forgery(CertFromPEM(kForgeryPEM));
+-
+-//   ASSERT_TRUE(cross_signing_root);
+-//   ASSERT_TRUE(root);
+-//   ASSERT_TRUE(root_cross_signed);
+-//   ASSERT_TRUE(intermediate);
+-//   ASSERT_TRUE(intermediate_self_signed);
+-//   ASSERT_TRUE(leaf);
+-//   ASSERT_TRUE(forgery);
+-//   ASSERT_TRUE(leaf_no_key_usage);
+-
+-//   // Most of these tests work with or without |X509_V_FLAG_TRUSTED_FIRST|,
+-//   // though in different ways.
+-//   for (bool trusted_first : {true, false}) {
+-//     SCOPED_TRACE(trusted_first);
+-//     std::function<void(X509_VERIFY_PARAM *)> configure_callback;
+-//     if (!trusted_first) {
+-//       // Note we need the callback to clear the flag. Setting |flags| to zero
+-//       // only skips setting new flags.
+-//       configure_callback = [&](X509_VERIFY_PARAM *param) {
+-//         X509_VERIFY_PARAM_clear_flags(param, X509_V_FLAG_TRUSTED_FIRST);
+-//       };
+-//     }
+-
+-//     // No trust anchors configured.
+-//     ASSERT_EQ(X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY,
+-//               Verify(leaf.get(), /*roots=*/{}, /*intermediates=*/{},
+-//                      /*crls=*/{}, /*flags=*/0, configure_callback));
+-//     ASSERT_EQ(
+-//         X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY,
+-//         Verify(leaf.get(), /*roots=*/{}, {intermediate.get()}, /*crls=*/{},
+-//                /*flags=*/0, configure_callback));
+-
+-//     // Each chain works individually.
+-//     ASSERT_EQ(X509_V_OK, Verify(leaf.get(), {root.get()}, {intermediate.get()},
+-//                                 /*crls=*/{}, /*flags=*/0, configure_callback));
+-//     ASSERT_EQ(X509_V_OK, Verify(leaf.get(), {cross_signing_root.get()},
+-//                                 {intermediate.get(), root_cross_signed.get()},
+-//                                 /*crls=*/{}, /*flags=*/0, configure_callback));
+-
+-//     // When both roots are available, we pick one or the other.
+-//     ASSERT_EQ(X509_V_OK,
+-//               Verify(leaf.get(), {cross_signing_root.get(), root.get()},
+-//                      {intermediate.get(), root_cross_signed.get()}, /*crls=*/{},
+-//                      /*flags=*/0, configure_callback));
+-
+-//     // This is the “altchains” test – we remove the cross-signing CA but include
+-//     // the cross-sign in the intermediates. With |trusted_first|, we
+-//     // preferentially stop path-building at |intermediate|. Without
+-//     // |trusted_first|, the "altchains" logic repairs it.
+-//     ASSERT_EQ(X509_V_OK, Verify(leaf.get(), {root.get()},
+-//                                 {intermediate.get(), root_cross_signed.get()},
+-//                                 /*crls=*/{}, /*flags=*/0, configure_callback));
+-
+-//     // If |X509_V_FLAG_NO_ALT_CHAINS| is set and |trusted_first| is disabled, we
+-//     // get stuck on |root_cross_signed|. If either feature is enabled, we can
+-//     // build the path.
+-//     //
+-//     // This test exists to confirm our current behavior, but these modes are
+-//     // just workarounds for not having an actual path-building verifier. If we
+-//     // fix it, this test can be removed.
+-//     ASSERT_EQ(trusted_first ? X509_V_OK
+-//                             : X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY,
+-//               Verify(leaf.get(), {root.get()},
+-//                      {intermediate.get(), root_cross_signed.get()}, /*crls=*/{},
+-//                      /*flags=*/X509_V_FLAG_NO_ALT_CHAINS, configure_callback));
+-
+-//     // |forgery| is signed by |leaf_no_key_usage|, but is rejected because the
+-//     // leaf is not a CA.
+-//     ASSERT_EQ(X509_V_ERR_INVALID_CA,
+-//               Verify(forgery.get(), {intermediate_self_signed.get()},
+-//                      {leaf_no_key_usage.get()}, /*crls=*/{}, /*flags=*/0,
+-//                      configure_callback));
+-
+-//     // Test that one cannot skip Basic Constraints checking with a contorted set
+-//     // of roots and intermediates. This is a regression test for CVE-2015-1793.
+-//     ASSERT_EQ(X509_V_ERR_INVALID_CA,
+-//               Verify(forgery.get(),
+-//                      {intermediate_self_signed.get(), root_cross_signed.get()},
+-//                      {leaf_no_key_usage.get(), intermediate.get()}, /*crls=*/{},
+-//                      /*flags=*/0, configure_callback));
+-//   }
+-// }
++static bssl::UniquePtr<STACK_OF(X509_CRL)> CRLsToStack(
++    const std::vector<X509_CRL *> &crls) {
++  bssl::UniquePtr<STACK_OF(X509_CRL)> stack(sk_X509_CRL_new_null());
++  if (!stack) {
++    return nullptr;
++  }
++  for (auto crl : crls) {
++    if (!bssl::PushToStack(stack.get(), bssl::UpRef(crl))) {
++      return nullptr;
++    }
++  }
++
++  return stack;
++}
++
++static const time_t kReferenceTime = 1474934400 /* Sep 27th, 2016 */;
++
++static int Verify(
++    X509 *leaf, const std::vector<X509 *> &roots,
++    const std::vector<X509 *> &intermediates,
++    const std::vector<X509_CRL *> &crls, unsigned long flags = 0,
++    std::function<void(X509_VERIFY_PARAM *)> configure_callback = nullptr,
++    int (*verify_callback)(int, X509_STORE_CTX *) = nullptr) {
++  bssl::UniquePtr<STACK_OF(X509)> roots_stack(CertsToStack(roots));
++  bssl::UniquePtr<STACK_OF(X509)> intermediates_stack(
++      CertsToStack(intermediates));
++  bssl::UniquePtr<STACK_OF(X509_CRL)> crls_stack(CRLsToStack(crls));
++
++  if (!roots_stack ||
++      !intermediates_stack ||
++      !crls_stack) {
++    return X509_V_ERR_UNSPECIFIED;
++  }
++
++  bssl::UniquePtr<X509_STORE_CTX> ctx(X509_STORE_CTX_new());
++  bssl::UniquePtr<X509_STORE> store(X509_STORE_new());
++  if (!ctx ||
++      !store) {
++    return X509_V_ERR_UNSPECIFIED;
++  }
++
++  if (!X509_STORE_CTX_init(ctx.get(), store.get(), leaf,
++                           intermediates_stack.get())) {
++    return X509_V_ERR_UNSPECIFIED;
++  }
++
++  X509_STORE_CTX_trusted_stack(ctx.get(), roots_stack.get());
++  X509_STORE_CTX_set0_crls(ctx.get(), crls_stack.get());
++
++  X509_VERIFY_PARAM *param = X509_STORE_CTX_get0_param(ctx.get());
++  X509_VERIFY_PARAM_set_time(param, kReferenceTime);
++  if (configure_callback) {
++    configure_callback(param);
++  }
++  if (flags) {
++    X509_VERIFY_PARAM_set_flags(param, flags);
++  }
++
++  ERR_clear_error();
++  if (X509_verify_cert(ctx.get()) != 1) {
++    return X509_STORE_CTX_get_error(ctx.get());
++  }
++
++  return X509_V_OK;
++}
++
++TEST(X509Test, TestVerify) {
++  //  cross_signing_root
++  //         |
++  //   root_cross_signed    root
++  //              \         /
++  //             intermediate
++  //                |     |
++  //              leaf  leaf_no_key_usage
++  //                      |
++  //                    forgery
++  bssl::UniquePtr<X509> cross_signing_root(CertFromPEM(kCrossSigningRootPEM));
++  bssl::UniquePtr<X509> root(CertFromPEM(kRootCAPEM));
++  bssl::UniquePtr<X509> root_cross_signed(CertFromPEM(kRootCrossSignedPEM));
++  bssl::UniquePtr<X509> intermediate(CertFromPEM(kIntermediatePEM));
++  bssl::UniquePtr<X509> intermediate_self_signed(
++      CertFromPEM(kIntermediateSelfSignedPEM));
++  bssl::UniquePtr<X509> leaf(CertFromPEM(kLeafPEM));
++  bssl::UniquePtr<X509> leaf_no_key_usage(CertFromPEM(kLeafNoKeyUsagePEM));
++  bssl::UniquePtr<X509> forgery(CertFromPEM(kForgeryPEM));
++
++  ASSERT_TRUE(cross_signing_root);
++  ASSERT_TRUE(root);
++  ASSERT_TRUE(root_cross_signed);
++  ASSERT_TRUE(intermediate);
++  ASSERT_TRUE(intermediate_self_signed);
++  ASSERT_TRUE(leaf);
++  ASSERT_TRUE(forgery);
++  ASSERT_TRUE(leaf_no_key_usage);
++
++  // Most of these tests work with or without |X509_V_FLAG_TRUSTED_FIRST|,
++  // though in different ways.
++  for (bool trusted_first : {true, false}) {
++    SCOPED_TRACE(trusted_first);
++    std::function<void(X509_VERIFY_PARAM *)> configure_callback;
++    if (!trusted_first) {
++      // Note we need the callback to clear the flag. Setting |flags| to zero
++      // only skips setting new flags.
++      configure_callback = [&](X509_VERIFY_PARAM *param) {
++        X509_VERIFY_PARAM_clear_flags(param, X509_V_FLAG_TRUSTED_FIRST);
++      };
++    }
++
++    // No trust anchors configured.
++    ASSERT_EQ(X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY,
++              Verify(leaf.get(), /*roots=*/{}, /*intermediates=*/{},
++                     /*crls=*/{}, /*flags=*/0, configure_callback));
++    ASSERT_EQ(
++        X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY,
++        Verify(leaf.get(), /*roots=*/{}, {intermediate.get()}, /*crls=*/{},
++               /*flags=*/0, configure_callback));
++
++    // Each chain works individually.
++    ASSERT_EQ(X509_V_OK, Verify(leaf.get(), {root.get()}, {intermediate.get()},
++                                /*crls=*/{}, /*flags=*/0, configure_callback));
++    ASSERT_EQ(X509_V_OK, Verify(leaf.get(), {cross_signing_root.get()},
++                                {intermediate.get(), root_cross_signed.get()},
++                                /*crls=*/{}, /*flags=*/0, configure_callback));
++
++    // When both roots are available, we pick one or the other.
++    ASSERT_EQ(X509_V_OK,
++              Verify(leaf.get(), {cross_signing_root.get(), root.get()},
++                     {intermediate.get(), root_cross_signed.get()}, /*crls=*/{},
++                     /*flags=*/0, configure_callback));
++
++    // This is the “altchains” test – we remove the cross-signing CA but include
++    // the cross-sign in the intermediates. With |trusted_first|, we
++    // preferentially stop path-building at |intermediate|. Without
++    // |trusted_first|, the "altchains" logic repairs it.
++    ASSERT_EQ(X509_V_OK, Verify(leaf.get(), {root.get()},
++                                {intermediate.get(), root_cross_signed.get()},
++                                /*crls=*/{}, /*flags=*/0, configure_callback));
++
++    // If |X509_V_FLAG_NO_ALT_CHAINS| is set and |trusted_first| is disabled, we
++    // get stuck on |root_cross_signed|. If either feature is enabled, we can
++    // build the path.
++    //
++    // This test exists to confirm our current behavior, but these modes are
++    // just workarounds for not having an actual path-building verifier. If we
++    // fix it, this test can be removed.
++    ASSERT_EQ(trusted_first ? X509_V_OK
++                            : X509_V_ERR_UNABLE_TO_GET_ISSUER_CERT_LOCALLY,
++              Verify(leaf.get(), {root.get()},
++                     {intermediate.get(), root_cross_signed.get()}, /*crls=*/{},
++                     /*flags=*/X509_V_FLAG_NO_ALT_CHAINS, configure_callback));
++
++    // |forgery| is signed by |leaf_no_key_usage|, but is rejected because the
++    // leaf is not a CA.
++    ASSERT_EQ(X509_V_ERR_INVALID_CA,
++              Verify(forgery.get(), {intermediate_self_signed.get()},
++                     {leaf_no_key_usage.get()}, /*crls=*/{}, /*flags=*/0,
++                     configure_callback));
++
++    // Test that one cannot skip Basic Constraints checking with a contorted set
++    // of roots and intermediates. This is a regression test for CVE-2015-1793.
++    ASSERT_EQ(X509_V_ERR_INVALID_CA,
++              Verify(forgery.get(),
++                     {intermediate_self_signed.get(), root_cross_signed.get()},
++                     {leaf_no_key_usage.get(), intermediate.get()}, /*crls=*/{},
++                     /*flags=*/0, configure_callback));
++  }
++}
+ 
+ // static const char kHostname[] = "example.com";
+ // static const char kWrongHostname[] = "example2.com";

--- a/bssl-compat/source/GENERAL_NAME_set0_value.cc
+++ b/bssl-compat/source/GENERAL_NAME_set0_value.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509v3.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/09b8fd44c3d36cab0860a8e520ecbfe58b02a7fa/include/openssl/x509v3.h#L500
+ * https://www.openssl.org/docs/man3.0/man3/GENERAL_NAME_set0_value.html
+ */
+extern "C" void GENERAL_NAME_set0_value(GENERAL_NAME *a, int type, void *value) {
+  ossl.ossl_GENERAL_NAME_set0_value(a, type, value);
+}

--- a/bssl-compat/source/X509_CRL_free.cc
+++ b/bssl-compat/source/X509_CRL_free.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L485
+ * https://www.openssl.org/docs/man3.0/man3/X509_CRL_free.html
+ */
+extern "C" void X509_CRL_free(X509_CRL *crl) {
+  ossl.ossl_X509_CRL_free(crl);
+}

--- a/bssl-compat/source/X509_CRL_up_ref.cc
+++ b/bssl-compat/source/X509_CRL_up_ref.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L472
+ * https://www.openssl.org/docs/man3.0/man3/X509_CRL_up_ref.html
+ */
+extern "C" int X509_CRL_up_ref(X509_CRL *crl) {
+  return ossl.ossl_X509_CRL_up_ref(crl);
+}

--- a/bssl-compat/source/X509_STORE_CTX_free.cc
+++ b/bssl-compat/source/X509_STORE_CTX_free.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L2840
+ * https://www.openssl.org/docs/man3.0/man3/X509_STORE_CTX_free.html
+ */
+extern "C" void X509_STORE_CTX_free(X509_STORE_CTX *ctx) {
+  ossl.ossl_X509_STORE_CTX_free(ctx);
+}

--- a/bssl-compat/source/X509_STORE_CTX_get0_param.cc
+++ b/bssl-compat/source/X509_STORE_CTX_get0_param.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L2925
+ * https://www.openssl.org/docs/man3.0/man3/X509_STORE_CTX_get0_param.html
+ */
+extern "C" X509_VERIFY_PARAM *X509_STORE_CTX_get0_param(X509_STORE_CTX *ctx) {
+  return ossl.ossl_X509_STORE_CTX_get0_param(ctx);
+}

--- a/bssl-compat/source/X509_STORE_CTX_get_error.cc
+++ b/bssl-compat/source/X509_STORE_CTX_get_error.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L2895
+ * https://www.openssl.org/docs/man3.0/man3/X509_STORE_CTX_get_error.html
+ */
+extern "C" int X509_STORE_CTX_get_error(X509_STORE_CTX *ctx) {
+  return ossl.ossl_X509_STORE_CTX_get_error(ctx);
+}

--- a/bssl-compat/source/X509_STORE_CTX_init.cc
+++ b/bssl-compat/source/X509_STORE_CTX_init.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L2841
+ * https://www.openssl.org/docs/man3.0/man3/X509_STORE_CTX_init.html
+ */
+extern "C" int X509_STORE_CTX_init(X509_STORE_CTX *ctx, X509_STORE *store, X509 *x509, STACK_OF(X509) *chain) {
+  return ossl.ossl_X509_STORE_CTX_init(ctx, store, x509, reinterpret_cast<ossl_STACK_OF(ossl_X509)*>(chain));
+}

--- a/bssl-compat/source/X509_STORE_CTX_new.cc
+++ b/bssl-compat/source/X509_STORE_CTX_new.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L2834
+ * https://www.openssl.org/docs/man3.0/man3/X509_STORE_CTX_new.html
+ */
+extern "C" X509_STORE_CTX *X509_STORE_CTX_new(void) {
+  return ossl.ossl_X509_STORE_CTX_new();
+}

--- a/bssl-compat/source/X509_STORE_CTX_set0_crls.cc
+++ b/bssl-compat/source/X509_STORE_CTX_set0_crls.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L2911
+ * https://www.openssl.org/docs/man3.0/man3/X509_STORE_CTX_set0_crls.html
+ */
+extern "C" void X509_STORE_CTX_set0_crls(X509_STORE_CTX *c, STACK_OF(X509_CRL) *sk) {
+  ossl.ossl_X509_STORE_CTX_set0_crls(c, reinterpret_cast<ossl_STACK_OF(ossl_X509_CRL)*>(sk));
+}

--- a/bssl-compat/source/X509_STORE_CTX_trusted_stack.cc
+++ b/bssl-compat/source/X509_STORE_CTX_trusted_stack.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L2843
+ * https://www.openssl.org/docs/man3.0/man3/X509_STORE_CTX_trusted_stack.html
+ */
+extern "C" void X509_STORE_CTX_trusted_stack(X509_STORE_CTX *ctx, STACK_OF(X509) *sk) {
+  ossl.ossl_X509_STORE_CTX_trusted_stack(ctx, reinterpret_cast<ossl_STACK_OF(ossl_X509)*>(sk));
+}

--- a/bssl-compat/source/X509_STORE_free.cc
+++ b/bssl-compat/source/X509_STORE_free.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L2768
+ * https://www.openssl.org/docs/man3.0/man3/X509_STORE_free.html
+ */
+extern "C" void X509_STORE_free(X509_STORE *v) {
+  ossl.ossl_X509_STORE_free(v);
+}

--- a/bssl-compat/source/X509_STORE_new.cc
+++ b/bssl-compat/source/X509_STORE_new.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L2766
+ * https://www.openssl.org/docs/man3.0/man3/X509_STORE_new.html
+ */
+extern "C" X509_STORE *X509_STORE_new(void) {
+  return ossl.ossl_X509_STORE_new();
+}

--- a/bssl-compat/source/X509_STORE_set_flags.cc
+++ b/bssl-compat/source/X509_STORE_set_flags.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L2775
+ * https://www.openssl.org/docs/man3.0/man3/X509_STORE_set_flags.html
+ */
+extern "C" int X509_STORE_set_flags(X509_STORE *ctx, unsigned long flags) {
+  return ossl.ossl_X509_STORE_set_flags(ctx, flags);
+}

--- a/bssl-compat/source/X509_STORE_set_verify_cb.cc
+++ b/bssl-compat/source/X509_STORE_set_verify_cb.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L2789
+ * https://www.openssl.org/docs/man3.0/man3/X509_STORE_set_verify_cb.html
+ */
+extern "C" void X509_STORE_set_verify_cb( X509_STORE *ctx, X509_STORE_CTX_verify_cb verify_cb) {
+  ossl.ossl_X509_STORE_set_verify_cb(ctx, verify_cb);
+}

--- a/bssl-compat/source/X509_VERIFY_PARAM_clear_flags.cc
+++ b/bssl-compat/source/X509_VERIFY_PARAM_clear_flags.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L2944
+ * https://www.openssl.org/docs/man3.0/man3/X509_VERIFY_PARAM_clear_flags.html
+ */
+extern "C" int X509_VERIFY_PARAM_clear_flags(X509_VERIFY_PARAM *param, unsigned long flags) {
+  return ossl.ossl_X509_VERIFY_PARAM_clear_flags(param, flags);
+}

--- a/bssl-compat/source/X509_VERIFY_PARAM_set1.cc
+++ b/bssl-compat/source/X509_VERIFY_PARAM_set1.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L2938
+ * https://www.openssl.org/docs/man3.0/man3/X509_VERIFY_PARAM_set1.html
+ */
+extern "C" int X509_VERIFY_PARAM_set1(X509_VERIFY_PARAM *to, const X509_VERIFY_PARAM *from) {
+  return ossl.ossl_X509_VERIFY_PARAM_set1(to, from);
+}

--- a/bssl-compat/source/X509_VERIFY_PARAM_set_flags.cc
+++ b/bssl-compat/source/X509_VERIFY_PARAM_set_flags.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L2942
+ * https://www.openssl.org/docs/man3.0/man3/X509_VERIFY_PARAM_set_flags.html
+ */
+extern "C" int X509_VERIFY_PARAM_set_flags(X509_VERIFY_PARAM *param, unsigned long flags) {
+  return ossl.ossl_X509_VERIFY_PARAM_set_flags(param, flags);
+}

--- a/bssl-compat/source/X509_VERIFY_PARAM_set_time.cc
+++ b/bssl-compat/source/X509_VERIFY_PARAM_set_time.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L2954
+ * https://www.openssl.org/docs/man3.0/man3/X509_VERIFY_PARAM_set_time.html
+ */
+extern "C" void X509_VERIFY_PARAM_set_time(X509_VERIFY_PARAM *param, time_t t) {
+  ossl.ossl_X509_VERIFY_PARAM_set_time(param, t);
+}

--- a/bssl-compat/source/X509_up_ref.cc
+++ b/bssl-compat/source/X509_up_ref.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L126
+ * https://www.openssl.org/docs/man3.0/man3/X509_up_ref.html
+ */
+extern "C" int X509_up_ref(X509 *x509) {
+  return ossl.ossl_X509_up_ref(x509);
+}

--- a/bssl-compat/source/X509_verify_cert.cc
+++ b/bssl-compat/source/X509_verify_cert.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L2324
+ * https://www.openssl.org/docs/man3.0/man3/X509_verify_cert.html
+ */
+extern "C" int X509_verify_cert(X509_STORE_CTX *ctx) {
+  return ossl.ossl_X509_verify_cert(ctx);
+}

--- a/bssl-compat/source/X509_verify_cert_error_string.cc
+++ b/bssl-compat/source/X509_verify_cert_error_string.cc
@@ -1,0 +1,11 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+/*
+ * https://github.com/google/boringssl/blob/557b80f1a3e599459367391540488c132a000d55/include/openssl/x509.h#L1759
+ * https://www.openssl.org/docs/man3.0/man3/X509_verify_cert_error_string.html
+ */
+extern "C" const char *X509_verify_cert_error_string(long err) {
+  return ossl.ossl_X509_verify_cert_error_string(err);
+}


### PR DESCRIPTION
Added:

- GENERAL_NAME_set0_value()
- X509_CRL_free()
- X509_CRL_up_ref()
- X509_STORE_CTX_free()
- X509_STORE_CTX_get_error()
- X509_STORE_CTX_get0_param()
- X509_STORE_CTX_init()
- X509_STORE_CTX_new()
- X509_STORE_CTX_set0_crls()
- X509_STORE_CTX_trusted_stack()
- X509_STORE_free()
- X509_STORE_new()
- X509_STORE_set_flags()
- X509_STORE_set_verify_cb()
- X509_up_ref()
- X509_verify_cert_error_string()
- X509_verify_cert()
- X509_VERIFY_PARAM_clear_flags()
- X509_VERIFY_PARAM_set_flags()
- X509_VERIFY_PARAM_set_time()
- X509_VERIFY_PARAM_set1()

Enabled more BoringSSL unit tests:

- X509Test.TestVerify

Signed-off-by: Ted Poole <tpoole@redhat.com>