### PR TITLE
fixing crash in prefixer.cpp

### DIFF
--- a/bssl-compat/prefixer/prefixer.cpp
+++ b/bssl-compat/prefixer/prefixer.cpp
@@ -783,7 +783,8 @@ int main(int argc, const char **argv) {
     }
   }
 
-  clang::tooling::ClangTool tool(CompilationDatabase(), { tmpfile });
+  CompilationDatabase compilationDB;
+  clang::tooling::ClangTool tool(compilationDB, { tmpfile });
   int ret = tool.run(clang::tooling::newFrontendActionFactory<MyFrontendAction>().get());
 
   std::filesystem::remove(tmpfile);


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/main/PULL_REQUESTS.md)
-->

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
