### PR TITLE
remove trailing backslashes in bssl-compat patches

### DIFF
--- a/bssl-compat/patch/include/openssl/bn.h.sh
+++ b/bssl-compat/patch/include/openssl/bn.h.sh
@@ -20,4 +20,4 @@ uncomment.sh "$1" --comment -h \
   --uncomment-func-decl BN_cmp_word \
   --uncomment-func-decl BN_ucmp \
   --uncomment-func-decl BN_bin2bn \
-  --uncomment-regex 'BORINGSSL_MAKE_DELETER(BIGNUM' \
+  --uncomment-regex 'BORINGSSL_MAKE_DELETER(BIGNUM'

--- a/bssl-compat/patch/include/openssl/conf.h.sh
+++ b/bssl-compat/patch/include/openssl/conf.h.sh
@@ -3,4 +3,4 @@
 set -euo pipefail
 
 uncomment.sh "$1" --comment \
-  --uncomment-macro-redef 'CONF_R_[a-zA-Z0-9_]*' \
+  --uncomment-macro-redef 'CONF_R_[a-zA-Z0-9_]*'

--- a/bssl-compat/patch/include/openssl/curve25519.h.sh
+++ b/bssl-compat/patch/include/openssl/curve25519.h.sh
@@ -6,4 +6,4 @@ uncomment.sh "$1" --comment -h \
   --uncomment-macro ED25519_PRIVATE_KEY_LEN \
   --uncomment-macro ED25519_PUBLIC_KEY_LEN \
   --uncomment-macro ED25519_SIGNATURE_LEN \
-  --uncomment-func-decl ED25519_verify \
+  --uncomment-func-decl ED25519_verify

--- a/bssl-compat/patch/include/openssl/dh.h.sh
+++ b/bssl-compat/patch/include/openssl/dh.h.sh
@@ -3,4 +3,4 @@
 set -euo pipefail
 
 uncomment.sh "$1" --comment \
-  --uncomment-macro-redef 'DH_R_[a-zA-Z0-9_]*' \
+  --uncomment-macro-redef 'DH_R_[a-zA-Z0-9_]*'

--- a/bssl-compat/patch/include/openssl/dsa.h.sh
+++ b/bssl-compat/patch/include/openssl/dsa.h.sh
@@ -3,4 +3,4 @@
 set -euo pipefail
 
 uncomment.sh "$1" --comment \
-  --uncomment-macro-redef 'DSA_R_[a-zA-Z0-9_]*' \
+  --uncomment-macro-redef 'DSA_R_[a-zA-Z0-9_]*'

--- a/bssl-compat/patch/include/openssl/ecdh.h.sh
+++ b/bssl-compat/patch/include/openssl/ecdh.h.sh
@@ -3,4 +3,4 @@
 set -euo pipefail
 
 uncomment.sh "$1" --comment \
-  --uncomment-macro-redef 'ECDH_R_[a-zA-Z0-9_]*' \
+  --uncomment-macro-redef 'ECDH_R_[a-zA-Z0-9_]*'

--- a/bssl-compat/patch/include/openssl/span.h.sh
+++ b/bssl-compat/patch/include/openssl/span.h.sh
@@ -21,4 +21,4 @@ uncomment.sh "$1" --comment -h \
   --uncomment-func-impl MakeConstSpan \
   --uncomment-func-impl MakeConstSpan \
   --uncomment-func-impl StringAsBytes \
-  --uncomment-func-impl BytesAsStringView \
+  --uncomment-func-impl BytesAsStringView

--- a/bssl-compat/patch/include/openssl/ssl.h.sh
+++ b/bssl-compat/patch/include/openssl/ssl.h.sh
@@ -215,4 +215,4 @@ uncomment.sh "$1" --comment -h \
   --uncomment-func-decl SSL_CIPHER_get_version \
   --uncomment-func-decl SSL_set0_CA_names \
   --uncomment-func-decl SSL_clear \
-  --uncomment-macro DTLS1_3_VERSION \
+  --uncomment-macro DTLS1_3_VERSION

--- a/bssl-compat/patch/include/openssl/stack.h.sh
+++ b/bssl-compat/patch/include/openssl/stack.h.sh
@@ -53,4 +53,4 @@ uncomment.sh "$1" --comment -h \
   --uncomment-func-decl sk_value \
   --uncomment-func-decl sk_free \
   --uncomment-macro OPENSSL_STACK \
