### PR TITLE
CVE backports to release/v1.32 (part 2): oghttp2 trailers END_STREAM + scoped IPv6 for QUIC

### DIFF
--- a/bazel/external/oghttp2_trailer_fix.patch
+++ b/bazel/external/oghttp2_trailer_fix.patch
@@ -1,0 +1,191 @@
+diff --git a/quiche/http2/adapter/oghttp2_session.cc b/quiche/http2/adapter/oghttp2_session.cc
+index 74584c0..be5c1d2 100644
+--- a/quiche/http2/adapter/oghttp2_session.cc
++++ b/quiche/http2/adapter/oghttp2_session.cc
+@@ -276,6 +276,13 @@ void OgHttp2Session::PassthroughHeadersHandler::OnHeaderBlockEnd(
+     SetResult(Http2VisitorInterface::HEADER_HTTP_MESSAGING);
+     return;
+   }
++  if ((type_ == HeaderType::REQUEST_TRAILER ||
++       type_ == HeaderType::RESPONSE_TRAILER) &&
++      !frame_contains_fin_) {
++    QUICHE_VLOG(1) << "Trailers must contain END_STREAM";
++    SetResult(Http2VisitorInterface::HEADER_HTTP_MESSAGING);
++    return;
++  }
+   if (frame_contains_fin_ && IsResponse(type_) &&
+       StatusIs1xx(status_header())) {
+     QUICHE_VLOG(1) << "Unexpected end of stream without final headers";
+diff --git a/quiche/http2/adapter/oghttp2_session_test.cc b/quiche/http2/adapter/oghttp2_session_test.cc
+index 654bde1..8267fae 100644
+--- a/quiche/http2/adapter/oghttp2_session_test.cc
++++ b/quiche/http2/adapter/oghttp2_session_test.cc
+@@ -1079,6 +1079,168 @@ TEST(OgHttp2SessionTest, ServerSeesErrorOnEndStream) {
+   EXPECT_FALSE(session.want_write());
+ }
+ 
++TEST(OgHttp2SessionTest, ClientReceivesTrailersWithoutEndStream) {
++  TestVisitor visitor;
++  OgHttp2Session::Options options;
++  options.perspective = Perspective::kClient;
++  OgHttp2Session session(visitor, options);
++
++  // Send client preface.
++  EXPECT_CALL(visitor, OnBeforeFrameSent(SETTINGS, 0, _, 0x0));
++  EXPECT_CALL(visitor, OnFrameSent(SETTINGS, 0, _, 0x0, 0));
++  int send_result = session.Send();
++  EXPECT_EQ(0, send_result);
++  visitor.Clear();
++
++  // Submit a request.
++  int stream_id =
++      session.SubmitRequest(ToHeaders({{":method", "GET"},
++                                       {":scheme", "http"},
++                                       {":authority", "example.com"},
++                                       {":path", "/"}}),
++                            true, nullptr);
++  ASSERT_EQ(stream_id, 1);
++
++  // Send the request HEADERS.
++  // 0x5 is END_STREAM | END_HEADERS.
++  EXPECT_CALL(visitor, OnBeforeFrameSent(HEADERS, stream_id, _, 0x5));
++  EXPECT_CALL(visitor, OnFrameSent(HEADERS, stream_id, _, 0x5, 0));
++  send_result = session.Send();
++  EXPECT_EQ(0, send_result);
++  visitor.Clear();
++
++  // Server sends preface, response headers, and then invalid trailers.
++  const std::string frames = TestFrameSequence()
++                                 .ServerPreface()
++                                 .Headers(1, {{":status", "200"}},
++                                          /*fin=*/false)
++                                 // Trailers without END_STREAM (fin=false)
++                                 .Headers(1, {{"final-status", "a-ok"}},
++                                          /*fin=*/false)
++                                 .Serialize();
++
++  testing::InSequence s;
++
++  // Server preface (empty SETTINGS)
++  EXPECT_CALL(visitor, OnFrameHeader(0, 0, SETTINGS, 0));
++  EXPECT_CALL(visitor, OnSettingsStart());
++  EXPECT_CALL(visitor, OnSettingsEnd());
++
++  // Response headers (4 is END_HEADERS)
++  EXPECT_CALL(visitor, OnFrameHeader(stream_id, _, HEADERS, 4));
++  EXPECT_CALL(visitor, OnBeginHeadersForStream(stream_id));
++  EXPECT_CALL(visitor, OnHeaderForStream(stream_id, ":status", "200"));
++  EXPECT_CALL(visitor, OnEndHeadersForStream(stream_id));
++
++  // Trailers (4 is END_HEADERS)
++  EXPECT_CALL(visitor, OnFrameHeader(stream_id, _, HEADERS, 4));
++  EXPECT_CALL(visitor, OnBeginHeadersForStream(stream_id));
++  EXPECT_CALL(visitor, OnHeaderForStream(stream_id, "final-status", "a-ok"));
++
++  // The fix should trigger OnInvalidFrame because of the missing END_STREAM.
++  EXPECT_CALL(
++      visitor,
++      OnInvalidFrame(stream_id,
++                     Http2VisitorInterface::InvalidFrameError::kHttpMessaging));
++
++  const int64_t result = session.ProcessBytes(frames);
++  EXPECT_EQ(frames.size(), static_cast<size_t>(result));
++
++  // Session should want to write SETTINGS ACK and RST_STREAM.
++  EXPECT_TRUE(session.want_write());
++
++  // We expect SETTINGS ACK.
++  EXPECT_CALL(visitor, OnBeforeFrameSent(SETTINGS, 0, 0, 0x1));
++  EXPECT_CALL(visitor, OnFrameSent(SETTINGS, 0, 0, 0x1, 0));
++
++  // We expect RST_STREAM due to the invalid trailers.
++  EXPECT_CALL(visitor, OnBeforeFrameSent(RST_STREAM, stream_id, _, 0x0));
++  EXPECT_CALL(visitor,
++              OnFrameSent(RST_STREAM, stream_id, _, 0x0,
++                          static_cast<int>(Http2ErrorCode::PROTOCOL_ERROR)));
++  EXPECT_CALL(visitor,
++              OnCloseStream(stream_id, Http2ErrorCode::HTTP2_NO_ERROR));
++
++  send_result = session.Send();
++  EXPECT_EQ(0, send_result);
++}
++
++// Regression test for receiving a second HEADERS frame without
++// END_STREAM on an existing stream on server side.
++// In current implementation, it is misinterpreted by
++// OgHttp2Session::OnHeaders as an attempt to open a new stream. Since the
++// stream ID has already been processed, it immediately triggers a
++// ConnectionError::kInvalidNewStreamId (connection error) before our
++// validation logic in OnHeaderBlockEnd can run. This still safely prevents
++// the UAF/crash, albeit via a connection teardown instead of a stream reset.
++TEST(OgHttp2SessionTest, ServerReceivesTrailersWithoutEndStream) {
++  TestVisitor visitor;
++  OgHttp2Session::Options options;
++  options.perspective = Perspective::kServer;
++  OgHttp2Session session(visitor, options);
++
++  // Send server preface (initial settings).
++  EXPECT_CALL(visitor, OnBeforeFrameSent(SETTINGS, 0, _, 0x0));
++  EXPECT_CALL(visitor, OnFrameSent(SETTINGS, 0, _, 0x0, 0));
++  int send_result = session.Send();
++  EXPECT_EQ(0, send_result);
++  visitor.Clear();
++
++  // Client sends preface, request headers, and then invalid trailers.
++  const std::string frames = TestFrameSequence()
++                                 .ClientPreface()
++                                 .Headers(1,
++                                          {{":method", "POST"},
++                                           {":scheme", "https"},
++                                           {":authority", "example.com"},
++                                           {":path", "/"}},
++                                          /*fin=*/false)
++                                 // Trailers without END_STREAM (fin=false)
++                                 .Headers(1, {{"customer-header", "value"}},
++                                          /*fin=*/false)
++                                 .Serialize();
++
++  testing::InSequence s;
++
++  // Client preface (empty SETTINGS)
++  EXPECT_CALL(visitor, OnFrameHeader(0, 0, SETTINGS, 0));
++  EXPECT_CALL(visitor, OnSettingsStart());
++  EXPECT_CALL(visitor, OnSettingsEnd());
++
++  // Request headers (4 is END_HEADERS)
++  EXPECT_CALL(visitor, OnFrameHeader(1, _, HEADERS, 4));
++  EXPECT_CALL(visitor, OnBeginHeadersForStream(1));
++  EXPECT_CALL(visitor, OnHeaderForStream(1, ":method", "POST"));
++  EXPECT_CALL(visitor, OnHeaderForStream(1, ":scheme", "https"));
++  EXPECT_CALL(visitor, OnHeaderForStream(1, ":authority", "example.com"));
++  EXPECT_CALL(visitor, OnHeaderForStream(1, ":path", "/"));
++  EXPECT_CALL(visitor, OnEndHeadersForStream(1));
++
++  // Trailers (4 is END_HEADERS)
++  EXPECT_CALL(visitor, OnFrameHeader(1, _, HEADERS, 4));
++
++  // It fails immediately in OnHeaders because fin is false on an existing
++  // stream, which is interpreted as a new stream with an invalid (already used)
++  // ID.
++  EXPECT_CALL(visitor,
++              OnConnectionError(
++                  Http2VisitorInterface::ConnectionError::kInvalidNewStreamId));
++
++  const int64_t result = session.ProcessBytes(frames);
++  EXPECT_GT(result, 0);
++
++  // Session should want to write GOAWAY.
++  EXPECT_TRUE(session.want_write());
++
++  // We expect GOAWAY.
++  EXPECT_CALL(visitor, OnBeforeFrameSent(GOAWAY, 0, _, 0x0));
++  EXPECT_CALL(visitor,
++              OnFrameSent(GOAWAY, 0, _, 0x0, 1));  // 1 is PROTOCOL_ERROR
++
++  send_result = session.Send();
++  EXPECT_EQ(0, send_result);
++}
++
+ }  // namespace test
+ }  // namespace adapter
+ }  // namespace http2

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -783,6 +783,11 @@ def _com_googlesource_chromium_base_trace_event_common():
 def _com_github_google_quiche():
     external_http_archive(
         name = "com_github_google_quiche",
+        patch_args = ["-p1"],
+        patches = [
+            "@envoy//bazel/external:oghttp2_trailer_fix.patch",
+        ],
+        patch_tool = "patch",
         patch_cmds = ["find quiche/ -type f -name \"*.bazel\" -delete"],
         build_file = "@envoy//bazel/external:quiche.BUILD",
     )

