### PR TITLE
OSSM-2029 Enable bssl-compat cmake build in upstream build container

### DIFF
--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -605,6 +605,7 @@ add_executable(utests-bssl-compat ${utests-source-list})
 target_add_bssl_source(utests-bssl-compat ${utests-bssl-source-list})
 set_source_files_properties(source/extra/err_extra.c PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
 target_link_libraries(utests-bssl-compat PRIVATE GTest::gtest_main bssl-compat)
+set_target_properties(utests-bssl-compat PROPERTIES BUILD_RPATH "${OPENSSL_INSTALL_DIR}/lib")
 gtest_discover_tests(utests-bssl-compat)
 
 ################################################################################

--- a/bssl-compat/cmake/openssl.cmake
+++ b/bssl-compat/cmake/openssl.cmake
@@ -40,11 +40,12 @@ else (OS_OPENSSL_HEADERS AND  OS_SSL_LIBRARY AND OS_CRYPTO_LIBRARY)
         CONFIGURE_COMMAND ${OPENSSL_SOURCE_DIR}/config
         --prefix=${OPENSSL_INSTALL_DIR}
         --openssldir=${OPENSSL_INSTALL_DIR}
+        --libdir=lib
         BUILD_COMMAND make
         LOG ${OPENSSL_BUILD_LOG_DIR}
         LOG_BUILD TRUE
         TEST_COMMAND ""
-        INSTALL_COMMAND make install
+        INSTALL_COMMAND make install_sw
         INSTALL_DIR ${OPENSSL_INSTALL_DIR}
     )
     file(MAKE_DIRECTORY ${OPENSSL_INCLUDE_DIR})

--- a/bssl-compat/prefixer/CMakeLists.txt
+++ b/bssl-compat/prefixer/CMakeLists.txt
@@ -1,10 +1,18 @@
 project(prefixer)
 
-find_package(LLVM REQUIRED CONFIG)
+# https://llvm.org/docs/CMake.html#embedding-llvm-in-your-project
+
 find_package(Clang REQUIRED CONFIG)
+find_package(LLVM REQUIRED CONFIG)
+
+message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION} (${LLVM_INSTALL_PREFIX},${LLVM_ENABLE_EH},${LLVM_ENABLE_RTTI},${LLVM_LINK_LLVM_DYLIB})")
+
+list(APPEND CMAKE_MODULE_PATH ${LLVM_CMAKE_DIR})
+include(AddLLVM) # For llvm_update_compile_flags()
 
 add_executable(prefixer prefixer.cpp)
