### PR TITLE
[ppc64le] Disable cmake make Configuration Option

### DIFF
--- a/bazel/rules_foreign_cc.patch
+++ b/bazel/rules_foreign_cc.patch
@@ -49,3 +49,16 @@ index 0000000..f6f4cc8
 +                     : "cc", "2", "3", "memory"                   \
 +                    );                                            \
 +    _zzq_result;                                                  \
+diff --git a/foreign_cc/built_tools/cmake_build.bzl b/foreign_cc/built_tools/cmake_build.bzl
+index 5022504..9b5e2cd 100644
+--- a/foreign_cc/built_tools/cmake_build.bzl
++++ b/foreign_cc/built_tools/cmake_build.bzl
+@@ -8,7 +8,7 @@ def cmake_tool(name, srcs, **kwargs):
+     configure_make(
+         name = "{}.build".format(name),
+         configure_command = "bootstrap",
+-        configure_options = ["--", "-DCMAKE_MAKE_PROGRAM=$$MAKE$$"],
++        #configure_options = ["--", "-DCMAKE_MAKE_PROGRAM=$$MAKE$$"],
+         # On macOS at least -DDEBUG gets set for a fastbuild
+         copts = ["-UDEBUG"],
+         lib_source = srcs,


### PR DESCRIPTION
Adding patch for rules_foreign_cc to resolve cmake build
(https://github.com/bazel-contrib/rules_foreign_cc/tree/0.10.1)
To resolve error 

```
CMake Error: Generator: execution of make failed.
Target @rules_foreign_cc//toolchains:cmake_tool.build failed to build
```