--- a/changelogs/current/bug_fixes/http2__fix-crash-on-trailers-without-eos.rst
+++ b/changelogs/current/bug_fixes/http2__fix-crash-on-trailers-without-eos.rst
@@ -1,0 +1,4 @@
+Fix: `GHSA-jjmm-fw8p-crpw <https://github.com/envoyproxy/envoy/security/advisories/GHSA-jjmm-fw8p-crpw>`_
+
+Fixed abnormal process termination when Envoy receives trailers without the END_STREAM flag
+over HTTP/2 protocol.

--- a/changelogs/current/bug_fixes/quic__fixed-crash-handling-scoped-ipv6-addresses.rst
+++ b/changelogs/current/bug_fixes/quic__fixed-crash-handling-scoped-ipv6-addresses.rst
@@ -1,0 +1,3 @@
+Fix: `GHSA-jp5f-qr64-c9vw <https://github.com/envoyproxy/envoy/security/advisories/GHSA-jp5f-qr64-c9vw>`_
+
+Fixed a crash when handling scoped IPv6 addresses in QUIC client connection and Original Dst cluster.

--- a/source/common/network/connection_impl.cc
+++ b/source/common/network/connection_impl.cc
@@ -1012,6 +1012,15 @@ ClientConnectionImpl::ClientConnectionImpl(
   }
 }
 