-
+llvm_update_compile_flags(prefixer) # Adds appropriate exception & rtti flags
+target_compile_definitions(prefixer PRIVATE LLVM_LIBRARY_DIR=\"${LLVM_LIBRARY_DIR}\")
 target_include_directories(prefixer PRIVATE "${LLVM_INCLUDE_DIRS}")
 target_link_directories(prefixer PRIVATE "${LLVM_LIBRARY_DIRS}")
-target_link_libraries(prefixer PRIVATE clang-cpp LLVM)
+target_link_libraries(prefixer PRIVATE clang-cpp $<$<BOOL:${LLVM_LINK_LLVM_DYLIB}>:LLVM>)

--- a/bssl-compat/prefixer/prefixer.cpp
+++ b/bssl-compat/prefixer/prefixer.cpp
@@ -403,7 +403,7 @@ class CompilationDatabase : public clang::tooling::CompilationDatabase
       std::vector<std::string> cmdline = {
           "dummy",
           std::string("-I") + opt::incdir().string(),
-          "-I/usr/lib64/clang/" LLVM_VERSION_STRING "/include/",
+          "-I" LLVM_LIBRARY_DIR "/clang/" LLVM_VERSION_STRING "/include/",
           file.str()
       };
       return { clang::tooling::CompileCommand(".", file, cmdline, "") };

--- a/bssl-compat/tools/uncomment.sh
+++ b/bssl-compat/tools/uncomment.sh
@@ -72,7 +72,7 @@ uncomment_line_range() {
 uncomment_regex_range() {
   [[ $# == 2 ]] || error "uncomment_regex_range(): Two regexes required"
   L1=$(grep -n "^// $1" "$HDR_FILE" | head -1 | cut -d: -f1)
-  L2=$(awk '(NR == '$L1'),/^\/\/ '$2'/{print NR}' "$HDR_FILE" | tail -1)
+  L2=$(gawk '(NR == '$L1'),/^\/\/ '$2'/{print NR}' "$HDR_FILE" | tail -1)
   [ -z "$L1" ] && error "Failed to locate first pattern in -R $1 $2"
   [ -z "$L2" ] && error "Failed to locate second pattern in -R $1 $2"
   uncomment_line_range $L1 $L2
@@ -81,7 +81,7 @@ uncomment_regex_range() {
 uncomment_preproc_directive() {
   [[ $# == 1 ]] || error "uncomment_preproc_directive(): One regex required"
   for L1 in $(grep -n "^// #\s*$1" "$HDR_FILE" | cut -d: -f1); do
-    L2=$(awk '(NR == '$L1'),/[^\\]$/{print NR}' "$HDR_FILE" | tail -1)
+    L2=$(gawk '(NR == '$L1'),/[^\\]$/{print NR}' "$HDR_FILE" | tail -1)
     uncomment_line_range $L1 $L2
   done
 }
@@ -94,7 +94,7 @@ comment_line_range() {
 comment_regex_range() {
   [[ $# == 2 ]] || error "comment_regex_range(): Two regexes required"
   L1=$(grep -n "$1" "$HDR_FILE" | head -1 | cut -d: -f1)
-  L2=$(awk '(NR == '$L1'),/'$2'/{print NR}' "$HDR_FILE" | tail -1)
+  L2=$(gawk '(NR == '$L1'),/'$2'/{print NR}' "$HDR_FILE" | tail -1)
   [ -z "$L1" ] && error "comment_regex_range(): Failed to locate first pattern"
   [ -z "$L2" ] && error "comment_regex_range(): Failed to locate second pattern"
   comment_line_range $L1 $L2
@@ -151,7 +151,7 @@ while [ $# -ne 0 ]; do
           [[ $i == 0 ]] && AWK="$AWK {l1=NR}" || AWK="$AWK && NR==(l1+$i) {}"
         done
         AWK="${AWK::-2} {printf \"%d %d\n\", l1, NR; exit 0}"
-        RANGE=$(awk "$AWK" "$HDR_FILE")
+        RANGE=$(gawk "$AWK" "$HDR_FILE")
         [ -z "$RANGE" ] && error "Failed to locate --uncomment-regex ${PATTERNS[@]}"
         uncomment_line_range $RANGE
       fi
@@ -172,7 +172,7 @@ while [ $# -ne 0 ]; do
       [[ $2 ]] && [[ $2 != -* ]] || error "Insufficient arguments for $1"
       option_end "$2"
       for L1 in $(grep -n "^// #\s*define\s*$2\>" "$HDR_FILE" | cut -d: -f1); do
-        L2=$(awk '(NR == '$L1'),/[^\\]$/{print NR}' "$HDR_FILE" | tail -1)
+        L2=$(gawk '(NR == '$L1'),/[^\\]$/{print NR}' "$HDR_FILE" | tail -1)
         uncomment_line_range $L1 $L2
       done
       shift
@@ -226,7 +226,7 @@ while [ $# -ne 0 ]; do
       LINE=$(grep -n "^// \s*\<typedef\>.*\<$2\>.*" "$HDR_FILE" | head -1)
       L1=$(echo "$LINE" | cut -d: -f1) && L2=$L1
       if [[ ! "$LINE" =~ \;$ ]]; then # multi-line
-        L2=$(awk '(NR == '$L1'),/^\/\/ .*;$/{print NR}' "$HDR_FILE" | tail -1)
+        L2=$(gawk '(NR == '$L1'),/^\/\/ .*;$/{print NR}' "$HDR_FILE" | tail -1)
       fi
       uncomment_line_range $L1 $L2
       shift
@@ -243,7 +243,7 @@ while [ $# -ne 0 ]; do
       LINE=$(grep -n "^// static\s*.*\b$2\b\s*(" "$HDR_FILE" | head -1)
       L1=$(echo "$LINE" | cut -d: -f1) && L2=$L1
       if [[ ! "$LINE" =~ }$ ]]; then # multi-line
-        L2=$(awk '(NR == '$L1'),/^\/\/ }$/{print NR}' "$HDR_FILE" | tail -1)
+        L2=$(gawk '(NR == '$L1'),/^\/\/ }$/{print NR}' "$HDR_FILE" | tail -1)
       fi
       uncomment_line_range $L1 $L2
       shift


### PR DESCRIPTION
A number of small changes to enable a cmake build of bssl-compat to work in the upstream envoyproxy/envoy-build-ubuntu builder image:

- The uncomment.sh script now explicitly uses gawk rather than awk so it knows which awk dialect it can use without any surprises.

- If OpenSSL is built as an ExternalProject, because it cannot be found installed on the host, then we need to tell the bssl-compat-utests binary where to load libcrypto/ssl.so from by adding their path to the executable's RPATH.

- Since the LLVM libraries can be configured & built with or without RTTI and/or exceptions, the compile & link of the prefixer tool needs to accommodte such differences. To achieve this, it now uses the LLVM provided cmake function llvm_update_compile_flags() to add the appropriate rtti and/or exception compilation flags.

- The prefixer now makes use of the LLVM_LIBRARY_DIR cmake variable, to locate the system headers (previously fixed to just /usr/lib/clang/...).