### PR TITLE
[bp/1.28] bssl-compat: clear error queue before SSL I/O to match BoringSSL

### DIFF
--- a/bssl-compat/CMakeLists.txt
+++ b/bssl-compat/CMakeLists.txt
@@ -151,6 +151,7 @@ add_library(bssl-compat STATIC
   source/SSL_CTX_set_verify.cc
   source/SSL_CTX_use_certificate.cc
   source/SSL_CTX_use_PrivateKey.cc
+  source/SSL_do_handshake.cc
   source/SSL_early_callback_ctx_extension_get.c
   source/SSL_enable_ocsp_stapling.cc
   source/SSL_error_description.cc
@@ -170,6 +171,7 @@ add_library(bssl-compat STATIC
   source/SSL_get_signature_algorithm_key_type.cc
   source/SSL_get_signature_algorithm_name.c
   source/SSL_is_signature_algorithm_rsa_pss.cc
+  source/SSL_read.cc
   source/SSL_send_fatal_alert.cc
   source/SSL_SESSION_from_bytes.c
   source/SSL_SESSION_get_ticket_lifetime_hint.cc
@@ -184,6 +186,8 @@ add_library(bssl-compat STATIC
   source/SSL_set_renegotiate_mode.cc
   source/SSL_set_info_callback.cc
   source/SSL_set_verify.cc
+  source/SSL_shutdown.cc
+  source/SSL_write.cc
   source/stack.c
   source/TLS_VERSION_to_string.cc
   source/TLS_with_buffers_method.cc
@@ -486,7 +490,6 @@ target_add_bssl_function(bssl-compat
   SSL_CTX_use_certificate_chain_file
   SSL_CTX_use_certificate_file
   SSL_CTX_use_PrivateKey_file
-  SSL_do_handshake
   SSL_free
   SSL_get_certificate
   SSL_get_current_cipher
@@ -504,7 +507,6 @@ target_add_bssl_function(bssl-compat
   SSL_is_server
   SSL_is_init_finished
   SSL_new
-  SSL_read
   SSL_select_next_proto
   SSL_SESSION_free
   SSL_SESSION_get_id
@@ -531,9 +533,7 @@ target_add_bssl_function(bssl-compat
   SSL_set1_curves_list
   SSL_state_string_long
   SSL_state_string
-  SSL_shutdown
   SSL_version
-  SSL_write
   TLS_client_method
   TLS_method
   TLS_server_method

--- a/bssl-compat/source/SSL_do_handshake.cc
+++ b/bssl-compat/source/SSL_do_handshake.cc
@@ -1,0 +1,8 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+int SSL_do_handshake(SSL *ssl) {
+  ossl.ossl_ERR_clear_error();
+  return ossl.ossl_SSL_do_handshake(ssl);
+}

--- a/bssl-compat/source/SSL_read.cc
+++ b/bssl-compat/source/SSL_read.cc
@@ -1,0 +1,8 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+extern "C" int SSL_read(SSL *ssl, void *buf, int num) {
+  ossl.ossl_ERR_clear_error();
+  return ossl.ossl_SSL_read(ssl, buf, num);
+}

--- a/bssl-compat/source/SSL_shutdown.cc
+++ b/bssl-compat/source/SSL_shutdown.cc
@@ -1,0 +1,8 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+int SSL_shutdown(SSL *ssl) {
+  ossl.ossl_ERR_clear_error();
+  return ossl.ossl_SSL_shutdown(ssl);
+}

--- a/bssl-compat/source/SSL_write.cc
+++ b/bssl-compat/source/SSL_write.cc
@@ -1,0 +1,8 @@
+#include <openssl/ssl.h>
+#include <ossl.h>
+
+
+int SSL_write(SSL *ssl, const void *buf, int num) {
+  ossl.ossl_ERR_clear_error();
+  return ossl.ossl_SSL_write(ssl, buf, num);
+}

--- a/bssl-compat/source/test/test_ssl.cc
+++ b/bssl-compat/source/test/test_ssl.cc
@@ -1855,3 +1855,72 @@ TEST(SSLTest, test_SSL_CTX_set_custom_verify_alert_codes) {
     ASSERT_STREQ(alert_string, static_cast<char*>(SSL_get_app_data(server_ssl.get())));
   }
 }
+
+
+struct SSLFunc {
+  const char *name;
+  void (*func)(SSL *ssl);
+};
+
+class SSLTestWithSSLFunc : public testing::TestWithParam<SSLFunc> {};
+
+TEST_P(SSLTestWithSSLFunc, test_func_clears_error_queue) {
+  bssl::UniquePtr<SSL_CTX> ctx(SSL_CTX_new(TLS_method()));
+  bssl::UniquePtr<SSL> ssl(SSL_new(ctx.get()));
+
+  // Push a stale error onto the thread error queue.
+  ERR_put_error(ERR_LIB_SSL, 0, SSL_R_BAD_SIGNATURE, __FILE__, __LINE__);
+  ASSERT_NE(0, ERR_peek_error());
+
+  // The function should clear the error queue before performing its job. We
+  // expect the call itself to fail (because there's no BIO attached to the
+  // SSL), but the stale error must be gone from the queue.
+  GetParam().func(ssl.get());
+
+  // Drain any errors that the function itself may have pushed, and verify that
+  // none of them are our stale SSL_R_BAD_SIGNATURE error.
+  while (unsigned long e = ERR_get_error()) {
+    EXPECT_NE(ERR_GET_REASON(e), SSL_R_BAD_SIGNATURE)
+     << GetParam().name << " did not clear the stale error";
+  }
+}
+
+// Instantiate a test for each SSL function that is knwon to pre-clear the error
+// queue in BoringSSL. Running against the real BoringSSL will confirm that it
+// does actually re-clear the error queue, while running aganst bssl-compat will
+// check that we have implemented the same behaviour.
+//
+// Note that the following functions should be added to this list when
+// bssl-compat implements them:
+// - SSL_peek()
+// - SSL_key_update()
+// - DTLSv1_handle_timeout()
+INSTANTIATE_TEST_SUITE_P(SSLTestWithSSLFunc, SSLTestWithSSLFunc,
+  ::testing::Values(
+    SSLFunc {
+      "SSL_do_handshake()",
+      [](SSL *ssl) { 
+        SSL_do_handshake(ssl);
+      },
+    },
+    SSLFunc {
+      "SSL_read()",
+      [](SSL *ssl) {
+        char buf[1];
+        SSL_read(ssl, buf, sizeof(buf));
+      },
+    },
+    SSLFunc {
+      "SSL_write()",
+      [](SSL *ssl) {
+        char buf[1];
+        SSL_write(ssl, buf, sizeof(buf));
+      }
+    },
+    SSLFunc {
+      "SSL_shutdown()",
+      [](SSL *ssl) {
+        SSL_shutdown(ssl);
+      }
+    }
+));


### PR DESCRIPTION
BoringSSL clears the error queue at the entry point of every SSL I/O function that a caller may subsequently pass to SSL_get_error(). OpenSSL does not. This causes stale errors left on the error queue by earlier operations (e.g. signature algorithm negotiation during handshake) to be misinterpreted and/or mis-reported by subsequent SSL operations, causing SSL_get_error() to give erroneous SSL_ERROR_SSL failures, when the actual result should be SSL_ERROR_WANT_READ, SSL_ERROR_WANT_WRITE, or SSL_ERROR_ZERO_RETURN.

Added ossl_ERR_clear_error() calls into the bssl-compat wrappers for SSL_read(), SSL_write(), SSL_do_handshake(), and SSL_shutdown() to match BoringSSL's documented behaviour.

Also added a utest that verifies that each of these functions does actually clear the error queue before performing its operation.