### PR TITLE
Boringssl fix for Z/P platforms

### DIFF
--- a/bssl-compat/third_party/boringssl/src/include/openssl/target.h
+++ b/bssl-compat/third_party/boringssl/src/include/openssl/target.h
@@ -54,6 +54,10 @@
 #define OPENSSL_32_BIT
 #elif defined(__myriad2__)
 #define OPENSSL_32_BIT
+#elif defined(__s390__) || defined(__s390x__) || defined(__zarch__)
+#define OPENSSL_64_BIT
+#elif defined(__ppc64le__) || defined(__ARCH_PPC64LE__) || defined(_ARCH_PPC64)
+#define OPENSSL_64_BIT
 #else
 // The list above enumerates the platforms that BoringSSL supports. For these
 // platforms we keep a reasonable bar of not breaking them: automated test


### PR DESCRIPTION
Add s390x and arm64 target architectures in bssl-compat.
(see https://github.com/envoyproxy/envoy-openssl/pull/166 in 1.32)
