### PR TITLE
Removed "callback failed" error message from tls_inspector.cc

### DIFF
--- a/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
+++ b/source/extensions/filters/listener/tls_inspector/tls_inspector.cc
@@ -89,7 +89,7 @@ Config::Config(
 
         // Return an error to stop the handshake; we have what we wanted already.
         *out_alert = SSL_AD_USER_CANCELLED;
-        return SSL_TLSEXT_ERR_ALERT_FATAL;
+        return SSL_TLSEXT_ERR_OK;
       });
 }
 


### PR DESCRIPTION
The TLS inspector listener filter installs a servername callback (using `SSL_CTX_set_tlsext_servername_callback()`). That callback obtains the server name and then halts the handshake by returning `SSL_TLSEXT_ERR_ALERT_FATAL`. It does this because once it has obtained the server name, it has no need to progress the handshake any further because it's only "peeking" at the received data, and not actually doing the "real" handshake. In upstream envoy, on BoringSSL, this is OK, but on OpenSSL the `SSL_TLSEXT_ERR_ALERT_FATAL` return value causes a "callback failed" error message to be logged. It turns out this error message is innocuous, but it is unsightly and distracting, so this commit removes it by returning `SSL_TLSEXT_ERR_OK` instead.