### PR TITLE
[Release 1.34] Update buildkit to 0.28.1 (CVE-2026-33748)

### DIFF
--- a/ci/Dockerfile-buildkit
+++ b/ci/Dockerfile-buildkit
@@ -1,3 +1,3 @@
 # We dont build from this dockerfile - we just parse the version, but storing
 # here means we get the dependabot updates
-FROM moby/buildkit:v0.23.2
+FROM moby/buildkit:v0.28.1


### PR DESCRIPTION
Upgrade moby/buildkit to fix moderate CVE-2026-33748.