### PR TITLE
[bp/v1.35] compat/openssl: Treat CRYPTO_set_mem_functions() failure as non-fatal

### DIFF
--- a/bssl-compat/prefixer/prefixer.cpp
+++ b/bssl-compat/prefixer/prefixer.cpp
@@ -558,10 +558,7 @@ void MyFrontendAction::EndSourceFileAction() {
          << "    exit(ELIBACC);" << std::endl
          << "  }" << std::endl
          << std::endl
-         << "  if (!set_mem_fn(ossl_malloc, ossl_realloc, ossl_free)) {" << std::endl
-         << "    fprintf(stderr, \"%s: CRYPTO_set_mem_functions() failed\\n\", __func__);" << std::endl
-         << "   exit(ELIBACC);" << std::endl
-         << " }" << std::endl
+         << "  set_mem_fn(ossl_malloc, ossl_realloc, ossl_free);" << std::endl
          << std::endl
          << "  if((libssl = ossl_dlopen(LIBSSL_SO)) == NULL) {" << std::endl
          << "    fprintf(stderr, \"%s: dlopen(%s) : %s\\n\", __func__, LIBSSL_SO, dlerror());" << std::endl


### PR DESCRIPTION
In some circumstances, libcrypto.so will perform some initial heap allocations during dlopen(), in which case subsequently calling CRYPTO_set_mem_functions() is not allowed. We should not treat this as a fatal error.

Back port of envoyproxy/envoy#46826