### PR TITLE
S390x - Update bazelrc parameter to fix cmake tool error on s390x

### DIFF
--- a/openssl/bazelrc
+++ b/openssl/bazelrc
@@ -16,4 +16,4 @@ build --build_tag_filters=-nofips
 test --test_tag_filters=-nofips
 
 # Arch-specific build flags, triggered with --config=$ARCH in bazel build command
-build:s390x --//source/extensions/filters/common/lua:luajit2=1 --copt="-Wno-deprecated-declarations" --linkopt=-fuse-ld=gold
+build:s390x --//source/extensions/filters/common/lua:luajit2=1 --copt="-Wno-deprecated-declarations" --action_env=BAZEL_LINKLIBS=-lstdc++ --linkopt=-fuse-ld=gold


### PR DESCRIPTION
Default bazel parameter --action_env=BAZEL_LINKLIBS=-l%:libstdc+.a is unable to statically link libstdc++ library when using gold linker on s390x and we are getting cmake tool build error. So we need to link with --action_env=BAZEL_LINKLIBS=-lstdc++ to fix this

```
[root@a8f7c98f3a46 envoy-openssl]# bazel build -c opt //source/exe:envoy-static --sandbox_debug --verbose_failures --//source/extensions/filters/common/lua:luajit2=1  --linkopt=-fuse-ld=gold
Starting local Bazel server and connecting to it...
INFO: Analyzed target //source/exe:envoy-static (1001 packages loaded, 65050 targets configured).
INFO: Found 1 target...
ERROR: /root/.cache/bazel/_bazel_root/e708ec56094462adb2c47f36d6f86338/external/rules_foreign_cc/toolchains/BUILD.bazel:161:11: Foreign Cc - Configure: Building cmake_tool.build [for tool] failed: (Exit 7): process-wrapper failed: error executing command 
  (cd /root/.cache/bazel/_bazel_root/e708ec56094462adb2c47f36d6f86338/sandbox/processwrapper-sandbox/621/execroot/envoy && \
  exec env - \
    CC=/usr/bin/clang \
    CXX=/usr/bin/clang++ \
    PATH=/bin:/usr/bin:/usr/local/bin \
    TMPDIR=/tmp \
  /root/.cache/bazel/_bazel_root/install/8d54c7dcc91a2873ced162e74478e202/process-wrapper '--timeout=0' '--kill_delay=15' '--stats=/root/.cache/bazel/_bazel_root/e708ec56094462adb2c47f36d6f86338/sandbox/processwrapper-sandbox/621/stats.out' /bin/bash -c bazel-out/s390x-opt-exec-2B5CBBC6/bin/external/rules_foreign_cc/toolchains/cmake_tool.build_foreign_cc/wrapper_build_script.sh)
rules_foreign_cc: Build failed!
rules_foreign_cc: Keeping temp build directory and dependencies directory for debug.
rules_foreign_cc: Please note that the directories inside a sandbox are still cleaned unless you specify --sandbox_debug Bazel command line flag.
rules_foreign_cc: Printing build logs:
_____ BEGIN BUILD LOGS _____

Bazel external C/C++ Rules. Building library cmake_tool.build

Environment:______________
BUILD_SCRIPT=bazel-out/s390x-opt-exec-2B5CBBC6/bin/external/rules_foreign_cc/toolchains/cmake_tool.build_foreign_cc/build_script.sh
EXT_BUILD_ROOT=/root/.cache/bazel/_bazel_root/e708ec56094462adb2c47f36d6f86338/sandbox/processwrapper-sandbox/621/execroot/envoy
BUILD_LOG=bazel-out/s390x-opt-exec-2B5CBBC6/bin/external/rules_foreign_cc/toolchains/cmake_tool.build_foreign_cc/Configure.log
PWD=/root/.cache/bazel/_bazel_root/e708ec56094462adb2c47f36d6f86338/sandbox/processwrapper-sandbox/621/execroot/envoy
CXX=/usr/bin/clang++
BUILD_WRAPPER_SCRIPT=bazel-out/s390x-opt-exec-2B5CBBC6/bin/external/rules_foreign_cc/toolchains/cmake_tool.build_foreign_cc/wrapper_build_script.sh
TMPDIR=/tmp
EXT_BUILD_DEPS=/root/.cache/bazel/_bazel_root/e708ec56094462adb2c47f36d6f86338/sandbox/processwrapper-sandbox/621/execroot/envoy/bazel-out/s390x-opt-exec-2B5CBBC6/bin/external/rules_foreign_cc/toolchains/cmake_tool.build.ext_build_deps
BUILD_TMPDIR=/root/.cache/bazel/_bazel_root/e708ec56094462adb2c47f36d6f86338/sandbox/processwrapper-sandbox/621/execroot/envoy/bazel-out/s390x-opt-exec-2B5CBBC6/bin/external/rules_foreign_cc/toolchains/cmake_tool.build.build_tmpdir
SHLVL=2
INSTALLDIR=/root/.cache/bazel/_bazel_root/e708ec56094462adb2c47f36d6f86338/sandbox/processwrapper-sandbox/621/execroot/envoy/bazel-out/s390x-opt-exec-2B5CBBC6/bin/external/rules_foreign_cc/toolchains/cmake_tool.build
PATH=/root/.cache/bazel/_bazel_root/e708ec56094462adb2c47f36d6f86338/sandbox/processwrapper-sandbox/621/execroot/envoy:/bin:/usr/bin:/usr/local/bin
CC=/usr/bin/clang
_=/bin/env
__________________________
+ mkdir -p /root/.cache/bazel/_bazel_root/e708ec56094462adb2c47f36d6f86338/sandbox/processwrapper-sandbox/621/execroot/envoy/bazel-out/s390x-opt-exec-2B5CBBC6/bin/external/rules_foreign_cc/toolchains/cmake_tool.build.build_tmpdir/cmake_tool.build
+ ARFLAGS=rcsD
+ AR_FLAGS=rcsD
+ ASFLAGS='-U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics -fno-omit-frame-pointer -g0 -O2 -D_FORTIFY_SOURCE=1 -DNDEBUG -ffunction-sections -fdata-sections -no-canonical-prefixes -Wno-builtin-macro-redefined -D_DATE_=redacted -D_TIMESTAMP_=redacted -D_TIME_=redacted -UDEBUG'
+ CFLAGS='-U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics -fno-omit-frame-pointer -g0 -O2 -D_FORTIFY_SOURCE=1 -DNDEBUG -ffunction-sections -fdata-sections -no-canonical-prefixes -Wno-builtin-macro-redefined -D_DATE_=redacted -D_TIMESTAMP_=redacted -D_TIME_=redacted -UDEBUG'
+ CXXFLAGS='-U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics -fno-omit-frame-pointer -g0 -O2 -D_FORTIFY_SOURCE=1 -DNDEBUG -ffunction-sections -fdata-sections -std=c++0x -no-canonical-prefixes -Wno-builtin-macro-redefined -D_DATE_=redacted -D_TIMESTAMP_=redacted -D_TIME_=redacted -std=c++17 -UDEBUG'
+ LDFLAGS='-fuse-ld=/usr/bin/ld.gold -Wl,-no-as-needed -Wl,-z,relro,-z,now -B/usr/bin -lm -Wl,--gc-sections -l:libstdc++.a'
+ AR=/usr/bin/ar
+ CC=/usr/bin/clang-14
+ CXX=/usr/bin/clang-14
+ RANLIB=:
+ CPPFLAGS=
+ /root/.cache/bazel/_bazel_root/e708ec56094462adb2c47f36d6f86338/sandbox/processwrapper-sandbox/621/execroot/envoy/external/cmake_src/bootstrap --prefix=/root/.cache/bazel/_bazel_root/e708ec56094462adb2c47f36d6f86338/sandbox/processwrapper-sandbox/621/execroot/envoy/bazel-out/s390x-opt-exec-2B5CBBC6/bin/external/rules_foreign_cc/toolchains/cmake_tool.build.build_tmpdir/cmake_tool.build -- -DCMAKE_MAKE_PROGRAM=/root/.cache/bazel/_bazel_root/e708ec56094462adb2c47f36d6f86338/sandbox/processwrapper-sandbox/621/execroot/envoy/bazel-out/s390x-opt-exec-2B5CBBC6/bin/external/rules_foreign_cc/toolchains/make/bin/make
---------------------------------------------
CMake 3.23.2, Copyright 2000-2022 Kitware, Inc. and Contributors
C compiler on this system is: /usr/bin/clang-14 -U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics -fno-omit-frame-pointer -g0 -O2 -D_FORTIFY_SOURCE=1 -DNDEBUG -ffunction-sections -fdata-sections -no-canonical-prefixes -Wno-builtin-macro-redefined -D_DATE_=redacted -D_TIMESTAMP_=redacted -D_TIME_=redacted -UDEBUG  
---------------------------------------------
Error when bootstrapping CMake:
Cannot find a C++ compiler that supports both C++11 and the specified C++ flags.
Please specify one using environment variable CXX.
The C++ flags are "-U_FORTIFY_SOURCE -fstack-protector -Wall -Wthread-safety -Wself-assign -Wunused-but-set-parameter -Wno-free-nonheap-object -fcolor-diagnostics -fno-omit-frame-pointer -g0 -O2 -D_FORTIFY_SOURCE=1 -DNDEBUG -ffunction-sections -fdata-sections -std=c++0x -no-canonical-prefixes -Wno-builtin-macro-redefined -D_DATE_=redacted -D_TIMESTAMP_=redacted -D_TIME_=redacted -std=c++17 -UDEBUG".
They can be changed using the environment variable CXXFLAGS.
See cmake_bootstrap.log for compilers attempted.
---------------------------------------------
Log of errors: /root/.cache/bazel/_bazel_root/e708ec56094462adb2c47f36d6f86338/sandbox/processwrapper-sandbox/621/execroot/envoy/bazel-out/s390x-opt-exec-2B5CBBC6/bin/external/rules_foreign_cc/toolchains/cmake_tool.build.build_tmpdir/Bootstrap.cmk/cmake_bootstrap.log
---------------------------------------------
_____ END BUILD LOGS _____
rules_foreign_cc: Build wrapper script location: bazel-out/s390x-opt-exec-2B5CBBC6/bin/external/rules_foreign_cc/toolchains/cmake_tool.build_foreign_cc/wrapper_build_script.sh
rules_foreign_cc: Build script location: bazel-out/s390x-opt-exec-2B5CBBC6/bin/external/rules_foreign_cc/toolchains/cmake_tool.build_foreign_cc/build_script.sh
rules_foreign_cc: Build log location: bazel-out/s390x-opt-exec-2B5CBBC6/bin/external/rules_foreign_cc/toolchains/cmake_tool.build_foreign_cc/Configure.log

Target //source/exe:envoy-static failed to build
INFO: Elapsed time: 230.164s, Critical Path: 78.35s
INFO: 3859 processes: 3181 internal, 1 local, 676 processwrapper-sandbox, 1 worker.
FAILED: Build did NOT complete successfully
```