### PR TITLE
bssl-compat: make Clang include path detection portable

### DIFF
--- a/bssl-compat/prefixer/CMakeLists.txt
+++ b/bssl-compat/prefixer/CMakeLists.txt
@@ -10,10 +10,21 @@ message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION} (${LLVM_INSTALL_PREFIX},${LLV
 list(APPEND CMAKE_MODULE_PATH ${LLVM_CMAKE_DIR})
 include(AddLLVM) # For llvm_update_compile_flags()
 
+# find include dir with clang header files
+find_program(CLANG_EXECUTABLE clang REQUIRED)
+
+execute_process(
+  COMMAND ${CLANG_EXECUTABLE} -print-resource-dir
+  OUTPUT_VARIABLE CLANG_RESOURCE_DIR_PATH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+set(CLANG_INCLUDE_DIR_PATH "${CLANG_RESOURCE_DIR_PATH}/include")
+message(STATUS "Passing Clang include path to prefixer: ${CLANG_INCLUDE_DIR_PATH}")
+
 add_executable(prefixer prefixer.cpp)
 llvm_update_compile_flags(prefixer) # Adds appropriate exception & rtti flags
 llvm_setup_rpath(prefixer)
-target_compile_definitions(prefixer PRIVATE LLVM_LIBRARY_DIR=\"${LLVM_LIBRARY_DIR}\")
+target_compile_definitions(prefixer PRIVATE CLANG_INCLUDE_DIR=\"${CLANG_INCLUDE_DIR_PATH}\")
 target_include_directories(prefixer PRIVATE "${LLVM_INCLUDE_DIRS}")
 target_link_directories(prefixer PRIVATE "${LLVM_LIBRARY_DIRS}")
 target_link_libraries(prefixer PRIVATE clang-cpp $<$<BOOL:${LLVM_LINK_LLVM_DYLIB}>:LLVM>)

--- a/bssl-compat/prefixer/prefixer.cpp
+++ b/bssl-compat/prefixer/prefixer.cpp
@@ -403,9 +403,7 @@ class CompilationDatabase : public clang::tooling::CompilationDatabase
       std::vector<std::string> cmdline = {
           "dummy",
           std::string("-I") + opt::incdir().string(),
-          // Some versions of clang ship with the full version string in the include path, others only with the major version number.
-          "-I" LLVM_LIBRARY_DIR "/clang/" LLVM_VERSION_STRING "/include/",
-          "-I" LLVM_LIBRARY_DIR "/clang/" + std::to_string(LLVM_VERSION_MAJOR) + "/include/",
+          "-I" CLANG_INCLUDE_DIR,
           file.str()
       };
       return { clang::tooling::CompileCommand(".", file, cmdline, "") };


### PR DESCRIPTION
Dynamically discover the Clang resource directory path by calling `clang -print-resource-dir`.

This fixes build failures on systems where the Clang include path is not in a location relative to the LLVM library directory (e.g., `/usr/lib` vs. `/usr/lib64`). The discovered path is passed to the C++ code as a preprocessor definition, making the solution generic.

