### PR TITLE
[ppc64le] Fixed ppc64le build failure for io_bazel_rules_go

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -108,7 +108,12 @@ def _go_deps(skip_targets):
     # Keep the skip_targets check around until Istio Proxy has stopped using
     # it to exclude the Go rules.
     if "io_bazel_rules_go" not in skip_targets:
-        external_http_archive(name = "io_bazel_rules_go")
+        external_http_archive(
+            name = "io_bazel_rules_go",
+            # TODO(wrowe, sunjayBhatia): remove when Windows RBE supports batch file invocation
+            patch_args = ["-p1"],
+            patches = ["@envoy//bazel:rules_go.patch"],
+        )
         external_http_archive("bazel_gazelle")
 
 def _rust_deps():

--- a/bazel/rules_go.patch
+++ b/bazel/rules_go.patch
@@ -1,0 +1,30 @@
+diff --git a/go/private/platforms.bzl b/go/private/platforms.bzl
+index ee6a1c76..ef5319a4 100644
+--- a/go/private/platforms.bzl
++++ b/go/private/platforms.bzl
+@@ -30,8 +30,7 @@ BAZEL_GOARCH_CONSTRAINTS = {
+     "amd64": "@platforms//cpu:x86_64",
+     "arm": "@platforms//cpu:armv7",
+     "arm64": "@platforms//cpu:aarch64",
+-    "ppc64": "@platforms//cpu:ppc",
+-    "ppc64le": "@platforms//cpu:ppc64le",
++    "ppc64le": "@platforms//cpu:ppc",
+     "s390x": "@platforms//cpu:s390x",
+ }
+ 
+diff --git a/go/private/rules/binary.bzl b/go/private/rules/binary.bzl
+index 40a17f4d..2741ad71 100644
+--- a/go/private/rules/binary.bzl
++++ b/go/private/rules/binary.bzl
+@@ -462,8 +462,9 @@ exit /b %GO_EXIT_CODE%
+             content = cmd,
+         )
+         ctx.actions.run(
+-            executable = bat,
+-            inputs = sdk.headers + sdk.tools + sdk.srcs + ctx.files.srcs + [sdk.go],
++            executable = "cmd.exe",
++            arguments = ["/S", "/C", bat.path.replace("/", "\\")],
++            inputs = sdk.headers + sdk.tools + sdk.srcs + ctx.files.srcs + [sdk.go, bat],
+             outputs = [out, gotmp],
+             mnemonic = "GoToolchainBinaryBuild",
+         )


### PR DESCRIPTION
ppc64le build is failing in proxy midstream CPAAS with the following error:

`ERROR: /root/.cache/bazel/_bazel_root/3be0275ba827ab9a624b25cbfec5d7ec/external/com_envoyproxy_protoc_gen_validate/BUILD.bazel:11:10: While resolving toolchains for target @com_envoyproxy_protoc_gen_validate//:protoc-gen-validate: No matching toolchains found for types @io_bazel_rules_go//go:toolchain`

Fix for https://issues.redhat.com/browse/OSSM-8522