### PR TITLE
v1.34: Raise default header limits for CVE-2026-47774 mitigation safety

### DIFF
--- a/api/envoy/api/v2/core/protocol.proto
+++ b/api/envoy/api/v2/core/protocol.proto
@@ -80,7 +80,7 @@ message HttpProtocolOptions {
   google.protobuf.Duration max_connection_duration = 3;
 
   // The maximum number of headers. If unconfigured, the default
-  // maximum number of request headers allowed is 100. Requests that exceed this limit will receive
+  // maximum number of request headers allowed is 1000. Requests that exceed this limit will receive
   // a 431 response for HTTP/1.x and cause a stream reset for HTTP/2.
   google.protobuf.UInt32Value max_headers_count = 2 [(validate.rules).uint32 = {gte: 1}];
 

--- a/api/envoy/config/core/v3/protocol.proto
+++ b/api/envoy/config/core/v3/protocol.proto
@@ -265,7 +265,7 @@ message HttpProtocolOptions {
 
   // The maximum number of headers (request headers if configured on HttpConnectionManager,
   // response headers when configured on a cluster).
-  // If unconfigured, the default maximum number of headers allowed is 100.
+  // If unconfigured, the default maximum number of headers allowed is 1000.
   // The default value for requests can be overridden by setting runtime key ``envoy.reloadable_features.max_request_headers_count``.
   // The default value for responses can be overridden by setting runtime key ``envoy.reloadable_features.max_response_headers_count``.
   // Downstream requests that exceed this limit will receive a 431 response for HTTP/1.x and cause a stream

--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -290,7 +290,7 @@ message HttpConnectionManager {
       [(validate.rules).enum = {defined_only: true}];
 
   // The maximum request headers size for incoming connections.
-  // If unconfigured, the default max request headers allowed is 60 KiB.
+  // If unconfigured, the default max request headers allowed is 128 KiB.
   // Requests that exceed this limit will receive a 431 response.
   google.protobuf.UInt32Value max_request_headers_kb = 29
       [(validate.rules).uint32 = {lte: 8192 gt: 0}];

--- a/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
+++ b/api/envoy/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto
@@ -484,7 +484,7 @@ message HttpConnectionManager {
   config.core.v3.SchemeHeaderTransformation scheme_header_transformation = 48;
 
   // The maximum request headers size for incoming connections.
-  // If unconfigured, the default max request headers allowed is 60 KiB.
+  // If unconfigured, the default max request headers allowed is 128 KiB.
   // The default value can be overridden by setting runtime key ``envoy.reloadable_features.max_request_headers_size_kb``.
   // Requests that exceed this limit will receive a 431 response.
   //

--- a/envoy/http/codec.h
+++ b/envoy/http/codec.h
@@ -36,10 +36,10 @@ namespace Http3 {
 struct CodecStats;
 }
 
-// Legacy default value of 60K is safely under both codec default limits.
-static constexpr uint32_t DEFAULT_MAX_REQUEST_HEADERS_KB = 60;
-// Default maximum number of headers.
-static constexpr uint32_t DEFAULT_MAX_HEADERS_COUNT = 100;
+// Safe default value for CVE-2026-47774 mitigation.
+static constexpr uint32_t DEFAULT_MAX_REQUEST_HEADERS_KB = 128;
+// Safe default for CVE-2026-47774 mitigation (cookie header expansion in H/2).
+static constexpr uint32_t DEFAULT_MAX_HEADERS_COUNT = 1000;
 
 const char MaxRequestHeadersCountOverrideKey[] =
     "envoy.reloadable_features.max_request_headers_count";

--- a/test/common/http/http1/codec_impl_test.cc
+++ b/test/common/http/http1/codec_impl_test.cc
@@ -3414,8 +3414,8 @@ TEST_P(Http1ClientConnectionImplTest, LowWatermarkDuringClose) {
 }
 
 TEST_P(Http1ServerConnectionImplTest, LargeTrailersRejected) {
-  // Default limit of 60 KiB
-  std::string long_string = "big: " + std::string(60 * 1024, 'q') + "\r\n\r\n\r\n";
+  // Default limit of 128 KiB
+  std::string long_string = "big: " + std::string(128 * 1024, 'q') + "\r\n\r\n\r\n";
   testTrailersExceedLimit(/*trailer_string*/ long_string,
                           /*error_message*/ "http/1.1 protocol error: trailers size exceeds limit",
                           /*enable_trailers*/ true,
@@ -3424,18 +3424,18 @@ TEST_P(Http1ServerConnectionImplTest, LargeTrailersRejected) {
 
 // Test that long trailer fields are consistently rejected.
 TEST_P(Http1ServerConnectionImplTest, LargeTrailerFieldRejected) {
-  // Construct partial headers with a long field name that exceeds the default limit of 60KiB.
-  std::string long_string = "bigfield" + std::string(60 * 1024, 'q');
+  // Construct partial headers with a long field name that exceeds the default limit of 128KiB.
+  std::string long_string = "bigfield" + std::string(128 * 1024, 'q');
   testTrailersExceedLimit(/*trailer_string*/ long_string,
                           /*error_message*/ "http/1.1 protocol error: trailers size exceeds limit",
                           /*enable_trailers*/ true,
                           /*expect_error*/ true);
 }
 
-// Tests that the default limit for the number of request headers is 100.
+// Tests that the default limit for the number of request headers is 1000.
 TEST_P(Http1ServerConnectionImplTest, ManyTrailersRejected) {
-  // Send a request with 101 headers.
-  testTrailersExceedLimit(/*trailer_string*/ createHeaderOrTrailerFragment(101) + "\r\n\r\n",
+  // Send a request with 1001 headers.
+  testTrailersExceedLimit(/*trailer_string*/ createHeaderOrTrailerFragment(1001) + "\r\n\r\n",
                           /*error_message*/ "http/1.1 protocol error: trailers count exceeds limit",
                           /*enable_trailers*/ true,
                           /*expect_error*/ true);
@@ -3446,7 +3446,7 @@ TEST_P(Http1ServerConnectionImplTest, ManyTrailersRejected) {
 TEST_P(Http1ServerConnectionImplTest, LargeTrailersRejectedIgnored) {
   // Send overly long trailers. http_parser will allow this if trailers are
   // disabled, balsa will not.
-  std::string long_string = "big: " + std::string(60 * 1024, 'q') + "\r\n\r\n\r\n";
+  std::string long_string = "big: " + std::string(128 * 1024, 'q') + "\r\n\r\n\r\n";
   testTrailersExceedLimit(/*trailer_string*/ long_string,
                           /*error_message*/ "http/1.1 protocol error: trailers size exceeds limit",
                           /*enable_trailers*/ false,
@@ -3456,18 +3456,18 @@ TEST_P(Http1ServerConnectionImplTest, LargeTrailersRejectedIgnored) {
 TEST_P(Http1ServerConnectionImplTest, LargeTrailerFieldRejectedIgnored) {
   // Send one overly long trailer. http_parser will allow this if trailers are
   // disabled, balsa will not.
-  std::string long_string = "bigfield" + std::string(60 * 1024, 'q') + ": value\r\n\r\n\r\n";
+  std::string long_string = "bigfield" + std::string(128 * 1024, 'q') + ": value\r\n\r\n\r\n";
   testTrailersExceedLimit(/*trailer_string*/ long_string,
                           /*error_message*/ "http/1.1 protocol error: trailers size exceeds limit",
                           /*enable_trailers*/ false,
                           /* expect_error */ parser_impl_ == Http1ParserImpl::BalsaParser);
 }
 
-// Tests that the default limit for the number of request headers is 100.
+// Tests that the default limit for the number of request headers is 1000.
 TEST_P(Http1ServerConnectionImplTest, ManyTrailersIgnored) {
-  // Send a request with 101 headers. Both balsa and http_parser ignore this
+  // Send a request with 1001 headers. Both balsa and http_parser ignore this
   // with trailers disabled.
-  testTrailersExceedLimit(/*trailer_string*/ createHeaderOrTrailerFragment(101) + "\r\n\r\n",
+  testTrailersExceedLimit(/*trailer_string*/ createHeaderOrTrailerFragment(1001) + "\r\n\r\n",
                           /*error_message*/ "http/1.1 protocol error: trailers count exceeds limit",
                           /*enable_trailers*/ false, /* expect_error */ false);
 }
@@ -3484,8 +3484,8 @@ TEST_P(Http1ServerConnectionImplTest, LargeRequestUrlRejected) {
         return decoder;
       }));
 
-  // Default limit of 60 KiB
-  std::string long_url = "/" + std::string(60 * 1024, 'q');
+  // Default limit of 128 KiB
+  std::string long_url = "/" + std::string(128 * 1024, 'q');
   Buffer::OwnedImpl buffer("GET " + long_url + " HTTP/1.1\r\n");
 
   auto status = codec_->dispatch(buffer);
@@ -3495,8 +3495,8 @@ TEST_P(Http1ServerConnectionImplTest, LargeRequestUrlRejected) {
 }
 
 TEST_P(Http1ServerConnectionImplTest, LargeRequestHeadersRejected) {
-  // Default limit of 60 KiB
-  std::string long_string = "big: " + std::string(60 * 1024, 'q') + "\r\n";
+  // Default limit of 128 KiB
+  std::string long_string = "big: " + std::string(128 * 1024, 'q') + "\r\n";
   testRequestHeadersExceedLimit(long_string, "http/1.1 protocol error: headers size exceeds limit",
                                 "http1.headers_too_large");
 }
@@ -3508,16 +3508,16 @@ TEST_P(Http1ServerConnectionImplTest, LargeRequestHeadersRejectedBeyondMaxConfig
                                 "http1.headers_too_large");
 }
 
-// Tests that the default limit for the number of request headers is 100.
+// Tests that the default limit for the number of request headers is 1000.
 TEST_P(Http1ServerConnectionImplTest, ManyRequestHeadersRejected) {
-  // Send a request with 101 headers.
-  testRequestHeadersExceedLimit(createHeaderOrTrailerFragment(101),
+  // Send a request with 1001 headers.
+  testRequestHeadersExceedLimit(createHeaderOrTrailerFragment(1001),
                                 "http/1.1 protocol error: headers count exceeds limit",
                                 "http1.too_many_headers");
 }
 
 TEST_P(Http1ServerConnectionImplTest, LargeRequestHeadersSplitRejected) {
-  // Default limit of 60 KiB
+  // Default limit of 128 KiB
   initialize();
 
   std::string exception_reason;
@@ -3532,11 +3532,11 @@ TEST_P(Http1ServerConnectionImplTest, LargeRequestHeadersSplitRejected) {
   auto status = codec_->dispatch(buffer);
 
   std::string long_string = std::string(1024, 'q');
-  for (int i = 0; i < 59; i++) {
+  for (int i = 0; i < 127; i++) {
     buffer = Buffer::OwnedImpl(fmt::format("big: {}\r\n", long_string));
     status = codec_->dispatch(buffer);
   }
-  // the 60th 1kb header should induce overflow
+  // the 128th 1kb header should induce overflow
   buffer = Buffer::OwnedImpl(fmt::format("big: {}\r\n", long_string));
   EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
   status = codec_->dispatch(buffer);
@@ -3575,10 +3575,10 @@ TEST_P(Http1ServerConnectionImplTest, LargeRequestHeadersSplitRejectedMaxConfigu
   EXPECT_EQ("http1.headers_too_large", response_encoder->getStream().responseDetails());
 }
 
-// Tests that the 101th request header causes overflow with the default max number of request
+// Tests that the 1001th request header causes overflow with the default max number of request
 // headers.
 TEST_P(Http1ServerConnectionImplTest, ManyRequestHeadersSplitRejected) {
-  // Default limit of 100.
+  // Default limit of 1000.
   initialize();
 
   std::string exception_reason;
@@ -3588,12 +3588,12 @@ TEST_P(Http1ServerConnectionImplTest, ManyRequestHeadersSplitRejected) {
   Buffer::OwnedImpl buffer("GET / HTTP/1.1\r\n");
   auto status = codec_->dispatch(buffer);
 
-  // Dispatch 100 headers.
-  buffer = Buffer::OwnedImpl(createHeaderOrTrailerFragment(100));
+  // Dispatch 1000 headers.
+  buffer = Buffer::OwnedImpl(createHeaderOrTrailerFragment(1000));
   status = codec_->dispatch(buffer);
 
-  // The final 101th header should induce overflow.
-  buffer = Buffer::OwnedImpl("header101:\r\n\r\n");
+  // The final 1001th header should induce overflow.
+  buffer = Buffer::OwnedImpl("header1001:\r\n\r\n");
   EXPECT_CALL(decoder, sendLocalReply(_, _, _, _, _));
   status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));
@@ -3906,7 +3906,7 @@ TEST_P(Http1ClientConnectionImplTest, ManyResponseHeadersRejected) {
 
   Buffer::OwnedImpl buffer("HTTP/1.1 200 OK\r\nContent-Length: 0\r\n");
   auto status = codec_->dispatch(buffer);
-  buffer = Buffer::OwnedImpl(createHeaderOrTrailerFragment(101) + "\r\n");
+  buffer = Buffer::OwnedImpl(createHeaderOrTrailerFragment(1001) + "\r\n");
 
   status = codec_->dispatch(buffer);
   EXPECT_TRUE(isCodecProtocolError(status));

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -1444,7 +1444,7 @@ TEST_P(Http2CodecImplTest, DumpsStreamlessConnectionWithoutAllocatingMemory) {
   EXPECT_THAT(
       ostream.contents(),
       HasSubstr(
-          "max_headers_kb_: 60, max_headers_count_: 100, "
+          "max_headers_kb_: 128, max_headers_count_: 1000, "
           "per_stream_buffer_limit_: 268435456, allow_metadata_: 0, "
           "stream_error_on_invalid_http_messaging_: 0, is_outbound_flood_monitored_control_frame_: "
           "0, dispatching_: 0, raised_goaway_: 0, "
@@ -2769,7 +2769,9 @@ TEST_P(Http2CodecImplTest, LargeRequestHeadersInvokeResetStream) {
   TestRequestHeaderMapImpl request_headers;
   HttpTestUtility::addDefaultHeaders(request_headers);
   std::string long_string = std::string(63 * 1024, 'q');
-  request_headers.addCopy("big", long_string);
+  request_headers.addCopy("big1", long_string);
+  request_headers.addCopy("big2", long_string);
+  request_headers.addCopy("big3", long_string);
   EXPECT_CALL(server_stream_callbacks_, onResetStream(_, _));
   if (Runtime::runtimeFeatureEnabled("envoy.reloadable_features.http2_propagate_reset_events")) {
     EXPECT_CALL(server_codec_event_callbacks_, onCodecLowLevelReset());
@@ -2872,13 +2874,13 @@ TEST_P(Http2CodecImplTest, LargeMethodRequestEncode) {
   driveToCompletion();
 }
 
-// Tests stream reset when the number of request headers exceeds the default maximum of 100.
+// Tests stream reset when the number of request headers exceeds the default maximum of 1000.
 TEST_P(Http2CodecImplTest, ManyRequestHeadersInvokeResetStream) {
   initialize();
 
   TestRequestHeaderMapImpl request_headers;
   HttpTestUtility::addDefaultHeaders(request_headers);
-  for (int i = 0; i < 100; i++) {
+  for (int i = 0; i < 1000; i++) {
     request_headers.addCopy(std::to_string(i), "");
   }
   EXPECT_CALL(server_stream_callbacks_, onResetStream(_, _));

--- a/test/common/upstream/upstream_impl_test.cc
+++ b/test/common/upstream/upstream_impl_test.cc
@@ -5826,7 +5826,7 @@ TEST_F(ClusterInfoImplTest, MaxResponseHeadersDefault) {
 
   auto cluster = makeCluster(yaml);
   EXPECT_FALSE(cluster->info()->maxResponseHeadersKb().has_value());
-  EXPECT_EQ(100, cluster->info()->maxResponseHeadersCount());
+  EXPECT_EQ(1000, cluster->info()->maxResponseHeadersCount());
 }
 
 // Test that the runtime override for the defaults is used when specified.

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -803,7 +803,7 @@ TEST_F(HttpConnectionManagerConfigTest, MaxRequestHeadersKbDefault) {
                                      &scoped_routes_config_provider_manager_, tracer_manager_,
                                      filter_config_provider_manager_, creation_status_);
   ASSERT_TRUE(creation_status_.ok());
-  EXPECT_EQ(60, config.maxRequestHeadersKb());
+  EXPECT_EQ(128, config.maxRequestHeadersKb());
 }
 
 TEST_F(HttpConnectionManagerConfigTest, MaxRequestHeadersKbConfigured) {
@@ -858,7 +858,7 @@ TEST_F(HttpConnectionManagerConfigTest, MaxRequestHeadersKbMaxConfiguredViaRunti
   )EOF";
 
   ON_CALL(context_.server_factory_context_.runtime_loader_.snapshot_,
-          getInteger("envoy.reloadable_features.max_request_headers_size_kb", 60))
+          getInteger("envoy.reloadable_features.max_request_headers_size_kb", 128))
       .WillByDefault(Return(9000));
 
   HttpConnectionManagerConfig config(parseHttpConnectionManagerFromYaml(yaml_string), context_,
@@ -994,7 +994,7 @@ TEST_F(HttpConnectionManagerConfigTest, DefaultMaxRequestHeaderCount) {
                                      &scoped_routes_config_provider_manager_, tracer_manager_,
                                      filter_config_provider_manager_, creation_status_);
   ASSERT_TRUE(creation_status_.ok());
-  EXPECT_EQ(100, config.maxRequestHeadersCount());
+  EXPECT_EQ(1000, config.maxRequestHeadersCount());
 }
 
 // Check that max request header count is configured.

--- a/test/integration/http2_flood_integration_test.cc
+++ b/test/integration/http2_flood_integration_test.cc
@@ -1584,7 +1584,7 @@ TEST_P(Http2FloodMitigationTest, HeadersContinuationObservesLimit) {
     sendFrame(request);
   }
 
-  // Expect request to be reset due to violation of the default limit of 100 headers
+  // Expect request to be reset due to violation of the default limit of 1000 headers
   auto response = readFrame();
   EXPECT_EQ(Http2Frame::Type::RstStream, response.type());
 

--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -2336,6 +2336,11 @@ TEST_P(Http2FrameIntegrationTest, MaxConcurrentStreamsIsRespected) {
 TEST_P(Http2FrameIntegrationTest, SetDetailsTwice) {
   autonomous_upstream_ = true;
   useAccessLog("%RESPONSE_FLAGS% %RESPONSE_CODE_DETAILS%");
+  config_helper_.addConfigModifier(
+      [&](envoy::extensions::filters::network::http_connection_manager::v3::HttpConnectionManager&
+              hcm) -> void {
+        hcm.mutable_common_http_protocol_options()->mutable_max_headers_count()->set_value(10);
+      });
   beginSession();
 
   // Send two concatenated frames, the first with too many headers, and the second an invalid frame

--- a/test/integration/multiplexed_upstream_integration_test.cc
+++ b/test/integration/multiplexed_upstream_integration_test.cc
@@ -506,15 +506,15 @@ typed_config:
   EXPECT_EQ(0, downstreamRxResetCounterValue());
 }
 
-// Tests the default limit for the number of response headers is 100. Results in a stream reset if
+// Tests the default limit for the number of response headers is 1000. Results in a stream reset if
 // exceeds.
 TEST_P(MultiplexedUpstreamIntegrationTest, TestManyResponseHeadersRejected) {
-  // Default limit for response headers is 100.
+  // Default limit for response headers is 1000.
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   Http::TestResponseHeaderMapImpl many_headers(default_response_headers_);
-  for (int i = 0; i < 100; i++) {
+  for (int i = 0; i < 1000; i++) {
     many_headers.addCopy(absl::StrCat("many", i), std::string(1, 'a'));
   }
   auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
@@ -554,13 +554,15 @@ TEST_P(MultiplexedUpstreamIntegrationTest, ManyResponseHeadersAccepted) {
   EXPECT_TRUE(response->complete());
 }
 
-// Tests that HTTP/2 response headers over 60 kB are rejected and result in a stream reset.
+// Tests that HTTP/2 response headers over 128 kB are rejected and result in a stream reset.
 TEST_P(MultiplexedUpstreamIntegrationTest, LargeResponseHeadersRejected) {
   initialize();
   codec_client_ = makeHttpConnection(lookupPort("http"));
 
   Http::TestResponseHeaderMapImpl large_headers(default_response_headers_);
-  large_headers.addCopy("large", std::string(60 * 1024, 'a'));
+  large_headers.addCopy("large1", std::string(63 * 1024, 'a'));
+  large_headers.addCopy("large2", std::string(63 * 1024, 'a'));
+  large_headers.addCopy("large3", std::string(63 * 1024, 'a'));
   auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
   waitForNextUpstreamRequest();
 

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -2623,11 +2623,11 @@ TEST_P(DownstreamProtocolIntegrationTest, ManyRequestHeadersAccepted) {
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, ManyRequestTrailersRejected) {
-  // Default header (and trailer) count limit is 100.
+  // Default header (and trailer) count limit is 1000.
   config_helper_.addConfigModifier(setEnableDownstreamTrailersHttp1());
   config_helper_.addConfigModifier(setEnableUpstreamTrailersHttp1());
   Http::TestRequestTrailerMapImpl request_trailers;
-  for (int i = 0; i < 150; i++) {
+  for (int i = 0; i < 1050; i++) {
     request_trailers.addCopy("trailer", std::string(1, 'a'));
   }
 


### PR DESCRIPTION
DEFAULT_MAX_REQUEST_HEADERS_KB: 60 → 128
DEFAULT_MAX_HEADERS_COUNT: 100 → 1000

The CVE-2026-47774 patch counts individual HTTP/2 cookie headers against header map limits, which can reject legitimate cookie-heavy traffic at the old defaults. These safe defaults recommended by upstream maintainers prevent breakage until upstream releases provide dedicated cookie-specific limits. Then this should be reverted.
