### PR TITLE
Add missing changes for luajit2 on ppc64le

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -4,7 +4,8 @@ load("@envoy_api//bazel:external_deps.bzl", "load_repository_locations")
 load(":repository_locations.bzl", "PROTOC_VERSIONS", "REPOSITORY_LOCATIONS_SPEC")
 load("@com_google_googleapis//:repository_rules.bzl", "switched_rules_by_language")
 
-PPC_SKIP_TARGETS = ["envoy.filters.http.lua"]
+# ppc64le uses luajit2 so http.lua can be built
+PPC_SKIP_TARGETS = []
 
 WINDOWS_SKIP_TARGETS = [
     "envoy.extensions.http.cache.file_system_http_cache",

--- a/openssl/bazelrc
+++ b/openssl/bazelrc
@@ -17,3 +17,4 @@ test --test_tag_filters=-nofips
 
 # Arch-specific build flags, triggered with --config=$ARCH in bazel build command
 build:s390x --//source/extensions/filters/common/lua:luajit2=1 --copt="-Wno-deprecated-declarations" --action_env=BAZEL_LINKLIBS=-lstdc++ --linkopt=-fuse-ld=gold
+build:ppc --//source/extensions/filters/common/lua:luajit2=1 --linkopt=-fuse-ld=lld


### PR DESCRIPTION
Fixed issue to use luajit2 on ppc64le for envoy-openssl build. 
Some ppc64le related changes were missed in #231 , have resolved that.
