### PR TITLE
Removed WORKSPACE file from bssl-compat directory

### DIFF
--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -533,12 +533,12 @@ config_setting(
 # Alias pointing to the selected version of BoringSSL:
 alias(
     name = "boringssl",
-    actual = "@bssl-compat//:ssl"
+    actual = "@envoy//bssl-compat:ssl"
 )
 
 alias(
     name = "boringcrypto",
-    actual = "@bssl-compat//:crypto"
+    actual = "@envoy//bssl-compat:crypto"
 )
 
 config_setting(

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -254,11 +254,11 @@ def envoy_dependencies(skip_targets = []):
     # Binding to an alias pointing to the bssl-compat layer
     native.bind(
         name = "ssl",
-        actual = "@bssl-compat//:ssl",
+        actual = "@envoy//bssl-compat:ssl",
     )
     native.bind(
         name = "crypto",
-        actual = "@bssl-compat//:crypto",
+        actual = "@envoy//bssl-compat:crypto",
     )
 
     # The long repo names (`com_github_fmtlib_fmt` instead of `fmtlib`) are

--- a/bssl-compat/WORKSPACE
+++ b/bssl-compat/WORKSPACE
@@ -1,1 +1,0 @@
-workspace(name = "bssl-compat")


### PR DESCRIPTION
Removed the `bssl-compat/WORKSPACE` file, and changed all `@bssl-compat//` references to `@envoy//bssl-compat`
i.e. `bssl-compat` is now a package, referenced relative to the `@envoy` repository, rather than being a repository itself.