-  --uncomment-macro _STACK \
+  --uncomment-macro _STACK

--- a/bssl-compat/patch/source/crypto/digest_extra/digest_test.cc.sh
+++ b/bssl-compat/patch/source/crypto/digest_extra/digest_test.cc.sh
@@ -9,4 +9,4 @@ uncomment.sh "$1" \
   --comment-regex-range '^\s*// BLAKE2b-256 tests' '},\s*$' \
   --comment-gtest-func DigestTest Getters \
   --comment-gtest-func DigestTest ASN1 \
-  --comment-gtest-func DigestTest TransformBlocks \
+  --comment-gtest-func DigestTest TransformBlocks

--- a/bssl-compat/patch/source/crypto/err/err_test.cc.sh
+++ b/bssl-compat/patch/source/crypto/err/err_test.cc.sh
@@ -9,4 +9,4 @@ uncomment.sh "$1" --comment \
   --uncomment-gtest-func ErrTest Overflow \
   --uncomment-gtest-func ErrTest ClearError \
   --uncomment-gtest-func ErrTest PreservesErrno \
-  --uncomment-gtest-func ErrTest UnknownError \
+  --uncomment-gtest-func ErrTest UnknownError

--- a/bssl-compat/patch/source/crypto/mem.cc.sh
+++ b/bssl-compat/patch/source/crypto/mem.cc.sh
@@ -6,4 +6,4 @@ uncomment.sh "$1" --comment \
   --uncomment-regex '#include\s*<openssl/' \
   --uncomment-func-impl OPENSSL_isdigit \
   --uncomment-func-impl OPENSSL_fromxdigit \
-  --uncomment-func-impl OPENSSL_isspace \
+  --uncomment-func-impl OPENSSL_isspace

--- a/bssl-compat/patch/source/crypto/pkcs8/pkcs12_test.cc.sh
+++ b/bssl-compat/patch/source/crypto/pkcs8/pkcs12_test.cc.sh
@@ -16,4 +16,4 @@ uncomment.sh "$1" --comment \
   --uncomment-gtest-func PKCS12Test TestEmptyPassword \
   --uncomment-gtest-func PKCS12Test TestNullPassword \
   --uncomment-gtest-func PKCS12Test TestUnicode \
-  --uncomment-gtest-func PKCS12Test TestWindowsCompat \
+  --uncomment-gtest-func PKCS12Test TestWindowsCompat

--- a/bssl-compat/patch/source/crypto/rand_extra/rand_test.cc.sh
+++ b/bssl-compat/patch/source/crypto/rand_extra/rand_test.cc.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 
 uncomment.sh "$1" \
   --comment-regex '#include "../fipsmodule/' \
-  --comment-regex '#include "../test/abi_test.h"' \
+  --comment-regex '#include "../test/abi_test.h"'

--- a/bssl-compat/patch/source/crypto/stack/stack_test.cc.sh
+++ b/bssl-compat/patch/source/crypto/stack/stack_test.cc.sh
@@ -3,4 +3,4 @@
 set -euo pipefail
 
 uncomment.sh "$1" \
-  --comment-gtest-func StackTest DeleteIf \
+  --comment-gtest-func StackTest DeleteIf

--- a/bssl-compat/patch/source/crypto/test/test_data.h.sh
+++ b/bssl-compat/patch/source/crypto/test/test_data.h.sh
@@ -2,5 +2,4 @@
 
 set -euo pipefail
 
-uncomment.sh "$1" --comment -h \
---uncomment-regex 'std::string\s*GetTestData\s*(.*);' \
+uncomment.sh "$1" --comment -h --uncomment-regex 'std::string\s*GetTestData\s*(.*);'

--- a/bssl-compat/patch/source/crypto/test/test_util.cc.sh
+++ b/bssl-compat/patch/source/crypto/test/test_util.cc.sh
@@ -6,4 +6,4 @@ uncomment.sh "$1" --comment -h \
   --uncomment-func-impl 'operator<<' \
   --uncomment-func-impl DecodeHex \
   --uncomment-func-impl EncodeHex \
-  --uncomment-func-impl ErrorEquals \
+  --uncomment-func-impl ErrorEquals


### PR DESCRIPTION
Newer bash versions can't handle them properly.