+ClientConnectionImpl::~ClientConnectionImpl() {
+  // Ensure the connection (and its underlying socket) is closed before stream_info_, which is
+  // owned by this class, is destroyed and before the base ConnectionImpl destructor runs its
+  // open-socket assert. Without this, a client connection that is still open at destruction time
+  // (e.g. an in-progress/unreachable scoped IPv6 upstream connect) trips the
+  // "ConnectionImpl destroyed with open socket" assert in ~ConnectionImpl().
+  close(ConnectionCloseType::NoFlush);
+}
+
 void ClientConnectionImpl::connect() {
   ENVOY_CONN_LOG_EVENT(debug, "client_connection", "connecting to {}", *this,
                        socket_->connectionInfoProvider().remoteAddress()->asString());

--- a/source/common/network/connection_impl.h
+++ b/source/common/network/connection_impl.h
@@ -286,6 +286,8 @@ public:
                        const Network::ConnectionSocket::OptionsSharedPtr& options,
                        const Network::TransportSocketOptionsConstSharedPtr& transport_options);
 
+  ~ClientConnectionImpl() override;
+
   // Network::ClientConnection
   void connect() override;
 

--- a/source/common/quic/envoy_quic_client_connection.cc
+++ b/source/common/quic/envoy_quic_client_connection.cc
@@ -173,13 +173,7 @@ void EnvoyQuicClientConnection::probeWithNewPort(const quic::QuicSocketAddress& 
       connectionSocket()->connectionInfoProvider().localAddress();
   // Creates an IP address with unset port. The port will be set when the new socket is created.
   Network::Address::InstanceConstSharedPtr new_local_address;
-  if (current_local_address->ip()->version() == Network::Address::IpVersion::v4) {
-    new_local_address = std::make_shared<Network::Address::Ipv4Instance>(
-        current_local_address->ip()->addressAsString(), &current_local_address->socketInterface());
-  } else {
-    new_local_address = std::make_shared<Network::Address::Ipv6Instance>(
-        current_local_address->ip()->addressAsString(), &current_local_address->socketInterface());
-  }
+  new_local_address = Network::Utility::getAddressWithPort(*current_local_address, 0);
 
   // The probing socket will have the same host but a different port.
   auto probing_socket = createConnectionSocket(

--- a/source/extensions/clusters/original_dst/original_dst_cluster.cc
+++ b/source/extensions/clusters/original_dst/original_dst_cluster.cc
@@ -70,7 +70,7 @@ HostConstSharedPtr OriginalDstCluster::LoadBalancer::chooseHost(LoadBalancerCont
       const Network::Address::Ip* dst_ip = dst_addr.ip();
       if (dst_ip) {
         Network::Address::InstanceConstSharedPtr host_ip_port(
-            Network::Utility::copyInternetAddressAndPort(*dst_ip));
+            Network::Utility::getAddressWithPort(dst_addr, dst_ip->port()));
         // Create a host we can use immediately.
         auto info = parent_->cluster_->info();
         HostSharedPtr host(std::make_shared<HostImpl>(

--- a/test/common/quic/envoy_quic_client_session_test.cc
+++ b/test/common/quic/envoy_quic_client_session_test.cc
@@ -854,5 +854,33 @@ TEST_P(EnvoyQuicClientSessionAllowMmsgTest, UsesRecvMmsgWhenNoGroAndMmsgAllowed)
                       dispatcher_->run(Event::Dispatcher::RunType::RunUntilExit));
 }
 
+TEST_P(EnvoyQuicClientSessionTest, ScopedIpv6PortMigrationCrash) {
+  // Create a local address with scope ID 1.
+  sockaddr_in6 sa6_local;
+  memset(&sa6_local, 0, sizeof(sa6_local));
+  sa6_local.sin6_family = AF_INET6;
+  sa6_local.sin6_port = htons(54321);
+  sa6_local.sin6_scope_id = 1;
+  inet_pton(AF_INET6, "fe80::1", &sa6_local.sin6_addr);
+  auto scoped_v6_local_addr = std::make_shared<Network::Address::Ipv6Instance>(sa6_local);
+
+  // Create an IPv6 remote address.
+  sockaddr_in6 sa6_remote;
+  memset(&sa6_remote, 0, sizeof(sa6_remote));
+  sa6_remote.sin6_family = AF_INET6;
+  sa6_remote.sin6_port = htons(80);
+  inet_pton(AF_INET6, "2001:db8::1", &sa6_remote.sin6_addr);
+  auto v6_remote_addr = std::make_shared<Network::Address::Ipv6Instance>(sa6_remote);
+
+  quic_connection_->connectionSocket()->connectionInfoProvider().setLocalAddress(
+      scoped_v6_local_addr);
+  quic_connection_->connectionSocket()->connectionInfoProvider().setRemoteAddress(v6_remote_addr);
+
+  // SPELLCHECKER(off)
+  // Trigger port migration. Under the vulnerable implementation, this will throw an EnvoyException
+  // (invalid ipv6 address 'fe80::1%1') and fail the test.
+  // SPELLCHECKER(on)
+  EXPECT_NO_THROW(quic_connection_->OnPathDegradingDetected());
+}
 } // namespace Quic
 } // namespace Envoy

--- a/test/extensions/filters/listener/original_dst/original_dst_integration_test.cc
+++ b/test/extensions/filters/listener/original_dst/original_dst_integration_test.cc
@@ -84,6 +84,35 @@ TEST_P(OriginalDstIntegrationTest, OriginalDstHttpManyConnections) {
   }
 }
 
