### PR TITLE
helpers for local development

### DIFF
--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -91,23 +91,23 @@ services:
   envoy-build:
     <<: *envoy-build-base
     volumes:
-    - ${ENVOY_DOCKER_BUILD_DIR:-/tmp/envoy-docker-build}:/build
-    - ${SOURCE_DIR:-..}:/source
-    - ${SHARED_TMP_DIR:-/tmp/bazel-shared}:${SHARED_TMP_DIR:-/tmp/bazel-shared}
+    - ${ENVOY_DOCKER_BUILD_DIR:-/tmp/envoy-docker-build}:/build:z
+    - ${SOURCE_DIR:-..}:/source:z
+    - ${SHARED_TMP_DIR:-/tmp/bazel-shared}:${SHARED_TMP_DIR:-/tmp/bazel-shared}:z
 
   envoy-build-gpg:
     <<: *envoy-build-base
     volumes:
-    - ${ENVOY_DOCKER_BUILD_DIR:-/tmp/envoy-docker-build}:/build
-    - ${SOURCE_DIR:-..}:/source
-    - ${ENVOY_GPG_DIR-${HOME}/.gnupg}:/build/.gnupg
-    - ${SHARED_TMP_DIR:-/tmp/bazel-shared}:${SHARED_TMP_DIR:-/tmp/bazel-shared}
+    - ${ENVOY_DOCKER_BUILD_DIR:-/tmp/envoy-docker-build}:/build:z
+    - ${SOURCE_DIR:-..}:/source:z
+    - ${ENVOY_GPG_DIR-${HOME}/.gnupg}:/build/.gnupg:z
+    - ${SHARED_TMP_DIR:-/tmp/bazel-shared}:${SHARED_TMP_DIR:-/tmp/bazel-shared}:z
 
   envoy-build-dind:
     privileged: true
     <<: *envoy-build-base
     volumes:
-    - ${ENVOY_DOCKER_BUILD_DIR:-/tmp/envoy-docker-build}:/build
-    - ${SOURCE_DIR:-..}:/source
-    - /var/run/docker.sock:/var/run/docker.sock
-    - ${SHARED_TMP_DIR:-/tmp/bazel-shared}:${SHARED_TMP_DIR:-/tmp/bazel-shared}
+    - ${ENVOY_DOCKER_BUILD_DIR:-/tmp/envoy-docker-build}:/build:z
+    - ${SOURCE_DIR:-..}:/source:z
+    - /var/run/docker.sock:/var/run/docker.sock:z
+    - ${SHARED_TMP_DIR:-/tmp/bazel-shared}:${SHARED_TMP_DIR:-/tmp/bazel-shared}:z

--- a/openssl/run_envoy_docker.sh
+++ b/openssl/run_envoy_docker.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -x
+set -euo pipefail
+
+# Change to the top dir
+cd "$(dirname "$0")/.."
+
+# Build with libstdc++ rather than libc++ because the bssl-compat prefixer tool
+# is linked against some of the LLVM libraries which require libstdc++
+export ENVOY_STDLIB=libstdc++
+
+# Tell the upstream run_envoy_docker.sh script to use our builder image
+export ENVOY_BUILD_IMAGE=$(grep ENVOY_BUILD_IMAGE .github/workflows/envoy-openssl.yml | awk '{print $2}')
+# Hand off to the upstream run_envoy_docker.sh script
+exec ./ci/run_envoy_docker.sh "$@"


### PR DESCRIPTION
- support selinux enabled systems
- add openssl/run_envoy_docker.sh script for easier local builds