### PR TITLE
[bp/1.36] Set envoy_reloadable_features_http2_use_oghttp2=false by default (#42319)

### DIFF
--- a/source/common/runtime/runtime_features.cc
+++ b/source/common/runtime/runtime_features.cc
@@ -50,7 +50,6 @@ RUNTIME_GUARD(envoy_reloadable_features_http1_balsa_disallow_lone_cr_in_chunk_ex
 RUNTIME_GUARD(envoy_reloadable_features_http2_discard_host_header);
 RUNTIME_GUARD(envoy_reloadable_features_http2_include_cookies_in_limits);
 RUNTIME_GUARD(envoy_reloadable_features_http2_propagate_reset_events);
-RUNTIME_GUARD(envoy_reloadable_features_http2_use_oghttp2);
 RUNTIME_GUARD(envoy_reloadable_features_http3_remove_empty_cookie);
 // Delay deprecation and decommission until UHV is enabled.
 RUNTIME_GUARD(envoy_reloadable_features_http_reject_path_with_fragment);
@@ -217,6 +216,9 @@ FALSE_RUNTIME_GUARD(envoy_reloadable_features_fixed_heap_use_allocated);
 // TODO(yavlasov): Enabling by default will be hugely disruptive to existing traffic.
 // Replace with a config option (default off) post CVE release.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_reject_early_connect_data);
+// Flip back to true once performance aligns with nghttp2 and
+// https://github.com/envoyproxy/envoy/issues/40070 is resolved.
+FALSE_RUNTIME_GUARD(envoy_reloadable_features_http2_use_oghttp2);
 
 // Enable histograms of HTTP/2 header sizes, including cookie size.
 FALSE_RUNTIME_GUARD(envoy_reloadable_features_http2_record_histograms);


### PR DESCRIPTION
This is a temporary workaround for https://github.com/envoyproxy/envoy/issues/40070. In upstream it is available from v1.37 branch.