+TEST_P(OriginalDstIntegrationTest, ScopedIpv6OriginalDstCrash) {
+  config_helper_.addConfigModifier([](envoy::config::bootstrap::v3::Bootstrap& bootstrap) {
+    RELEASE_ASSERT(bootstrap.mutable_static_resources()->clusters_size() == 1, "");
+    auto& cluster = *bootstrap.mutable_static_resources()->mutable_clusters(0);
+    cluster.clear_load_balancing_policy();
+
+    cluster.set_type(envoy::config::cluster::v3::Cluster::ORIGINAL_DST);
+    cluster.set_lb_policy(envoy::config::cluster::v3::Cluster::CLUSTER_PROVIDED);
+    cluster.mutable_original_dst_lb_config()->set_use_http_header(true);
+    cluster.clear_load_assignment();
+  });
+
+  initialize();
+
+  // Send a raw HTTP/1.1 request with a scoped link-local IPv6 in the override header.
+  auto tcp = makeTcpConnection(lookupPort("http"));
+  ASSERT_TRUE(tcp->write("GET / HTTP/1.1\r\n"
+                         "Host: h\r\n"
+                         "x-envoy-original-dst-host: [fe80::1%1]:80\r\n"
+                         "\r\n",
+                         false));
+
+  // Since chooseHost() now successfully handles the scoped IPv6 address without throwing/aborting,
+  // Envoy should gracefully handle the request and return a 503 response because the target is
+  // unreachable.
+  tcp->waitForData("HTTP/1.1 503");
+  EXPECT_TRUE(absl::StartsWith(tcp->data(), "HTTP/1.1 503"));
+}
+
 class OriginalDstTcpProxyIntegrationTest
     : public testing::TestWithParam<Network::Address::IpVersion>,
       public BaseIntegrationTest {

--- a/test/integration/multiplexed_integration_test.cc
+++ b/test/integration/multiplexed_integration_test.cc
@@ -2154,6 +2154,149 @@ TEST_P(Http2FrameIntegrationTest, SetDetailsTwice) {
   EXPECT_THAT(waitForAccessLog(access_log_name_), HasSubstr("too_many_headers"));
 }
 
+TEST_P(Http2FrameIntegrationTest, UpstreamResponseTrailersWithoutEndStream) {
+  beginSession();
+
+  // Downstream → Envoy: header-only GET (END_STREAM|END_HEADERS).
+  sendFrame(Http2Frame::makeRequest(1, "host", "/"));
+
+  // Envoy → upstream: grab the raw upstream TCP connection.
+  FakeRawConnectionPtr upstream;
+  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(upstream));
+
+  // Wait until Envoy has actually written its preface + SETTINGS + request
+  // HEADERS to the upstream so the client codec stream-1 exists and is
+  // half_closed_local (we sent a header-only GET).
+  std::string observed;
+  ASSERT_TRUE(upstream->waitForData(FakeRawConnection::waitForAtLeastBytes(40), &observed));
+
+  // Craft the malicious upstream response, all in one write so the client
+  // codec processes it in a single dispatch():
+  //   1. SETTINGS (server preface)
+  //   2. SETTINGS ACK
+  //   3. HEADERS stream=1 :status=200, END_HEADERS only (no END_STREAM)
+  //   4. HEADERS stream=1 trailer "x: y", END_HEADERS only (no END_STREAM)
+  //      ← oghttp2 delivers this as RESPONSE_TRAILER without fin; Envoy's
+  //        onHeaders() sees flags & END_STREAM == 0 and fires
+  //        ASSERT(stream->remote_end_stream_).
+  //   5. HEADERS stream=1 trailer again, END_HEADERS|END_STREAM — in a
+  //      release build (ASSERT compiled out) step 4 ran decodeTrailers()
+  //      and freed the ActiveRequest; this third HEADERS dereferences the
+  //      dangling response_decoder_.
+  std::string buf;
+  absl::StrAppend(&buf, std::string(Http2Frame::makeEmptySettingsFrame()));
+  absl::StrAppend(&buf,
+                  std::string(Http2Frame::makeEmptySettingsFrame(Http2Frame::SettingsFlags::Ack)));
+
+  // Response headers: :status 200, END_HEADERS only.
+  absl::StrAppend(&buf, std::string(Http2Frame::makeHeadersFrameWithStatus(
+                            "200", 1, Http2Frame::HeadersFlags::EndHeaders)));
+
+  // Trailers WITHOUT END_STREAM: a single regular header, END_HEADERS only.
+  {
+    Http2Frame trailers =
+        Http2Frame::makeEmptyHeadersFrame(1, Http2Frame::HeadersFlags::EndHeaders);
+    trailers.appendHeaderWithoutIndexing(Http2Frame::Header("x", "y"));
+    trailers.adjustPayloadSize();
+    absl::StrAppend(&buf, std::string(trailers));
+  }
+
+  // Third HEADERS (release-build UAF amplifier).
+  {
+    Http2Frame extra = Http2Frame::makeEmptyHeadersFrame(
+        1, static_cast<Http2Frame::HeadersFlags>(Http::Http2::orFlags(
+               Http2Frame::HeadersFlags::EndStream, Http2Frame::HeadersFlags::EndHeaders)));
+    extra.appendHeaderWithoutIndexing(Http2Frame::Header("x", "z"));
+    extra.adjustPayloadSize();
+    absl::StrAppend(&buf, std::string(extra));
+  }
+
+  ASSERT_TRUE(upstream->write(buf));
+
+  // We expect HEADERS (response headers) first.
+  Http2Frame response = readFrame();
+  EXPECT_EQ(Http2Frame::Type::Headers, response.type());
+
+  // Then we expect RST_STREAM.
+  Http2Frame reset = readFrame();
+  EXPECT_EQ(Http2Frame::Type::RstStream, reset.type());
+
+  tcp_client_->close();
+
+  if (upstream->connected()) {
+    ASSERT_TRUE(upstream->close());
+  }
+}
+
+TEST_P(Http2FrameIntegrationTest, UpstreamResponseTrailersWithoutEndStream_DataFrameAmplifier) {
+  beginSession();
+
+  // Downstream → Envoy: header-only GET (END_STREAM|END_HEADERS).
+  sendFrame(Http2Frame::makeRequest(1, "host", "/"));
+
+  // Envoy → upstream: grab the raw upstream TCP connection.
+  FakeRawConnectionPtr upstream;
+  ASSERT_TRUE(fake_upstreams_[0]->waitForRawConnection(upstream));
+
+  // Wait until Envoy has actually written its preface + SETTINGS + request
+  // HEADERS to the upstream so the client codec stream-1 exists and is
+  // half_closed_local (we sent a header-only GET).
+  std::string observed;
+  ASSERT_TRUE(upstream->waitForData(FakeRawConnection::waitForAtLeastBytes(40), &observed));
+
+  // Craft the malicious upstream response, all in one write so the client
+  // codec processes it in a single dispatch():
+  //   1. SETTINGS (server preface)
+  //   2. SETTINGS ACK
+  //   3. HEADERS stream=1 :status=200, END_HEADERS only (no END_STREAM)
+  //   4. HEADERS stream=1 trailer "x: y", END_HEADERS only (no END_STREAM)
+  //      ← oghttp2 delivers this as RESPONSE_TRAILER without fin; Envoy's
+  //        onHeaders() sees flags & END_STREAM == 0 and fires
+  //        ASSERT(stream->remote_end_stream_).
+  //   5. DATA stream=1 empty, END_STREAM — in a release build (ASSERT
+  //      compiled out) step 4 ran decodeTrailers() and freed the ActiveRequest;
+  //      this DATA frame dereferences the dangling response_decoder_.
+  std::string buf;
+  absl::StrAppend(&buf, std::string(Http2Frame::makeEmptySettingsFrame()));
+  absl::StrAppend(&buf,
+                  std::string(Http2Frame::makeEmptySettingsFrame(Http2Frame::SettingsFlags::Ack)));
+
+  // Response headers: :status 200, END_HEADERS only.
+  absl::StrAppend(&buf, std::string(Http2Frame::makeHeadersFrameWithStatus(
+                            "200", 1, Http2Frame::HeadersFlags::EndHeaders)));
+
+  // Trailers WITHOUT END_STREAM: a single regular header, END_HEADERS only.
+  {
+    Http2Frame trailers =
+        Http2Frame::makeEmptyHeadersFrame(1, Http2Frame::HeadersFlags::EndHeaders);
+    trailers.appendHeaderWithoutIndexing(Http2Frame::Header("x", "y"));
+    trailers.adjustPayloadSize();
+    absl::StrAppend(&buf, std::string(trailers));
+  }
+
+  // Third frame (release-build UAF amplifier): empty DATA frame with END_STREAM.
+  {
+    Http2Frame extra = Http2Frame::makeEmptyDataFrame(1, Http2Frame::DataFlags::EndStream);
+    absl::StrAppend(&buf, std::string(extra));
+  }
+
+  ASSERT_TRUE(upstream->write(buf));
+
+  // We expect HEADERS (response headers) first.
+  Http2Frame response = readFrame();
+  EXPECT_EQ(Http2Frame::Type::Headers, response.type());
+
+  // Then we expect RST_STREAM.
+  Http2Frame reset = readFrame();
+  EXPECT_EQ(Http2Frame::Type::RstStream, reset.type());
+
+  tcp_client_->close();
+
+  if (upstream->connected()) {
+    ASSERT_TRUE(upstream->close());
+  }
+}
+
 TEST_P(Http2FrameIntegrationTest, AdjustUpstreamSettingsMaxStreams) {
   // Configure max concurrent streams to 2.
   config_helper_.addConfigModifier([&](envoy::config::bootstrap::v3::Bootstrap& bootstrap) -> void {


### PR DESCRIPTION
## CVE backports to `release/v1.32` (part 2)

Second batch of the 2026Q3 CVE backport stack, applied on top of the merged part 1 (#609). Each commit mirrors its upstream patch, preserving original authorship and DCO sign-offs. Fork adaptations (OpenSSL/oghttp2 variant) are noted below.

### Commits

- **quiche: patch oghttp2 to validate trailers END_STREAM flag and add integration tests** — [GHSA-jjmm-fw8p-crpw](https://github.com/envoyproxy/envoy/security/advisories/GHSA-jjmm-fw8p-crpw)
  - Enforces HTTP/2 RFC 9113 §8.1 in the QUICHE oghttp2 codec: trailers MUST carry `END_STREAM`. Prevents stream-state corruption / UAF when an upstream sends response trailers without `END_STREAM`.
  - Fork adaptation: the QUICHE source hunk uses the fork's unscoped enum form `Http2VisitorInterface::HEADER_HTTP_MESSAGING` (upstream's newer QUICHE uses `OnHeaderResult::HEADER_HTTP_MESSAGING`).

- **Fix parsing of scoped IPv6 addresses for QUIC requests** — [GHSA-jp5f-qr64-c9vw](https://github.com/envoyproxy/envoy/security/advisories/GHSA-jp5f-qr64-c9vw)
  - Fixes a crash handling scoped IPv6 addresses in the QUIC client connection and Original Dst cluster.
  - Fork adaptation: skipped one cosmetic upstream whitespace hunk in `connection_impl.cc` (the fork's `~ConnectionImpl()` uses a different ASSERT message); the functional fix (new `~ClientConnectionImpl()` destructor) applied as-is. `original_dst_cluster.cc` hunk re-applied over minor context drift.

### Testing

Both patches' new tests pass in isolation in the clang/docker toolchain. Full-suite runs surfaced only pre-existing timing flakes unrelated to these changes (e.g. `WebsocketIntegrationTest.WebSocketConnectionIdleTimeout`, `CredentialInjectorIntegrationTest.RetryTokenRequestOnSecretUpdate` — the latter already carries an upstream "Fix test flake" history); all pass when run alone.

> **Merge note:** use **Rebase and merge**, not squash, to preserve the individual per-CVE commits and their authorship.
