### PR TITLE
[BP/1.32] tls: fix of SAN validation for OTHERNAME types with embedded nulls

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -1262,17 +1262,17 @@ REPOSITORY_LOCATIONS_SPEC = dict(
     com_googlesource_googleurl = dict(
         project_name = "Chrome URL parsing library",
         project_desc = "Chrome URL parsing library",
-        project_url = "https://quiche.googlesource.com/googleurl",
+        project_url = "https://github.com/google/gurl",
         version = "dd4080fec0b443296c0ed0036e1e776df8813aa7",
-        sha256 = "fc694942e8a7491dcc1dde1bddf48a31370a1f46fef862bc17acf07c34dc6325",
-        # Static snapshot of https://quiche.googlesource.com/googleurl/+archive/dd4080fec0b443296c0ed0036e1e776df8813aa7.tar.gz
-        urls = ["https://storage.googleapis.com/quiche-envoy-integration/{version}.tar.gz"],
+        sha256 = "4ffa45a827646692e7b26e2a8c0dcbc1b1763a26def2fbbd82362970962a2fcf",
+        urls = ["https://github.com/google/gurl/archive/{version}.tar.gz"],
+        strip_prefix = "gurl-{version}",
         use_category = ["controlplane", "dataplane_core"],
         extensions = [],
         release_date = "2022-11-03",
         cpe = "N/A",
-        license = "googleurl",
-        license_url = "https://quiche.googlesource.com/googleurl/+/{version}/LICENSE",
+        license = "BSD-3-Clause",
+        license_url = "https://github.com/google/gurl/blob/{version}/LICENSE",
     ),
     com_google_cel_cpp = dict(
         project_name = "Common Expression Language (CEL) C++ library",

--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -288,11 +288,13 @@ target_add_bssl_include(bssl-compat
 
 # Case where simple mapping exists
 target_add_bssl_function(bssl-compat
+  ASN1_BMPSTRING_new
   ASN1_ENUMERATED_to_BN
   ASN1_IA5STRING_free
   ASN1_IA5STRING_new
   ASN1_IA5STRING_new
   ASN1_IA5STRING_new
+  ASN1_UNIVERSALSTRING_new
   ASN1_INTEGER_free
   ASN1_INTEGER_new
   ASN1_INTEGER_to_BN
@@ -307,6 +309,8 @@ target_add_bssl_function(bssl-compat
   ASN1_TIME_diff
   ASN1_TIME_new
   ASN1_TIME_set
+  ASN1_TYPE_new
+  ASN1_TYPE_set
   BIO_clear_flags
   BIO_clear_retry_flags
   BIO_clear_flags
@@ -428,6 +432,7 @@ target_add_bssl_function(bssl-compat
   EVP_sha384
   EVP_sha512
   GENERAL_NAME_set0_value
+  GENERAL_NAME_set0_othername
   HMAC
   HMAC_CTX_free
   HMAC_CTX_new

--- a/bssl-compat/patch/include/openssl/asn1.h.sh
+++ b/bssl-compat/patch/include/openssl/asn1.h.sh
@@ -36,4 +36,9 @@ uncomment.sh "$1" --comment -h \
   --uncomment-macro DECLARE_ASN1_ENCODE_FUNCTIONS \
   --uncomment-macro DECLARE_ASN1_ENCODE_FUNCTIONS_const \
   --uncomment-macro DECLARE_ASN1_FUNCTIONS_const \
-  --uncomment-macro DECLARE_ASN1_ALLOC_FUNCTIONS_name
+  --uncomment-macro DECLARE_ASN1_ALLOC_FUNCTIONS_name \
+  --uncomment-func-decl ASN1_UNIVERSALSTRING_new \
+  --uncomment-func-decl ASN1_BMPSTRING_new \
+  --uncomment-func-decl ASN1_TYPE_new \
+  --uncomment-func-decl ASN1_TYPE_set \
+

--- a/bssl-compat/patch/include/openssl/base.h.sh
+++ b/bssl-compat/patch/include/openssl/base.h.sh
@@ -110,5 +110,7 @@ uncomment.sh "$1" --comment -h \
   --uncomment-regex-range 'template\s*<typename\s*T,\s*typename\s*Enable\s*=\s*void>' 'struct\s*DeleterImpl\s*\{\};' \
   --uncomment-struct Deleter \
   --uncomment-regex-range 'template\s*<typename\s*T,\s*typename\s*CleanupRet,\s*void\s*(\*init)(T\s*\*),' '};$' \
-  --uncomment-regex 'template\s*<typename' 'using\s*UniquePtr'
+  --uncomment-regex 'template\s*<typename' 'using\s*UniquePtr' \
+  --uncomment-typedef-redef  ASN1_BMPSTRING \
+  --uncomment-typedef-redef  ASN1_UNIVERSALSTRING
 

--- a/bssl-compat/patch/include/openssl/x509v3.h.sh
+++ b/bssl-compat/patch/include/openssl/x509v3.h.sh
@@ -27,4 +27,5 @@ uncomment.sh "$1" --comment -h \
   --uncomment-regex 'BORINGSSL_MAKE_DELETER(NAME_CONSTRAINTS, NAME_CONSTRAINTS_free)' \
   --uncomment-macro-redef 'X509V3_R_[[:alnum:]_]*' \
   --uncomment-macro-redef 'X509V3_ADD_[[:alnum:]_]*' \
+  --uncomment-func-decl GENERAL_NAME_set0_othername \
 

--- a/changelogs/current.yaml
+++ b/changelogs/current.yaml
@@ -3,7 +3,12 @@ date: October 13, 2025
 bug_fixes:
 - area: dependency
   change: |
-    Resolve dependency CVEs:
+    Fixed a connection leak in the TCP proxy when the ``receive_before_connect`` feature is enabled and the
+    downstream connection closes before the upstream connection is established.
+- area: tls
+  change: |
+    Fixed an issue where SANs of type ``OTHERNAME`` in a TLS cert were truncated if there was
+    an embedded null octet, leading to incorrect SAN validation.
 
     - CVE-2025-0725: curl
     - CVE-2024-7246: gRPC

--- a/source/common/tls/utility.cc
+++ b/source/common/tls/utility.cc
@@ -296,22 +296,24 @@ std::string Utility::generalNameAsString(const GENERAL_NAME* general_name) {
       break;
     }
     case V_ASN1_BMPSTRING: {
-      // `ASN1_BMPSTRING` is encoded using `UCS-4`, which needs conversion to UTF-8.
+      // `ASN1_BMPSTRING` is encoded using `UTF-16`, which needs conversion to UTF-8.
       unsigned char* tmp = nullptr;
-      if (ASN1_STRING_to_UTF8(&tmp, value->value.bmpstring) < 0) {
+      int length = ASN1_STRING_to_UTF8(&tmp, value->value.bmpstring);
+      if (length < 0) {
         break;
       }
-      san.assign(reinterpret_cast<const char*>(tmp));
+      san.assign(reinterpret_cast<const char*>(tmp), length);
       OPENSSL_free(tmp);
       break;
     }
     case V_ASN1_UNIVERSALSTRING: {
       // `ASN1_UNIVERSALSTRING` is encoded using `UCS-4`, which needs conversion to UTF-8.
       unsigned char* tmp = nullptr;
-      if (ASN1_STRING_to_UTF8(&tmp, value->value.universalstring) < 0) {
+      int length = ASN1_STRING_to_UTF8(&tmp, value->value.universalstring);
+      if (length < 0) {
         break;
       }
-      san.assign(reinterpret_cast<const char*>(tmp));
+      san.assign(reinterpret_cast<const char*>(tmp), length);
       OPENSSL_free(tmp);
       break;
     }


### PR DESCRIPTION
Certificates with an OTHERNAME SAN using type `V_ASN1_UNIVERSALSTRING` or `V_ASN1_BMPSTRING` with an embedded null would have the name truncated at the first null, resulting in an incorrect check.
