### PR TITLE
s390x/ppc - fixed depdency path for luajit2

### DIFF
--- a/source/extensions/filters/common/lua/BUILD
+++ b/source/extensions/filters/common/lua/BUILD
@@ -28,7 +28,6 @@ envoy_cc_library(
     srcs = ["lua.cc"],
     hdrs = ["lua.h"],
     deps = [
-        "//bazel/foreign_cc:luajit",
         "//envoy/thread_local:thread_local_interface",
         "//source/common/common:assert_lib",
         "//source/common/common:c_smart_ptr_lib",
@@ -36,8 +35,8 @@ envoy_cc_library(
         "//source/common/common:thread_lib",
         "//source/common/protobuf",
     ] + select({
-        ":with_luajit2": [envoy_external_dep_path("luajit2")],
-        "//conditions:default": [envoy_external_dep_path("luajit")],
+        ":with_luajit2": ["//bazel/foreign_cc:luajit2"],
+        "//conditions:default": ["//bazel/foreign_cc:luajit"],
     }),
 )
 


### PR DESCRIPTION
With addition of newer deps path in envoy 1.32 "//bazel/foreign_cc:luajit" luajit2 build was failing on Z/P. 

`[root@3adc8eeac21a envoy-openssl]# bazel build -c opt //source/exe:envoy-static --config=s390x --define=wasm=disable
d --cxxopt=-fpermissive --sandbox_debug --verbose_failures --local_cpu_resources=6 --local_ram_resources=61440 --job
s=3
INFO: Build option --copt has changed, discarding analysis cache.
INFO: Analyzed target //source/exe:envoy-static (1073 packages loaded, 72995 targets configured).
INFO: Found 1 target...
ERROR: /root/envoy-openssl/bazel/foreign_cc/BUILD:113:15: output 'bazel/foreign_cc/luajit/lib/libluajit-5.1.a' was n
ot created
ERROR: /root/envoy-openssl/bazel/foreign_cc/BUILD:113:15: Foreign Cc - Configure: Building luajit failed: not all ou
tputs were created or valid
Target //source/exe:envoy-static failed to build
INFO: Elapsed time: 1321.089s, Critical Path: 1311.13s
INFO: 754 processes: 20 internal, 734 processwrapper-sandbox.
FAILED: Build did NOT complete successfully`

Fixed with condition to select correct dependency path for luajit2.
