### PR TITLE
OSSM-2029 Enabled envoy compilation against bssl-compat

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,1 +1,3 @@
 import %workspace%/envoy/.bazelrc
+build --@envoy//bazel:http3=False
+try-import %workspace%/user.bazelrc

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,22 +13,6 @@ load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_depende
 
 rules_foreign_cc_dependencies(register_default_tools = False, register_built_tools = False)
 
-openssl_files = """\
-filegroup(
-    name = "srcs",
-    srcs = glob(["**"]),
-    visibility = ["//visibility:public"],
-)
-"""
-
-http_archive(
-    name = "openssl",
-    build_file_content = openssl_files,
-    sha256 = "fc513913724790510f53af07caa24eaf0eae3fc8cf476c17c113221b5868edac",
-    strip_prefix = "openssl-OpenSSL_1_1_1r",
-    urls = ["https://github.com/openssl/openssl/archive/OpenSSL_1_1_1r.tar.gz"],
-)
-
 local_repository(
     name = "bssl-compat",
     path = "bssl-compat",

--- a/bssl-compat/BUILD
+++ b/bssl-compat/BUILD
@@ -1,4 +1,4 @@
-load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make", "cmake")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
 
 filegroup(
     name = "srcs",
@@ -7,23 +7,21 @@ filegroup(
 
 licenses(["notice"])  # Apache 2
 
-configure_make(
-    name = "openssl",
-    lib_source = "@openssl//:srcs",
-    configure_command = "config",
-    out_shared_libs = ["libcrypto.so", "libssl.so"],
-    visibility = ["//visibility:public"],
-)
-
 cmake(
     name = "bssl-compat",
     lib_source = ":srcs",
     out_shared_libs = [],
     out_static_libs = ["libbssl-compat.a"],
     visibility = ["//visibility:public"],
-    deps = [":openssl"],
     generate_crosstool_file = False,
     tags = ["requires-network"],
+    env = { "GOCACHE" : "/tmp" }
+)
+
+alias(
+    name = "crypto",
+    actual = ":bssl-compat",
+    visibility = ["//visibility:public"],
 )
 
 alias(

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -550,6 +550,7 @@ install(TARGETS bssl-compat LIBRARY DESTINATION lib)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include DESTINATION include)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ext DESTINATION include)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/ossl DESTINATION include)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/openssl DESTINATION include)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/include/ossl.h DESTINATION include)
 
 ################################################################################

--- a/bssl-compat/cmake/boringssl.cmake
+++ b/bssl-compat/cmake/boringssl.cmake
@@ -5,6 +5,8 @@ ExternalProject_Add(BoringSSL
   SOURCE_DIR  "${CMAKE_CURRENT_SOURCE_DIR}/external/boringssl"
   CMAKE_ARGS  -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
               -DCMAKE_INSTALL_LIBDIR=lib
+              -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+              -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
 )
 
 ExternalProject_Get_Property(BoringSSL INSTALL_DIR)

--- a/run-build-container.sh
+++ b/run-build-container.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ENVOY_OPENSSL_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf -- "$TMP_DIR"' EXIT
+
+DOCKER_IMAGE=$(sed -n 's/^build:docker-sandbox --experimental_docker_image=//p' "${ENVOY_OPENSSL_DIR}/envoy/.bazelrc")
+if [[ -z "${DOCKER_IMAGE}" ]]; then
+	echo "Failed to determine builder docker image"
+	exit 1
+fi
+
+
+cat << 'EOF' > "${TMP_DIR}/entrypoint.sh"
+    #!/bin/bash -e
+
+    sudo chown -R "$(id -u):$(id -g)" $HOME
+    export BAZELRC_FILE=$HOME/.bazelrc
+
+    /source/envoy/bazel/setup_clang.sh /opt/llvm # Writes to $BAZELRC_FILE
+
+    # See https://github.com/envoyproxy/envoy/blob/main/bazel/README.md#config-flag-choices
+    echo "build --config=clang" >> $BAZELRC_FILE
+    # echo "build --config=libc++" >> $BAZELRC_FILE
+
+    if [ ! -z "$BAZEL_REMOTE_CACHE" ]; then
+        echo "build --remote_cache=${BAZEL_REMOTE_CACHE}" >> $BAZELRC_FILE
+    fi
+
+    if [ ! -z "$BAZEL_EXPERIMENTAL_REMOTE_DOWNLOADER" ]; then
+        echo "build --experimental_remote_downloader=${BAZEL_EXPERIMENTAL_REMOTE_DOWNLOADER}" >> $BAZELRC_FILE
+    fi
+
+    if true; then # Useful for debugging build failures
+        echo "build --verbose_failures" >> $BAZELRC_FILE
+        echo "build --sandbox_debug" >> $BAZELRC_FILE
+        echo "build --experimental_ui_max_stdouterr_bytes=104857600" >> $BAZELRC_FILE
+    fi
+
+    exec /bin/bash
+EOF
+
+
+cat << EOF > "${TMP_DIR}/Dockerfile"
+    FROM ${DOCKER_IMAGE}
+
+    RUN apt update -y
+    RUN apt install -y vim
+    RUN apt install -y gawk
+
+    ADD https://go.dev/dl/go1.19.11.linux-amd64.tar.gz /tmp
+    RUN tar -C /usr/local -xzf /tmp/go1.19.11.linux-amd64.tar.gz && rm /tmp/go1.19.11.linux-amd64.tar.gz
+    ENV PATH=/usr/local/go/bin:\$PATH
+
+    ENV HOME=/build
+    RUN groupadd --gid $(id -g) $(id -u -n)
+    RUN useradd -s /bin/bash --uid $(id -u) --gid $(id -g) -m $(id -u -n) -G pcap -d ${HOME}
+    RUN echo $(id -u -n) ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$(id -u -n) && chmod 0440 /etc/sudoers.d/$(id -u -n)
+    USER $(id -u -n):$(id -g -n)
+
+    ENV PATH=/opt/llvm/bin:\$PATH
+    ENV LD_LIBRARY_PATH=/opt/llvm/lib:\$LD_LIBRARY_PATH
+
+    VOLUME /build
+    VOLUME /source
+
+    ADD --chmod=755 entrypoint.sh /entrypoint.sh
+    ENTRYPOINT /entrypoint.sh
+EOF
+
+DOCKER_BUILDKIT=1 docker build --pull --iidfile "${TMP_DIR}/iid" "${TMP_DIR}"
+
+mkdir -p "${ENVOY_OPENSSL_DIR}/build-volume"
+
+docker run --rm \
+           --tty \
+           --interactive \
+           --network=host \
+           --env BAZEL_REMOTE_CACHE \
+           --env BAZEL_EXPERIMENTAL_REMOTE_DOWNLOADER \
+           --volume="${ENVOY_OPENSSL_DIR}/build-volume:/build" \
+           --volume="${ENVOY_OPENSSL_DIR}:/source" \
+           --volume="${HOME}:${HOME}" \
+           --workdir=/source \
+           $(cat "${TMP_DIR}/iid")
+
+
+# bazel build @bssl-compat//:bssl-compat
+# bazel build @envoy//:envoy
+# cd envoy && bazel build :envoy


### PR DESCRIPTION
Added run-build-container.sh script which launches a build container based on the upstream envoy-builder image. Inside this container, simply run the following command to kick off a build:

$ bazel build @envoy//:envoy