### PR TITLE
[bp/v1.34] compat/openssl: Treat CRYPTO_set_mem_functions() failure as non-fatal

### DIFF
--- a/bssl-compat/prefixer/prefixer.cpp
+++ b/bssl-compat/prefixer/prefixer.cpp
@@ -554,10 +554,7 @@ void MyFrontendAction::EndSourceFileAction() {
          << "    exit(ELIBACC);" << std::endl
          << "  }" << std::endl
          << std::endl
-         << "  if (!set_mem_fn(ossl_malloc, ossl_realloc, ossl_free)) {" << std::endl
-         << "    fprintf(stderr, \"%s: CRYPTO_set_mem_functions() failed\\n\", __func__);" << std::endl
-         << "   exit(ELIBACC);" << std::endl
-         << " }" << std::endl
+         << "  set_mem_fn(ossl_malloc, ossl_realloc, ossl_free);" << std::endl
          << std::endl
          << "  if((libssl = dlopen(LIBSSL_SO, RTLD_NOW | RTLD_LOCAL)) == NULL) {" << std::endl
          << "    fprintf(stderr, \"dlopen(%s) : %s\\n\", LIBSSL_SO, dlerror());" << std::endl


### PR DESCRIPTION
In some circumstances, libcrypto.so will perform some initial heap allocations during dlopen(), in which case subsequently calling CRYPTO_set_mem_functions() is not allowed. We should not treat this as a fatal error.

Back port of envoyproxy/envoy#46826