### PR TITLE
Patch to remove hard coded -lcrypto from proxy-wasm-cpp-host on s390x

### DIFF
--- a/bazel/proxy_wasm_cpp_host.patch
+++ b/bazel/proxy_wasm_cpp_host.patch
@@ -11,3 +11,28 @@ index 69c9bda..d293092 100644
      }),
      alwayslink = 1,
  )
+diff --git a/bazel/BUILD b/bazel/BUILD
+index 650fa29..733c975 100644
+--- a/bazel/BUILD
++++ b/bazel/BUILD
+@@ -57,19 +57,6 @@ config_setting(
+ )
+ 
+ config_setting(
+-    name = "requested_crypto_system",
+-    values = {"define": "crypto=system"},
+-)
+-
+-config_setting(
+-    name = "linux_s390x",
+-    values = {"cpu": "s390x"},
+-)
+-
+-selects.config_setting_group(
+     name = "crypto_system",
+-    match_any = [
+-        ":requested_crypto_system",
+-        ":linux_s390x",
+-    ],
++    values = {"define": "crypto=system"},
+ )


### PR DESCRIPTION
The proxy-wasm-cpp-host `bazel/BUILD` file adds the `-lcrypto` option to the link line if either `--define=crypto=system` is specified to bazel, or if building on s390x. This effectively means that on s390x, the `-lcrypto` linker option is *always* added and there's no way to remove it.

This updated patch removes that special s390x case, so that `-lcrypto` is *not* added to the link line unless `--define=crypto=system` is specified, the same as for all other architectures. In the context of envoy-openssl, this means that proxy-wasm-cpp-host, along with everything else, gets linked against `libbssl-compat.a` rather than `libcrypto.so`, which is what we need.