### PR TITLE
Adding changes for ppc64le.

### DIFF
--- a/bazel/rules_go.patch
+++ b/bazel/rules_go.patch
@@ -28,3 +28,15 @@ index 91748eda..c1aeb91e 100644
              outputs = [out, gopath, gocache],
              mnemonic = "GoToolchainBinaryBuild",
          )
+diff --git a/go/private/platforms.bzl b/go/private/platforms.bzl
+index 4da43060..9003755d 100644
+--- a/go/private/platforms.bzl
++++ b/go/private/platforms.bzl
+@@ -30,7 +30,6 @@ BAZEL_GOARCH_CONSTRAINTS = {
+     "amd64": "@platforms//cpu:x86_64",
+     "arm": "@platforms//cpu:arm",
+     "arm64": "@platforms//cpu:aarch64",
+-    "ppc64": "@platforms//cpu:ppc",
+     "ppc64le": "@platforms//cpu:ppc",
+     "s390x": "@platforms//cpu:s390x",
+ }

--- a/bssl-compat/third_party/boringssl/src/include/openssl/base.h
+++ b/bssl-compat/third_party/boringssl/src/include/openssl/base.h
@@ -118,6 +118,8 @@ extern "C" {
 #define OPENSSL_32_BIT
 #elif defined(__s390__) || defined(__s390x__) || defined(__zarch__)
 #define OPENSSL_64_BIT
+#elif defined(__ppc64le__) || defined(__ARCH_PPC64LE__)
+#define OPENSSL_64_BIT
 #else
 // Note BoringSSL only supports standard 32-bit and 64-bit two's-complement,
 // little-endian architectures. Functions will not produce the correct answer


### PR DESCRIPTION
- Added changes for fixing envoy openssl library build failure on ppc64le.
- Added missing PR for ppc64le from 2.5 release.