### PR TITLE
Lower the required cmake version

### DIFF
--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.24 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 
 include(FetchContent)
 include(GoogleTest)


### PR DESCRIPTION
The `maistra-builder:2.5` image has got `cmake` 3.20.x installed, whereas the `bssl-compat/CMakeLists.txt` file specifies 3.24 as a minimum, causing the build to fail inside a container.

Since the bssl-compat build doesn't actually rely on any >3.20.x features, it's safe to downgrade the required version to enable building bssl-compat inside a `maistra-builde:2.5` container