### PR TITLE
Tidy up some bssl-compat compiler warnings

### DIFF
--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -7,8 +7,8 @@ if(POLICY CMP0135)
   cmake_policy(SET CMP0135 NEW)
 endif()
 
-set(OPENSSL_URL      https://github.com/openssl/openssl/archive/refs/tags/openssl-3.0.8.tar.gz)
-set(OPENSSL_URL_HASH 6933e2f1da6f23a50ea226eec6e91b543d277d2098025763b5931cf6a7e099c7)
+set(OPENSSL_URL      https://github.com/openssl/openssl/archive/refs/tags/openssl-3.0.13.tar.gz)
+set(OPENSSL_URL_HASH e74504ed7035295ec7062b1da16c15b57ff2a03cd2064a28d8c39458cacc45fc)
 
 SET (CMAKE_C_COMPILER    "clang")
 SET (CMAKE_CXX_COMPILER  "clang++")
@@ -132,6 +132,7 @@ add_library(bssl-compat STATIC
   source/SSL_CTX_get_max_proto_version.cc
   source/SSL_CTX_get_min_proto_version.cc
   source/SSL_CTX_get_ex_new_index.cc
+  source/SSL_CTX_get_session_cache_mode.cc
   source/SSL_CTX_sess_set_new_cb.cc
   source/SSL_CTX_set_alpn_select_cb.cc
   source/SSL_CTX_set_cert_verify_callback.cc
@@ -196,6 +197,7 @@ add_library(bssl-compat STATIC
   source/X509_sign.cc
   source/X509_STORE_CTX_get0_untrusted.cc
   source/X509_STORE_CTX_init.cc
+  source/X509_STORE_CTX_get0_chain.cc
   source/X509_STORE_CTX_set0_crls.cc
   source/X509_STORE_CTX_set0_trusted_stack.cc
   source/X509_STORE_CTX_set_verify_cb.cc
@@ -470,7 +472,6 @@ target_add_bssl_function(bssl-compat
   SSL_CTX_set_cert_store
   SSL_CTX_get_ex_data
   SSL_CTX_get_options
-  SSL_CTX_get_session_cache_mode
   SSL_CTX_get_verify_mode
   SSL_CTX_get0_certificate
   SSL_CTX_get0_param
@@ -593,7 +594,6 @@ target_add_bssl_function(bssl-compat
   X509_STORE_CTX_get_error_depth
   X509_STORE_CTX_get_ex_data
   X509_STORE_CTX_get0_cert
-  X509_STORE_CTX_get0_chain
   X509_STORE_CTX_get0_param
   X509_STORE_CTX_new
   X509_STORE_CTX_set_default

--- a/bssl-compat/source/SSL_CTX_get_session_cache_mode.cc
+++ b/bssl-compat/source/SSL_CTX_get_session_cache_mode.cc
@@ -1,0 +1,7 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+extern "C" int SSL_CTX_get_session_cache_mode(const SSL_CTX *ctx) {
+  return ossl_SSL_CTX_get_session_cache_mode(const_cast<SSL_CTX*>(ctx));
+}

--- a/bssl-compat/source/SSL_CTX_set_verify.cc
+++ b/bssl-compat/source/SSL_CTX_set_verify.cc
@@ -1,11 +1,7 @@
 #include <openssl/ssl.h>
 #include <ossl.h>
-#include "log.h"
 
 
 extern "C" void SSL_CTX_set_verify(SSL_CTX *ctx, int mode, int (*callback)(int ok, X509_STORE_CTX *store_ctx)) {
-  if (callback) {
-    bssl_compat_fatal("%s() with non-null callback not implemented", __func__);
-  }
-  ossl.ossl_SSL_CTX_set_verify(ctx, mode, NULL);
+  ossl.ossl_SSL_CTX_set_verify(ctx, mode, callback);
 }

--- a/bssl-compat/source/X509_STORE_CTX_get0_chain.cc
+++ b/bssl-compat/source/X509_STORE_CTX_get0_chain.cc
@@ -1,0 +1,7 @@
+#include <openssl/x509.h>
+#include <ossl.h>
+
+
+extern "C" STACK_OF(X509) *X509_STORE_CTX_get0_chain(X509_STORE_CTX *ctx) {
+  return reinterpret_cast<STACK_OF(X509)*>(ossl_X509_STORE_CTX_get0_chain(ctx));
+}

--- a/bssl-compat/source/test/test_err.cc
+++ b/bssl-compat/source/test/test_err.cc
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 #include <openssl/err.h>
-#include <openssl/sslerr.h>
+#include <openssl/ssl.h>
 #include <limits>
 
 
@@ -38,9 +38,9 @@ TEST(ErrTest, test_SSL_R_NO_SUITABLE_SIGNATURE_ALGORITHM) {
   ERR_clear_error();
 
 #ifdef BSSL_COMPAT
-  ossl_ERR_put_error(ERR_LIB_SSL, 0, SSL_R_NO_SUITABLE_SIGNATURE_ALGORITHM, __FILE__, __LINE__);
+  ERR_put_error(ERR_LIB_SSL, 0, ossl_SSL_R_NO_SUITABLE_SIGNATURE_ALGORITHM, __FILE__, __LINE__);
 #else // BoringSSL
-  ERR_put_error(ERR_LIB_SSL, 0, 253/*SSL_R_NO_COMMON_SIGNATURE_ALGORITHMS*/, __FILE__, __LINE__);
+  ERR_put_error(ERR_LIB_SSL, 0, SSL_R_NO_COMMON_SIGNATURE_ALGORITHMS, __FILE__, __LINE__);
 #endif
 
   uint32_t e = ERR_get_error();


### PR DESCRIPTION
The ErrTest.test_SSL_R_NO_SUITABLE_SIGNATURE_ALGORITHM test was failing to compile because it was referring to SSL_R_NO_SUITABLE_SIGNATURE_ALGORITHM rather than the prefixed ossl_SSL_R_NO_SUITABLE_SIGNATURE_ALGORITHM.

The previously generated implementations of SSL_CTX_get_session_cache_mode() and X509_STORE_CTX_get0_chain() have been replaced with hand written ones, with the addition of some const casting to remove compiler warnings.

Finally, the OpenSSL version is increased from 3.0.8 to 3.0.13