### PR TITLE
[1.32] Fix the CI image tag SHA

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -538,7 +538,7 @@ common:bes-envoy-engflow --bes_timeout=3600s
 common:bes-envoy-engflow --bes_upload_mode=fully_async
 common:bes-envoy-engflow --nolegacy_important_outputs
 common:rbe-envoy-engflow --remote_executor=grpcs://mordenite.cluster.engflow.com
-common:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://quay.io/jwendell/envoy-build-ubuntu@sha256:3eb12d3f8639ec7c6202c57c62db5fdf9e8abae1c74d9ec165b259407ab3c022
+common:rbe-envoy-engflow --remote_default_exec_properties=container-image=docker://quay.io/jwendell/envoy-build-ubuntu@sha256:3ab6f2ba384ca16153376e3c1c37334516a0db4dcdafa3b5860ce75e69c943e4
 common:rbe-envoy-engflow --jobs=200
 common:rbe-envoy-engflow --define=engflow_rbe=true
 

--- a/.github/workflows/envoy-openssl.yml
+++ b/.github/workflows/envoy-openssl.yml
@@ -33,4 +33,4 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         ENVOY_STDLIB: libstdc++
         IMAGE_NAME: quay.io/jwendell/envoy-build-ubuntu
-        IMAGE_ID: openssl-cb86d91cf406995012e330ab58830e6ee10240cb
+        IMAGE_ID: openssl-f94a38f62220a2b017878b790b6ea98a0f6c5f9c

--- a/bazel/rbe/toolchains/configs/linux/clang/config/BUILD
+++ b/bazel/rbe/toolchains/configs/linux/clang/config/BUILD
@@ -42,7 +42,7 @@ platform(
         "@bazel_tools//tools/cpp:clang",
     ],
     exec_properties = {
-        "container-image": "docker://quay.io/jwendell/envoy-build-ubuntu@sha256:3eb12d3f8639ec7c6202c57c62db5fdf9e8abae1c74d9ec165b259407ab3c022",
+        "container-image": "docker://quay.io/jwendell/envoy-build-ubuntu@sha256:3ab6f2ba384ca16153376e3c1c37334516a0db4dcdafa3b5860ce75e69c943e4",
         "OSFamily": "Linux",
     },
     parents = ["@local_config_platform//:host"],

--- a/bazel/rbe/toolchains/configs/linux/clang_libcxx/config/BUILD
+++ b/bazel/rbe/toolchains/configs/linux/clang_libcxx/config/BUILD
@@ -42,7 +42,7 @@ platform(
         "@bazel_tools//tools/cpp:clang",
     ],
     exec_properties = {
-        "container-image": "docker://quay.io/jwendell/envoy-build-ubuntu@sha256:3eb12d3f8639ec7c6202c57c62db5fdf9e8abae1c74d9ec165b259407ab3c022",
+        "container-image": "docker://quay.io/jwendell/envoy-build-ubuntu@sha256:3ab6f2ba384ca16153376e3c1c37334516a0db4dcdafa3b5860ce75e69c943e4",
         "OSFamily": "Linux",
     },
     parents = ["@local_config_platform//:host"],

--- a/bazel/rbe/toolchains/configs/linux/gcc/config/BUILD
+++ b/bazel/rbe/toolchains/configs/linux/gcc/config/BUILD
@@ -42,7 +42,7 @@ platform(
         "@bazel_tools//tools/cpp:clang",
     ],
     exec_properties = {
-        "container-image": "docker://quay.io/jwendell/envoy-build-ubuntu@sha256:3eb12d3f8639ec7c6202c57c62db5fdf9e8abae1c74d9ec165b259407ab3c022",
+        "container-image": "docker://quay.io/jwendell/envoy-build-ubuntu@sha256:3ab6f2ba384ca16153376e3c1c37334516a0db4dcdafa3b5860ce75e69c943e4",
         "OSFamily": "Linux",
     },
     parents = ["@local_config_platform//:host"],


### PR DESCRIPTION
The current SHA and tag
(`openssl-cb86d91cf406995012e330ab58830e6ee10240cb`) although contains the right contents, it's using the tag meant for 1.34 jobs.

This PR changes it to use the correct tag and SHA: `openssl-f94a38f62220a2b017878b790b6ea98a0f6c5f9c`.

This is the same tag used in [upstream 1.32
jobs](https://github.com/envoyproxy/envoy/blob/release/v1.32/.github/config.yml#L9), with the addition of the `openssl` prefix.
