### PR TITLE
Boringssl and rules python fix for s390x

### DIFF
--- a/bazel/repositories_extra.bzl
+++ b/bazel/repositories_extra.bzl
@@ -24,7 +24,7 @@ def envoy_dependencies_extra(
     python_register_toolchains(
         name = "python%s" % _python_minor_version(python_version),
         python_version = python_version,
-        ignore_root_user_error = True,
+        ignore_root_user_error = ignore_root_user_error,
     )
 
     aspect_bazel_lib_dependencies()

--- a/bazel/repositories_extra.bzl
+++ b/bazel/repositories_extra.bzl
@@ -8,7 +8,7 @@ def _python_minor_version(python_version):
     return "_".join(python_version.split(".")[:-1])
 
 # Python version for `rules_python`
-PYTHON_VERSION = "3.11.3"
+PYTHON_VERSION = "3.11.4"
 PYTHON_MINOR_VERSION = _python_minor_version(PYTHON_VERSION)
 
 # Envoy deps that rely on a first stage of dependency loading in envoy_dependencies().
@@ -24,7 +24,7 @@ def envoy_dependencies_extra(
     python_register_toolchains(
         name = "python%s" % _python_minor_version(python_version),
         python_version = python_version,
-        ignore_root_user_error = ignore_root_user_error,
+        ignore_root_user_error = True,
     )
 
     aspect_bazel_lib_dependencies()

--- a/bssl-compat/third_party/boringssl/src/include/openssl/base.h
+++ b/bssl-compat/third_party/boringssl/src/include/openssl/base.h
@@ -116,6 +116,8 @@ extern "C" {
 #define OPENSSL_32_BIT
 #elif defined(__myriad2__)
 #define OPENSSL_32_BIT
+#elif defined(__s390__) || defined(__s390x__) || defined(__zarch__)
+#define OPENSSL_64_BIT
 #else
 // Note BoringSSL only supports standard 32-bit and 64-bit two's-complement,
 // little-endian architectures. Functions will not produce the correct answer


### PR DESCRIPTION
Added s390x arch to build bssl-compat library